### PR TITLE
feat(onboarding): add OpenAI-compatible provider to setup wizard

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -886,6 +886,29 @@ def _run_first_run_wizard() -> bool:
             except Exception as exc:
                 return f"Failed to save: {exc}"
 
+        def fetch_compatible_models(self, data: dict) -> dict:
+            import urllib.request
+            import urllib.error
+            base_url = str(data.get("baseUrl", "") or "").rstrip("/")
+            api_key = str(data.get("apiKey", "") or "").strip()
+            if not base_url:
+                return {"error": "baseUrl is required"}
+            try:
+                req = urllib.request.Request(
+                    f"{base_url}/models",
+                    headers=({"Authorization": f"Bearer {api_key}"} if api_key else {}),
+                )
+                with urllib.request.urlopen(req, timeout=10) as resp:
+                    raw = json.loads(resp.read())
+                raw_models = raw.get("data") or []
+                models = sorted({
+                    str(m.get("id", "") or "").strip()
+                    for m in raw_models if isinstance(m, dict) and m.get("id")
+                })
+                return {"models": models}
+            except Exception as exc:
+                return {"error": str(exc)}
+
         def claude_code_status(self) -> dict:
             return _claude_code_status_payload(settings)
 

--- a/ouroboros/gateway/contracts.py
+++ b/ouroboros/gateway/contracts.py
@@ -469,6 +469,7 @@ HTTP_ENDPOINTS: tuple[str, ...] = (
     "GET /api/logs/{name}",
     "POST /api/chat/upload",
     "DELETE /api/chat/upload",
+    "POST /api/openai-compatible/models",
     "GET /api/local-model/status",
     "POST /api/local-model/start",
     "POST /api/local-model/stop",

--- a/ouroboros/gateway/models.py
+++ b/ouroboros/gateway/models.py
@@ -452,6 +452,26 @@ async def api_local_model_test(request: Request) -> JSONResponse:
         return json_exception(e)
 
 
+async def api_openai_compatible_models(request: Request) -> JSONResponse:
+    """Proxy GET {baseUrl}/models so the onboarding wizard avoids browser CORS limits."""
+    try:
+        body = await request.json()
+        base_url = str(body.get("baseUrl", "") or "").strip()
+        api_key = str(body.get("apiKey", "") or "").strip()
+        if not base_url:
+            return json_error("baseUrl is required", 400)
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            models = await _fetch_openai_compatible_model_catalog(
+                client, "openai-compatible", "OpenAI-compatible", api_key, base_url
+            )
+        model_ids = [m["value"].removeprefix("openai-compatible::") for m in models if m.get("value")]
+        return JSONResponse({"models": model_ids})
+    except httpx.HTTPStatusError as e:
+        return JSONResponse({"error": f"HTTP {e.response.status_code}"}, status_code=502)
+    except Exception as e:
+        return json_exception(e)
+
+
 async def api_local_model_install_runtime(request: Request) -> JSONResponse:
     """Start an async install of llama-cpp-python into the app-managed interpreter.
 

--- a/ouroboros/gateway/router.py
+++ b/ouroboros/gateway/router.py
@@ -68,6 +68,7 @@ def collect_routes(
         api_local_model_stop,
         api_local_model_test,
         api_model_catalog,
+        api_openai_compatible_models,
     )
     from ouroboros.gateway.schedules import (
         api_schedules_delete,
@@ -194,6 +195,7 @@ def collect_routes(
         Route("/api/logs/{name}", endpoint=api_logs_tail, methods=["GET"]),
         Route("/api/chat/upload", endpoint=api_chat_upload, methods=["POST"]),
         Route("/api/chat/upload", endpoint=api_chat_upload_delete, methods=["DELETE"]),
+        Route("/api/openai-compatible/models", endpoint=api_openai_compatible_models, methods=["POST"]),
         Route("/api/local-model/start", endpoint=api_local_model_start, methods=["POST"]),
         Route("/api/local-model/stop", endpoint=api_local_model_stop, methods=["POST"]),
         Route("/api/local-model/status", endpoint=api_local_model_status),

--- a/ouroboros/server_runtime.py
+++ b/ouroboros/server_runtime.py
@@ -287,6 +287,7 @@ def has_remote_provider(settings: dict) -> bool:
             "OPENAI_API_KEY",
             "ANTHROPIC_API_KEY",
             "OPENAI_COMPATIBLE_API_KEY",
+            "OPENAI_COMPATIBLE_BASE_URL",
             "CLOUDRU_FOUNDATION_MODELS_API_KEY",
             "GIGACHAT_CREDENTIALS",
         )

--- a/ouroboros/settings_setup_contract.py
+++ b/ouroboros/settings_setup_contract.py
@@ -33,6 +33,8 @@ _MODEL_DEFAULTS = {
     "openai": dict(OPENAI_DIRECT_DEFAULTS),
     "cloudru": dict(CLOUDRU_DIRECT_DEFAULTS),
     "anthropic": dict(ANTHROPIC_DIRECT_DEFAULTS),
+    # No defaults: model names are server-specific; user must fill all slots.
+    "openai-compatible": {"main": "", "code": "", "light": "", "fallback": ""},
 }
 _MODEL_DEFAULTS["local"] = dict(_MODEL_DEFAULTS["openrouter"])
 for _profile_defaults in _MODEL_DEFAULTS.values():
@@ -47,11 +49,13 @@ _STEPS = _rows(("id", "title", "railCopy", "copy", "footer"), (
 ))
 _STEP_ORDER = [step["id"] for step in _STEPS]
 
-_PROVIDER_FIELDS = _rows(("id", "stateKey", "settingKey", "settingsInputId", "label", "placeholder", "note"), (
-    ("openrouter-key", "openrouterKey", "OPENROUTER_API_KEY", "s-openrouter", "OpenRouter API Key", "sk-or-v1-...", "Optional. Best when you want one router for OpenAI, Anthropic, Google, and more."),
-    ("openai-key", "openaiKey", "OPENAI_API_KEY", "s-openai", "OpenAI API Key", "sk-...", "Optional. If this is the only remote key, the next step prefills direct openai::... models."),
-    ("cloudru-key", "cloudruKey", "CLOUDRU_FOUNDATION_MODELS_API_KEY", "s-cloudru-key", "Cloud.ru Foundation Models API Key", "Cloud.ru API key", "Optional. If this is the only remote key, the next step prefills direct cloudru::... models."),
-    ("anthropic-key", "anthropicKey", "ANTHROPIC_API_KEY", "s-anthropic", "Anthropic API Key", "sk-ant-...", "Optional. Saved for direct anthropic::... models and Claude tooling."),
+_PROVIDER_FIELDS = _rows(("id", "stateKey", "settingKey", "settingsInputId", "label", "placeholder", "note", "inputType"), (
+    ("openrouter-key", "openrouterKey", "OPENROUTER_API_KEY", "s-openrouter", "OpenRouter API Key", "sk-or-v1-...", "Optional. Best when you want one router for OpenAI, Anthropic, Google, and more.", "password"),
+    ("openai-key", "openaiKey", "OPENAI_API_KEY", "s-openai", "OpenAI API Key", "sk-...", "Optional. If this is the only remote key, the next step prefills direct openai::... models.", "password"),
+    ("cloudru-key", "cloudruKey", "CLOUDRU_FOUNDATION_MODELS_API_KEY", "s-cloudru-key", "Cloud.ru Foundation Models API Key", "Cloud.ru API key", "Optional. If this is the only remote key, the next step prefills direct cloudru::... models.", "password"),
+    ("anthropic-key", "anthropicKey", "ANTHROPIC_API_KEY", "s-anthropic", "Anthropic API Key", "sk-ant-...", "Optional. Saved for direct anthropic::... models and Claude tooling.", "password"),
+    ("openai-compatible-url", "compatibleBaseUrl", "OPENAI_COMPATIBLE_BASE_URL", "s-compatible-url", "OpenAI-compatible Base URL", "http://localhost:11434/v1", "Base URL for your OpenAI-compatible endpoint (e.g. Ollama, LM Studio, vLLM). Required when using openai-compatible:: models.", "url"),
+    ("openai-compatible-key", "compatibleApiKey", "OPENAI_COMPATIBLE_API_KEY", "s-compatible-key", "OpenAI-compatible API Key", "Leave empty for no auth", "API key for the endpoint. Leave empty if your server does not require authentication.", "password"),
 ))
 
 _PROFILE_SPECS = {
@@ -59,6 +63,7 @@ _PROFILE_SPECS = {
     "openai": ("OpenAI", "OpenAI is present, so the next step prefills direct openai:: model values.", "OpenAI-only setup detected. These defaults are explicit and official."),
     "cloudru": ("Cloud.ru Foundation Models", "Cloud.ru is present, so the next step prefills direct cloudru:: model values.", "Cloud.ru-only setup detected. These defaults use explicit cloudru:: model IDs."),
     "anthropic": ("Anthropic", "Anthropic is present, so the next step prefills direct anthropic:: model values.", "Anthropic-only setup detected. These defaults are explicit and official."),
+    "openai-compatible": ("OpenAI-compatible endpoint", "An OpenAI-compatible base URL is configured. Enter the model names your server exposes in the next step.", "OpenAI-compatible endpoint detected. Use openai-compatible::your-model-name for every slot. The model list is whatever your server supports."),
     "direct-multi": ("Direct multi-provider", "Multiple direct providers are present, so the next step keeps your model values editable without forcing one provider family.", "Multiple direct providers are configured. Start here, then split model slots across them if you want."),
     "local": ("Local-first", "No remote key is present yet, so local-only setup remains available below.", "Local-only setup detected. Review the model values and local routing before launch."),
 }
@@ -167,6 +172,8 @@ def derive_provider_profile(settings: dict) -> str:
     flags = {field["settingKey"]: bool(_string(settings.get(field["settingKey"]))) for field in _PROVIDER_FIELDS}
     if flags["OPENROUTER_API_KEY"]:
         return "openrouter"
+    if flags["OPENAI_COMPATIBLE_BASE_URL"]:
+        return "openai-compatible"
     direct = [
         ("OPENAI_API_KEY", "openai"),
         ("CLOUDRU_FOUNDATION_MODELS_API_KEY", "cloudru"),
@@ -281,13 +288,13 @@ def validate_setup_payload(data: dict, current_settings: dict) -> Tuple[dict, st
 
     for field in _PROVIDER_FIELDS:
         value = keys[field["settingKey"]]
-        if value and len(value) < 10:
+        if value and field.get("inputType") != "url" and len(value) < 10:
             return {}, f"{field['label'].replace(' API Key', '')} API key looks too short."
 
     has_remote = any(keys.values())
     has_local = bool(local_source)
     if not has_remote and not has_local:
-        return {}, "Configure OpenRouter, OpenAI, Cloud.ru, Anthropic, or a local model before continuing."
+        return {}, "Configure OpenRouter, OpenAI, OpenAI-compatible, Cloud.ru, Anthropic, or a local model before continuing."
     if has_local and "/" in local_source and not local_source.startswith(("/", "~")) and not local_filename:
         return {}, "Local HuggingFace sources need a GGUF filename."
     if review_enforcement not in {"advisory", "blocking"}:

--- a/tests/test_onboarding_wizard.py
+++ b/tests/test_onboarding_wizard.py
@@ -34,7 +34,7 @@ def test_prepare_onboarding_settings_requires_runnable_config():
     prepared, error = prepare_onboarding_settings(_base_payload(), {})
 
     assert prepared == {}
-    assert "Configure OpenRouter, OpenAI, Cloud.ru, Anthropic, or a local model" in error
+    assert "Configure OpenRouter, OpenAI, OpenAI-compatible, Cloud.ru, Anthropic, or a local model" in error
 
 
 def test_prepare_onboarding_settings_accepts_openai_only_setup():
@@ -168,28 +168,46 @@ def test_prepare_onboarding_settings_sets_all_local_routes():
     assert prepared["USE_LOCAL_FALLBACK"] is True
 
 
-def test_prepare_onboarding_settings_preserves_user_visible_provider_fields():
+def test_prepare_onboarding_settings_preserves_non_wizard_provider_fields():
     """The wizard only edits fields it actually exposes. Settings fields
     that live in ``settings_ui.js`` but not in the wizard (``OPENAI_BASE_URL``,
-    ``OPENAI_COMPATIBLE_*``, ``CLOUDRU_FOUNDATION_MODELS_BASE_URL``) must
-    survive re-running onboarding so a user who edited them in Settings
-    does not silently lose the value."""
+    ``CLOUDRU_FOUNDATION_MODELS_BASE_URL``) must survive re-running onboarding.
+    ``OPENAI_COMPATIBLE_*`` are now wizard-managed and come from the payload."""
     payload = _base_payload()
     payload["OPENAI_API_KEY"] = "sk-openai-1234567890"
+    payload["OPENAI_COMPATIBLE_BASE_URL"] = "https://compat.example/v1"
+    payload["OPENAI_COMPATIBLE_API_KEY"] = "compat-secret-xyz"
     current = {
         "OPENAI_BASE_URL": "https://legacy.example/v1",
-        "OPENAI_COMPATIBLE_API_KEY": "compat-secret",
-        "OPENAI_COMPATIBLE_BASE_URL": "https://compat.example/v1",
         "CLOUDRU_FOUNDATION_MODELS_BASE_URL": "https://cloud.example/v1",
     }
 
     prepared, error = prepare_onboarding_settings(payload, current)
 
     assert error is None
+    # Non-wizard fields are preserved from current settings.
     assert prepared["OPENAI_BASE_URL"] == "https://legacy.example/v1"
-    assert prepared["OPENAI_COMPATIBLE_API_KEY"] == "compat-secret"
-    assert prepared["OPENAI_COMPATIBLE_BASE_URL"] == "https://compat.example/v1"
     assert prepared["CLOUDRU_FOUNDATION_MODELS_BASE_URL"] == "https://cloud.example/v1"
+    # Compatible fields come from the wizard payload.
+    assert prepared["OPENAI_COMPATIBLE_BASE_URL"] == "https://compat.example/v1"
+    assert prepared["OPENAI_COMPATIBLE_API_KEY"] == "compat-secret-xyz"
+
+
+def test_prepare_onboarding_settings_accepts_openai_compatible_setup():
+    """An OpenAI-compatible base URL alone (no key) is a valid remote provider."""
+    payload = _base_payload()
+    payload["OPENAI_COMPATIBLE_BASE_URL"] = "http://localhost:11434/v1"
+    payload["OUROBOROS_MODEL"] = "openai-compatible::llama3"
+    payload["OUROBOROS_MODEL_CODE"] = "openai-compatible::llama3"
+    payload["OUROBOROS_MODEL_LIGHT"] = "openai-compatible::llama3"
+    payload["OUROBOROS_MODEL_FALLBACK"] = "openai-compatible::llama3"
+
+    prepared, error = prepare_onboarding_settings(payload, {})
+
+    assert error is None
+    assert prepared["OPENAI_COMPATIBLE_BASE_URL"] == "http://localhost:11434/v1"
+    assert prepared["OPENAI_COMPATIBLE_API_KEY"] == ""
+    assert prepared["OUROBOROS_MODEL"] == "openai-compatible::llama3"
 
 
 def test_build_onboarding_html_contains_multistep_markers():

--- a/web/modules/onboarding_wizard.js
+++ b/web/modules/onboarding_wizard.js
@@ -95,12 +95,14 @@
                 trim(state[field.stateKey]).length >= 10,
             ]));
             const hasOpenrouter = configured.OPENROUTER_API_KEY;
