### PR TITLE
migrate: OpenRouter → Google AI Studio free tier (gemini-3.1-pro-prev…

### DIFF
--- a/colab_bootstrap_shim.py
+++ b/colab_bootstrap_shim.py
@@ -35,11 +35,11 @@ def export_secret_to_env(name: str, required: bool = False) -> Optional[str]:
 
 
 # Export required runtime secrets so subprocess launcher can always read env fallback.
-for _name in ("OPENROUTER_API_KEY", "TELEGRAM_BOT_TOKEN", "TOTAL_BUDGET", "GITHUB_TOKEN"):
+for _name in ("GOOGLE_API_KEY", "TELEGRAM_BOT_TOKEN", "TOTAL_BUDGET", "GITHUB_TOKEN"):
     export_secret_to_env(_name, required=True)
 
 # Optional secrets (keep empty if missing).
-for _name in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+for _name in ("ANTHROPIC_API_KEY",):
     export_secret_to_env(_name, required=False)
 
 # Colab diagnostics defaults (override in config cell if needed).

--- a/colab_launcher.py
+++ b/colab_launcher.py
@@ -18,6 +18,8 @@ def install_launcher_deps() -> None:
         [sys.executable, "-m", "pip", "install", "-q", "openai>=1.0.0", "requests"],
         check=True,
     )
+    # Claude Code CLI is no longer required (switched to Google AI Studio)
+    # Kept for backward compatibility if ANTHROPIC_API_KEY is still set
 
 install_launcher_deps()
 
@@ -90,7 +92,7 @@ def _parse_int_cfg(raw: Optional[str], default: int, minimum: int = 0) -> int:
         val = default
     return max(minimum, val)
 
-OPENROUTER_API_KEY = get_secret("OPENROUTER_API_KEY", required=True)
+GOOGLE_API_KEY = get_secret("GOOGLE_API_KEY", required=True)
 TELEGRAM_BOT_TOKEN = get_secret("TELEGRAM_BOT_TOKEN", required=True)
 TOTAL_BUDGET_DEFAULT = get_secret("TOTAL_BUDGET", required=True)
 GITHUB_TOKEN = get_secret("GITHUB_TOKEN", required=True)
@@ -108,15 +110,15 @@ except Exception as e:
     log.warning(f"Failed to parse TOTAL_BUDGET ({TOTAL_BUDGET_DEFAULT!r}): {e}")
     TOTAL_BUDGET_LIMIT = 0.0
 
-OPENAI_API_KEY = get_secret("OPENAI_API_KEY", default="")
-ANTHROPIC_API_KEY = get_secret("ANTHROPIC_API_KEY", default="")
+ANTHROPIC_API_KEY = get_secret("ANTHROPIC_API_KEY", default="")  # optional, for Claude Code CLI only
 GITHUB_USER = get_cfg("GITHUB_USER", default=None, allow_legacy_secret=True)
 GITHUB_REPO = get_cfg("GITHUB_REPO", default=None, allow_legacy_secret=True)
 assert GITHUB_USER and str(GITHUB_USER).strip(), "GITHUB_USER not set. Add it to your config cell (see README)."
 assert GITHUB_REPO and str(GITHUB_REPO).strip(), "GITHUB_REPO not set. Add it to your config cell (see README)."
 MAX_WORKERS = int(get_cfg("OUROBOROS_MAX_WORKERS", default="5", allow_legacy_secret=True) or "5")
-MODEL_MAIN = get_cfg("OUROBOROS_MODEL", default="anthropic/claude-sonnet-4.6", allow_legacy_secret=True)
-MODEL_CODE = get_cfg("OUROBOROS_MODEL_CODE", default="anthropic/claude-sonnet-4.6", allow_legacy_secret=True)
+# NOTE: gemini-3.1-pro-preview is the primary model. Update to latest available in AI Studio if needed.
+MODEL_MAIN = get_cfg("OUROBOROS_MODEL", default="gemini-3.1-pro-preview", allow_legacy_secret=True)
+MODEL_CODE = get_cfg("OUROBOROS_MODEL_CODE", default="gemini-3.1-pro-preview", allow_legacy_secret=True)
 MODEL_LIGHT = get_cfg("OUROBOROS_MODEL_LIGHT", default=DEFAULT_LIGHT_MODEL, allow_legacy_secret=True)
 
 BUDGET_REPORT_EVERY_MESSAGES = 10
