### PR TITLE
fix(launcher): fix launcher-agent startup race condition

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -1028,6 +1028,14 @@ def main():
     global _webview_window
     port = AGENT_SERVER_PORT
 
+    # Clear any stale server process or ports before starting the new agent
+    _cleanup_recorded_server_process("preflight")
+    _kill_stale_runtime_ports(port)
+    try:
+        PORT_FILE.unlink(missing_ok=True)
+    except OSError:
+        pass
+
     lifecycle_thread = threading.Thread(target=agent_lifecycle_loop, args=(port,), daemon=True)
     lifecycle_thread.start()
 


### PR DESCRIPTION
Synchronously executes stale process/port cleanup in preflight prior to launching the server and webview, preventing race conditions that load a dead/killed server port and yield a black screen.