+            const hasCompatible = trim(state.compatibleBaseUrl).length > 0;
             const direct = [
                 ['OPENAI_API_KEY', 'openai'],
                 ['CLOUDRU_FOUNDATION_MODELS_API_KEY', 'cloudru'],
                 ['ANTHROPIC_API_KEY', 'anthropic'],
             ].filter(([settingKey]) => configured[settingKey]);
             if (hasOpenrouter) return 'openrouter';
+            if (hasCompatible) return 'openai-compatible';
             if (direct.length > 1) return 'direct-multi';
             if (direct.length === 1) return direct[0][1];
             if (hasLocalModel()) return 'local';
@@ -203,7 +205,7 @@
             const keyValues = PROVIDER_FIELDS.map((field) => [field, trim(state[field.stateKey])]);
             const localSource = trim(state.localSource);
             const localFilename = trim(state.localFilename);
-            const shortKey = keyValues.find(([, value]) => value && value.length < 10);
+            const shortKey = keyValues.find(([field, value]) => value && (field.inputType || 'password') === 'password' && value.length < 10);
             if (shortKey) return `${shortKey[0].label.replace(' API Key', '')} API key looks too short.`;
             const hasRemote = keyValues.some(([, value]) => value);
             if (!hasRemote && !localSource) {
@@ -498,14 +500,15 @@
         return rows;
     }
 