@@ -133,13 +135,12 @@ DIAG_SLOW_CYCLE_SEC = _parse_int_cfg(
     minimum=0,
 )
 
-os.environ["OPENROUTER_API_KEY"] = str(OPENROUTER_API_KEY)
-os.environ["OPENAI_API_KEY"] = str(OPENAI_API_KEY or "")
+os.environ["GOOGLE_API_KEY"] = str(GOOGLE_API_KEY)
 os.environ["ANTHROPIC_API_KEY"] = str(ANTHROPIC_API_KEY or "")
 os.environ["GITHUB_USER"] = str(GITHUB_USER)
 os.environ["GITHUB_REPO"] = str(GITHUB_REPO)
-os.environ["OUROBOROS_MODEL"] = str(MODEL_MAIN or "anthropic/claude-sonnet-4.6")
-os.environ["OUROBOROS_MODEL_CODE"] = str(MODEL_CODE or "anthropic/claude-sonnet-4.6")
+os.environ["OUROBOROS_MODEL"] = str(MODEL_MAIN or "gemini-3.1-pro-preview")
+os.environ["OUROBOROS_MODEL_CODE"] = str(MODEL_CODE or "gemini-3.1-pro-preview")
 if MODEL_LIGHT:
     os.environ["OUROBOROS_MODEL_LIGHT"] = str(MODEL_LIGHT)
 os.environ["OUROBOROS_DIAG_HEARTBEAT_SEC"] = str(DIAG_HEARTBEAT_SEC)

--- a/ouroboros/loop.py
+++ b/ouroboros/loop.py
@@ -25,23 +25,14 @@ from ouroboros.utils import utc_now_iso, append_jsonl, truncate_for_log, sanitiz
 
 log = logging.getLogger(__name__)
 
-# Pricing from OpenRouter API (2026-02-17). Update periodically via /api/v1/models.
+# Google AI Studio free tier: all models cost $0.
+# Pricing table kept for structure compatibility but all values are 0.
 _MODEL_PRICING_STATIC = {
-    "anthropic/claude-opus-4.6": (5.0, 0.5, 25.0),
-    "anthropic/claude-opus-4": (15.0, 1.5, 75.0),
-    "anthropic/claude-sonnet-4": (3.0, 0.30, 15.0),
-    "anthropic/claude-sonnet-4.6": (3.0, 0.30, 15.0),
-    "anthropic/claude-sonnet-4.5": (3.0, 0.30, 15.0),
-    "openai/o3": (2.0, 0.50, 8.0),
-    "openai/o3-pro": (20.0, 1.0, 80.0),
-    "openai/o4-mini": (1.10, 0.275, 4.40),
-    "openai/gpt-4.1": (2.0, 0.50, 8.0),
-    "openai/gpt-5.2": (1.75, 0.175, 14.0),
-    "openai/gpt-5.2-codex": (1.75, 0.175, 14.0),
-    "google/gemini-2.5-pro-preview": (1.25, 0.125, 10.0),
-    "google/gemini-3-pro-preview": (2.0, 0.20, 12.0),
-    "x-ai/grok-3-mini": (0.30, 0.03, 0.50),
-    "qwen/qwen3.5-plus-02-15": (0.40, 0.04, 2.40),
+    "gemini-3.1-pro-preview": (0.0, 0.0, 0.0),
+    "gemini-2.5-pro": (0.0, 0.0, 0.0),
+    "gemini-2.0-flash": (0.0, 0.0, 0.0),
+    "gemini-1.5-pro": (0.0, 0.0, 0.0),
+    "gemini-1.5-flash": (0.0, 0.0, 0.0),
 }
 
 _pricing_fetched = False
