### PR TITLE
Fix kill_process_tree: reap descendants that escaped the process group

### DIFF
--- a/ouroboros/platform_layer.py
+++ b/ouroboros/platform_layer.py
@@ -457,21 +457,46 @@ def _win32_unlock(fd: int) -> None:
 # Process management.
 
 def kill_process_tree(proc: subprocess.Popen) -> None:
-    """Force-kill a subprocess and its entire process tree."""
+    """Force-kill a subprocess and its entire process tree.
+
+    On POSIX the immediate process group is SIGKILLed first (fast path for the
+    common case), then any descendants that escaped into their own
+    session/process group are swept by PID. Without that sweep a timed-out or
+    cancelled child which spawned grandchildren in new groups (for example
+    pytest running tests that use ``subprocess_new_group_kwargs``) would leak
+    runaway orphan processes. Descendants are collected BEFORE the kill because
+    once the parent dies its children are reparented and the ppid links we rely
+    on disappear.
+    """
+    pid = proc.pid
     if IS_WINDOWS:
         try:
             _hidden_run(
-                ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                ["taskkill", "/F", "/T", "/PID", str(pid)],
                 capture_output=True, timeout=10,
             )
         except Exception:
             pass
-    else:
+        return
+    descendants: list[int] = []
+    try:
+        _collect_descendants(pid, descendants)
+    except Exception:
+        descendants = []
+    try:
+        pgid = os.getpgid(pid)
+        os.killpg(pgid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+    for dpid in reversed(descendants):
         try:
-            pgid = os.getpgid(proc.pid)
-            os.killpg(pgid, signal.SIGKILL)
+            os.kill(dpid, signal.SIGKILL)
         except (ProcessLookupError, PermissionError, OSError):
             pass
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
 
 
 def terminate_process_tree(proc: subprocess.Popen) -> None:

--- a/tests/test_kill_process_tree_orphans.py
+++ b/tests/test_kill_process_tree_orphans.py
@@ -1,0 +1,52 @@
+"""Regression test for the kill_process_tree orphan-reaping fix.
+
+A grandchild spawned in its own session/process group survives ``os.killpg`` of
+the parent's group. ``kill_process_tree`` must collect descendants BEFORE
+killing (parent death reparents children and loses the ppid links) and then
+SIGKILL the escaped descendants by PID, or timed-out subprocess trees (for
+example a pytest preflight run whose tests spawn children via
+``subprocess_new_group_kwargs``) leak runaway orphan processes.
+"""
+import pytest
+
+
+def test_kill_process_tree_sweeps_escaped_descendants(monkeypatch):
+    import signal as _signal
+    import ouroboros.platform_layer as pl
+
+    if pl.IS_WINDOWS:
+        pytest.skip("POSIX process-group sweep path")
+
+    order = []
+    escaped = [4101, 4102]
+    killpg_calls = []
+    kill_calls = []
+
+    def fake_collect(pid, result, visited=None):
+        order.append(("collect", pid))
+        result.extend(escaped)
+
+    def fake_killpg(pgid, sig):
+        order.append(("killpg", pgid))
+        killpg_calls.append((pgid, sig))
+
+    monkeypatch.setattr(pl, "_collect_descendants", fake_collect)
+    monkeypatch.setattr(pl.os, "getpgid", lambda pid: 7777)
+    monkeypatch.setattr(pl.os, "killpg", fake_killpg)
+    monkeypatch.setattr(pl.os, "kill", lambda pid, sig: kill_calls.append((pid, sig)))
+
+    class _FakeProc:
+        pid = 4242
+
+    pl.kill_process_tree(_FakeProc())
+
+    # Descendants collected BEFORE the group kill (reparenting can't hide them).
+    assert order[0] == ("collect", 4242)
+    assert order.index(("collect", 4242)) < order.index(("killpg", 7777))
+    # Process group SIGKILLed.
+    assert (7777, _signal.SIGKILL) in killpg_calls
+    # Escaped descendants and the parent itself SIGKILLed by PID.
+    killed = {pid for pid, _ in kill_calls}
+    assert escaped[0] in killed and escaped[1] in killed
+    assert 4242 in killed
+    assert all(sig == _signal.SIGKILL for _, sig in kill_calls)


### PR DESCRIPTION
## Problem

On POSIX, `platform_layer.kill_process_tree()` only `os.killpg`'d the immediate
process group. Tests and tools that spawn grandchildren in their **own**
session/process group via `subprocess_new_group_kwargs()` could leave a runaway
orphan after a timeout — observed concretely as a pytest preflight orphan stuck
at ~96% CPU / ~4 GB RAM after the 120s timeout killed only the pytest group.

## Fix

Collect the descendant tree **before** killing (once the parent dies its
children are reparented and the ppid links disappear), SIGKILL the immediate
process group, then SIGKILL each surviving descendant by PID. This closes the
orphan-leak class for every kill path that funnels through
`kill_process_tree` (run_command / run_script / preflight / services / panic).

The change is confined to the POSIX branch of `kill_process_tree`; the Windows
`taskkill /F /T` path is unchanged. It depends only on the pre-existing
`_collect_descendants` helper.

## Tests

Adds a deterministic regression test
(`tests/test_kill_process_tree_orphans.py`) asserting:

- descendants are collected **before** `os.killpg` (so reparenting cannot hide
  them),
- the immediate process group is SIGKILLed,
- escaped descendants **and** the parent are SIGKILLed by PID,
- every signal sent is `SIGKILL`.

The test is POSIX-scoped (skips on Windows) and uses monkeypatched
`os.getpgid` / `os.killpg` / `os.kill`, so it never touches a real process.