-        function providerKeyField({ id, label, placeholder, value, note }) {
+        function providerKeyField({ id, label, placeholder, value, note, inputType }) {
+            const type = inputType || 'password';
             return `
                 <div class="field">
                 <div class="field-label-row">
                     <label for="${escapeHtml(id)}">${escapeHtml(label)}</label>
                     <button class="field-clear" data-clear="${escapeHtml(id)}" type="button">Clear</button>
                 </div>
-                <input id="${escapeHtml(id)}" type="password" placeholder="${escapeHtml(placeholder)}" value="${escapeHtml(value)}">
+                <input id="${escapeHtml(id)}" type="${escapeHtml(type)}" placeholder="${escapeHtml(placeholder)}" value="${escapeHtml(value)}">
                 <div class="field-note">${escapeHtml(note)}</div>
             </div>
             `;
@@ -591,6 +594,20 @@
         `;
     }
 
+        function renderCompatibleModelLoader() {
+            return `
+            <div class="panel-card" id="compatible-model-loader">
+                <h3>Load models from endpoint</h3>
+                <p class="field-note">Fetch the model list from your configured URL, then click a model to fill all empty slots.</p>
+                <div style="display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;margin-top:0.5rem;">
+                    <button type="button" class="btn btn-secondary" id="load-compatible-models">Load models</button>
+                    <span id="compatible-load-status" class="field-note" style="margin:0;"></span>
+                </div>
+                <div id="compatible-model-list" hidden style="margin-top:0.75rem;display:flex;flex-wrap:wrap;gap:0.5rem;"></div>
+            </div>
+            `;
+        }
+
         function renderModelsStep() {
             const profile = activeProviderProfile();
             return `
@@ -604,6 +621,7 @@
                     <h3>Current profile</h3>
                     <p>${escapeHtml(PROVIDER_PROFILES[profile]?.modelCopy || '')}</p>
                 </div>
+                ${profile === 'openai-compatible' ? renderCompatibleModelLoader() : ''}
                 <div class="grid two">
                     ${MODEL_SLOTS.map((slot) => modelSuggestionField({
                         id: slot.inputId,
@@ -612,7 +630,7 @@
                         note: slot.note,
                     })).join('')}
                 </div>
-            <div class="wizard-inline-note">Direct providers use <code>openai::gpt-5.5</code>, <code>cloudru::zai-org/GLM-4.7</code>, and <code>anthropic::claude-sonnet-4-6</code>. Plain <code>openai/...</code> or <code>anthropic/...</code> stays router-style by design.</div>
+            <div class="wizard-inline-note">Direct providers use <code>openai::gpt-5.5</code>, <code>cloudru::zai-org/GLM-4.7</code>, and <code>anthropic::claude-sonnet-4-6</code>. OpenAI-compatible endpoints use <code>openai-compatible::your-model-name</code>. Plain <code>openai/...</code> or <code>anthropic/...</code> stays router-style by design.</div>
         `;
     }
 
@@ -944,8 +962,75 @@
         syncCurrentStepActionState();
     }
 
+        function bindCompatibleModelLoader() {
+            const loadBtn = document.getElementById('load-compatible-models');
+            if (!loadBtn) return;
+            loadBtn.addEventListener('click', async () => {
+                const baseUrl = trim(state.compatibleBaseUrl).replace(/\/+$/, '');
+                const apiKey = trim(state.compatibleApiKey);
+                const statusEl = document.getElementById('compatible-load-status');
+                const listEl = document.getElementById('compatible-model-list');
+                if (!baseUrl) {
+                    if (statusEl) statusEl.textContent = 'Go back and enter a base URL first.';
+                    return;
+                }
+                if (statusEl) statusEl.textContent = 'Loading…';
+                loadBtn.disabled = true;
+                try {
+                    let models;
+                    if (HOST_MODE === 'web') {
+                        const resp = await fetch('/api/openai-compatible/models', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ baseUrl, apiKey }),
+                            cache: 'no-store',
+                        });
+                        const data = await resp.json().catch(() => ({}));
+                        if (!resp.ok) throw new Error(data.error || `HTTP ${resp.status}`);
+                        models = (data.models || []).map((m) => trim(m)).filter(Boolean).sort();
+                    } else {
+                        if (!window.pywebview?.api?.fetch_compatible_models) {
+                            throw new Error('Desktop model-fetch bridge unavailable.');
+                        }
+                        const result = await window.pywebview.api.fetch_compatible_models({ baseUrl, apiKey });
+                        if (result?.error) throw new Error(result.error);
+                        models = (result?.models || []).map((m) => trim(m)).filter(Boolean).sort();
+                    }
+                    if (!models.length) throw new Error('No models returned by endpoint.');
+                    if (statusEl) statusEl.textContent = `${models.length} model${models.length === 1 ? '' : 's'} found — click one to fill empty slots.`;
+                    if (listEl) {
+                        listEl.hidden = false;
+                        listEl.innerHTML = models.map((m) =>
+                            `<button type="button" class="selection-pill" data-apply-model="${escapeHtml(m)}">${escapeHtml(m)}</button>`
+                        ).join('');
+                    }
+                } catch (err) {
+                    const msg = String(err?.message || err || 'Unknown error');
+                    if (statusEl) statusEl.textContent = `Failed: ${msg}`;
+                    if (listEl) { listEl.hidden = true; listEl.innerHTML = ''; }
+                } finally {
+                    loadBtn.disabled = false;
+                }
+            });
+            if (!root._compatModelListenerBound) {
+                root._compatModelListenerBound = true;
+                root.addEventListener('click', (event) => {
+                    const pill = event.target.closest('[data-apply-model]');
+                    if (!pill) return;
+                    const modelId = `openai-compatible::${pill.dataset.applyModel}`;
+                    if (!trim(state.mainModel)) state.mainModel = modelId;
+                    if (!trim(state.codeModel)) state.codeModel = modelId;
+                    if (!trim(state.lightModel)) state.lightModel = modelId;
+                    if (!trim(state.fallbackModel)) state.fallbackModel = modelId;
+                    state.modelsDirty = true;
+                    render();
+                });
+            }
+        }
+
         function bindModelsStep() {
             const modelInputMap = Object.fromEntries(MODEL_SLOTS.map((slot) => [slot.inputId, slot.stateKey]));
+            bindCompatibleModelLoader();
             function suggestionMatches(query) {
                 const needle = trim(query).toLowerCase();
                 return MODEL_SUGGESTIONS


### PR DESCRIPTION
## OpenAI-compatible provider in onboarding wizard
  
  Adds full onboarding support for OpenAI-compatible endpoints
  (Ollama, LM Studio,
  vLLM, and others). Previously `OPENAI_COMPATIBLE_BASE_URL` /
  `OPENAI_COMPATIBLE_API_KEY`
  existed in `llm.py` and `SETTINGS_DEFAULTS` but were invisible to
  the wizard —
  users had to hand-edit `settings.json` to use them.

## What changed

### Providers step
  - Added two new fields to `_PROVIDER_FIELDS`:
  `OPENAI_COMPATIBLE_BASE_URL`
    (`inputType: url`, plain text input) and
  `OPENAI_COMPATIBLE_API_KEY`
    (`inputType: password`, optional)
  - Extended `_PROVIDER_FIELDS` schema with an `inputType` column so
  URL fields
    render as `<input type="url">` and are skipped by the "key too
  short"
    validation
  - Added `openai-compatible` profile to `_PROFILE_SPECS` and
  `_MODEL_DEFAULTS`;
    detection priority: openrouter → openai-compatible →
  direct-single →
    direct-multi → local
  - `has_remote_provider` now recognises `OPENAI_COMPATIBLE_BASE_URL`
  so
    auth-free servers (Ollama out of the box) correctly skip
  onboarding on
    subsequent launches

### Models step
  - When the active profile is `openai-compatible`, a **Load models 
  from endpoint**
    panel appears above the model slots
  - Clicking **Load models** fetches `GET {baseUrl}/models` and
  displays the
    returned model IDs as clickable pills
  - Clicking a pill fills all empty model slots with
  `openai-compatible::<model-id>`
  - Inline hint updated to include the
  `openai-compatible::your-model-name` syntax

### Backend proxy (`POST /api/openai-compatible/models`)
  - New endpoint proxies the `/v1/models` request server-side to
  avoid browser
    CORS restrictions; reuses the existing
  `_fetch_openai_compatible_model_catalog`
    helper
  - In desktop mode (pywebview) the fetch goes through
  `WizardApi.fetch_compatible_models`,
    a synchronous `urllib.request` call with the same `{models:
  [...]}` response shape
  - Endpoint registered in `router.py` and declared in `contracts.py`

### Tests
  - `test_prepare_onboarding_settings_preserves_non_wizard_provider_f
  ields`:
    updated to reflect that `OPENAI_COMPATIBLE_*` fields are now
  wizard-managed
    (sourced from the payload, not preserved from `current_settings`)
  -`test_prepare_onboarding_settings_accepts_openai_compatible_setup`:
  new test
    asserting that a base URL without an API key is a valid remote
  provider
    configuration

## Compatibility

No breaking changes. Existing values saved via the Settings UI are
loaded into
the new wizard fields on the next run and survive a round-trip
through
`validate_setup_payload` unchanged.

<img width="1280" height="1258" alt="telegram-cloud-photo-size-2-5262854299920833272-y" src="https://github.com/user-attachments/assets/8c92c8b7-a7a4-4c72-aea2-fb8700ef09a0" />
<img width="1110" height="796" alt="image" src="https://github.com/user-attachments/assets/3d807cc0-3c61-4feb-8feb-75b0ef51b19e" />