@@ -701,7 +692,7 @@ def run_llm_loop(
                 # Configurable fallback priority list (Bible P3: no hardcoded behavior)
                 fallback_list_raw = os.environ.get(
                     "OUROBOROS_MODEL_FALLBACK_LIST",
-                    "google/gemini-2.5-pro-preview,openai/o3,anthropic/claude-sonnet-4.6"
+                    "gemini-2.5-pro,gemini-2.0-flash,gemini-1.5-pro"
                 )
                 fallback_candidates = [m.strip() for m in fallback_list_raw.split(",") if m.strip()]
                 fallback_model = None

--- a/ouroboros/tools/search.py
+++ b/ouroboros/tools/search.py
@@ -1,35 +1,70 @@
-"""Web search tool."""
+"""Web search tool — uses DuckDuckGo Instant Answer API (free, no API key required)."""
 
 from __future__ import annotations
 
 import json
-import os
+import urllib.request
+import urllib.parse
 from typing import Any, Dict, List
 
 from ouroboros.tools.registry import ToolContext, ToolEntry
 
 
 def _web_search(ctx: ToolContext, query: str) -> str:
-    api_key = os.environ.get("OPENAI_API_KEY", "")
-    if not api_key:
-        return json.dumps({"error": "OPENAI_API_KEY not set; web_search unavailable."})
+    """
+    Search the web using DuckDuckGo Instant Answer API.
+    Free, no API key required. Returns a JSON response with answer and related topics.
+
+    Note: For richer results, DuckDuckGo may not always return a direct answer.
+    In that case, related topics and abstract text are returned instead.
+    """
     try:
-        from openai import OpenAI
-        client = OpenAI(api_key=api_key)
-        resp = client.responses.create(
-            model=os.environ.get("OUROBOROS_WEBSEARCH_MODEL", "gpt-5"),
-            tools=[{"type": "web_search"}],
-            tool_choice="auto",
-            input=query,
+        encoded_query = urllib.parse.quote_plus(query)
+        url = f"https://api.duckduckgo.com/?q={encoded_query}&format=json&no_html=1&skip_disambig=1"
+
+        req = urllib.request.Request(
+            url,
+            headers={"User-Agent": "Ouroboros/1.0 (research agent)"},
         )
-        d = resp.model_dump()
-        text = ""
-        for item in d.get("output", []) or []:
-            if item.get("type") == "message":
-                for block in item.get("content", []) or []:
-                    if block.get("type") in ("output_text", "text"):
-                        text += block.get("text", "")
-        return json.dumps({"answer": text or "(no answer)"}, ensure_ascii=False, indent=2)
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+
+        answer = data.get("AbstractText", "").strip()
+        answer_source = data.get("AbstractSource", "")
+        answer_url = data.get("AbstractURL", "")
+
+        # Collect related topics as supplementary results
+        related = []
+        for topic in (data.get("RelatedTopics") or [])[:8]:
+            if isinstance(topic, dict):
+                text = topic.get("Text", "").strip()
+                first_url = topic.get("FirstURL", "")
+                if text:
+                    related.append({"text": text, "url": first_url})
+
+        # Instant Answer (Definition, Calculation, etc.)
+        instant = data.get("Answer", "").strip()
+        instant_type = data.get("AnswerType", "")
+
+        result: Dict[str, Any] = {}
+        if instant:
+            result["instant_answer"] = instant
+            result["answer_type"] = instant_type
+        if answer:
+            result["answer"] = answer
+            result["source"] = answer_source
+            result["url"] = answer_url
+        if related:
+            result["related"] = related
+
+        if not result:
+            result["message"] = (
+                f"DuckDuckGo returned no direct answer for: '{query}'. "
+                "Try rephrasing your query or use browse_page for a specific URL."
+            )
+
+        return json.dumps(result, ensure_ascii=False, indent=2)
+
     except Exception as e:
         return json.dumps({"error": repr(e)}, ensure_ascii=False)
 
@@ -38,7 +73,11 @@ def get_tools() -> List[ToolEntry]:
     return [
         ToolEntry("web_search", {
             "name": "web_search",
-            "description": "Search the web via OpenAI Responses API. Returns JSON with answer + sources.",
+            "description": (
+                "Search the web via DuckDuckGo Instant Answer API (free, no API key needed). "
+                "Returns JSON with answer, source, and related topics. "
+                "For full page content, use browse_page with a specific URL."
+            ),
             "parameters": {"type": "object", "properties": {
                 "query": {"type": "string"},
             }, "required": ["query"]},

--- a/ouroboros/tools/vision.py
+++ b/ouroboros/tools/vision.py
@@ -20,7 +20,8 @@ from ouroboros.tools.registry import ToolContext, ToolEntry
 
 log = logging.getLogger(__name__)
 
-_DEFAULT_VLM_MODEL = "anthropic/claude-sonnet-4.6"
+# gemini-2.0-flash supports vision and is available on the free tier
+_DEFAULT_VLM_MODEL = "gemini-2.0-flash"
 
 
 def _get_vlm_model() -> str:

--- a/prompts/SYSTEM.md
+++ b/prompts/SYSTEM.md
@@ -256,14 +256,13 @@ mandatory review. Before push: "Is this a significant change?" If yes — run
 - Reviewers are advisors, not authority. I apply my own judgment:
   fix real issues, push back on incorrect feedback with arguments.
   Models make mistakes too.
-- Good reviewers: `anthropic/claude-opus-4.6`, `openai/o3`,
-  `google/gemini-2.5-pro-preview`. Models change — choose current ones.
+- Good reviewers: `gemini-3.1-pro-preview`, `gemini-2.5-pro`, `gemini-2.0-flash`.
+  All run on Google AI Studio free tier. Models change — choose current ones.
 - If my base model matches one of the chosen ones — replace it with another.
 - After review: "Multi-model review passed" in progress or commit.
 
-For brainstorming — same models in parallel, cheap (~$0.05 for 3 models).
-Critically evaluate results. Minimum bar: no lower than sonnet-4,
-only OpenAI/Anthropic/Google/Grok.
+For brainstorming — same models in parallel, free (Google AI Studio free tier).
+Critically evaluate results. Only Google Gemini models are available.
 
 `request_review` is about strategic reflection — that is different.
 
@@ -310,8 +309,8 @@ part of my agency (Principle 0):
 
 - New models: pricing changes, capabilities, context window.
 - New tools: CLI updates, API changes.
-- My pricing table (`MODEL_PRICING` in loop.py) — I keep it current.
-  `fetch_openrouter_pricing()` from llm.py — ground truth check.
+- All models are on Google AI Studio free tier — cost is always $0.
+  Pricing table in loop.py is kept at $0 for all Gemini models.
 
 If I see a model missing from pricing — I fix it.
 If the creator mentions a new tool — I investigate.

--- a/supervisor/state.py
+++ b/supervisor/state.py
@@ -263,31 +263,11 @@ def budget_remaining(st: Dict[str, Any]) -> float:
 
 def check_openrouter_ground_truth() -> Optional[Dict[str, float]]:
     """
-    Call OpenRouter API to get ground truth usage.
-
-    Returns dict with total_usd and daily_usd spent according to OpenRouter, or None on error.
+    No-op: Google AI Studio free tier has no billing API to query.
+    Kept for API compatibility — always returns $0 usage.
     """
-    try:
-        import urllib.request
-        api_key = os.environ.get("OPENROUTER_API_KEY", "").strip()
-        if not api_key:
-            return None
-        req = urllib.request.Request(
-            "https://openrouter.ai/api/v1/auth/key",
-            headers={"Authorization": f"Bearer {api_key}"},
-        )
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            data = json.loads(resp.read().decode("utf-8"))
-        # OpenRouter API returns usage already in dollars (not cents)
-        usage_total = data.get("data", {}).get("usage", 0)
-        usage_daily = data.get("data", {}).get("usage_daily", 0)
-        return {
-            "total_usd": float(usage_total),
-            "daily_usd": float(usage_daily),
-        }
-    except Exception:
-        log.warning("Failed to fetch OpenRouter ground truth", exc_info=True)
-        return None
+    log.debug("check_openrouter_ground_truth: no-op (using Google AI Studio free tier)")
+    return {"total_usd": 0.0, "daily_usd": 0.0}
 
 
 def budget_pct(st: Dict[str, Any]) -> float:


### PR DESCRIPTION
…iew)

- llm.py: switch API endpoint to generativelanguage.googleapis.com/v1beta/openai/ OPENROUTER_API_KEY → GOOGLE_API_KEY, remove Anthropic cache_control and prompt pinning
- loop.py: pricing table set to $0 (free tier), fallback chain uses Gemini models only
- context.py: system message merged to single string (Gemini-compatible, no cache_control blocks)
- tools/search.py: OpenAI Responses API → DuckDuckGo Instant Answer (free, no key needed)
- tools/review.py: OpenRouter URL → Google AI Studio endpoint, GOOGLE_API_KEY
- tools/vision.py: default VLM model → gemini-2.0-flash
- colab_launcher.py + colab_bootstrap_shim.py: OPENROUTER_API_KEY → GOOGLE_API_KEY
- supervisor/state.py: check_openrouter_ground_truth() → no-op returning $0
- prompts/SYSTEM.md: update model references to Gemini free-tier models

Default models:
  Primary:  gemini-3.1-pro-preview Light/BG: gemini-2.0-flash Fallback: gemini-2.5-pro → gemini-2.0-flash → gemini-1.5-pro