### PR TITLE
fixed Bad request for strict openai-compatible providers

### DIFF
--- a/ouroboros/llm.py
+++ b/ouroboros/llm.py
@@ -1493,9 +1493,15 @@ class LLMClient:
         """Normalize an OpenAI-compatible response; skip_cost_fetch keeps no_proxy pure."""
         usage = resp_dict.get("usage") or {}
         choices = resp_dict.get("choices") or [{}]
-        msg = (choices[0] if choices else {}).get("message") or {}
+        msg = dict((choices[0] if choices else {}).get("message") or {})
         if resp_dict.get("id") and "response_id" not in msg:
             msg["response_id"] = resp_dict["id"]
+
+        # OpenAI SDK model_dump() adds nullable fields that strict OpenAI-compatible
+        # providers reject as extra inputs when the message re-enters conversation history.
+        for _sdk_field in ("refusal", "annotations", "audio", "function_call"):
+            if msg.get(_sdk_field) is None:
+                msg.pop(_sdk_field, None)
 
         if not usage.get("cached_tokens"):
             prompt_details = usage.get("prompt_tokens_details") or {}


### PR DESCRIPTION
  # Problem

  Strict OpenAI-compatible providers (e.g. those using Pydantic
  extra='forbid') returned 400 Bad Request on any request with a
  non-empty conversation history:
  
  400 - "4 request validation errors: Extra inputs are not permitted,
  field: 'messages[3].refusal', value: None;
  field: 'messages[3].annotations', value: None;
  field: 'messages[3].audio', value: None;
  field: 'messages[3].function_call', value: None"

  # Root cause

  openai SDK's ChatCompletionMessage.model_dump() serializes all
  fields of the response object, including nullable ones (refusal,
  annotations, audio, function_call) as None. These fields were
  stored as-is in conversation history and re-sent to the provider on
   subsequent turns.
   
   #  Why only strict providers were affected

  Most OpenAI-compatible implementations silently ignore unknown
  fields (Pydantic extra='ignore' default). The OpenAI API itself
  accepts them since they originate from its own SDK. Only providers
  with strict validation exposed this latent bug.