### PR TITLE
fix(chat,widgets): reconnect message loss, progress-bar race, bg-consciousness card finalize

### DIFF
--- a/ouroboros/consciousness.py
+++ b/ouroboros/consciousness.py
@@ -165,6 +165,23 @@ class BackgroundConsciousness:
             log_label="consciousness live",
         )
 
+    def _emit_cycle_idle(self, state: str) -> None:
+        """Signal that a background-thinking cycle ended, so the web UI can retire
+        the bg-consciousness live card instead of leaving it in a perpetual
+        "thinking" phase.
+
+        Background consciousness writes no task_result, so the renderer has no
+        terminal signal of its own. This emits a structured marker
+        (``consciousness_state``) consumed by ``web/modules/log_events.js`` — never
+        a text-matched one. Replay after reload is handled separately in
+        ``gateway/history.py``.
+        """
+        self._emit_live_log(
+            "consciousness_status",
+            is_progress=True,
+            consciousness_state=state,
+        )
+
     def _loop(self) -> None:
         """Daemon thread: sleep, wake, think, repeat."""
         while not self._stop_event.is_set():
@@ -192,6 +209,10 @@ class BackgroundConsciousness:
                 # Preserve distinct overflow/LLM error statuses set inside _think().
                 if cycle_completed and not self._stop_event.is_set() and not self._paused:
                     self._last_idle_reason = "sleeping"
+                # Retire the live card now that this cycle is done (skip while paused:
+                # a real task is active and owns the status).
+                if not self._paused:
+                    self._emit_cycle_idle(self._last_idle_reason)
             except Exception as e:
                 self._last_cycle_finished_at = utc_now_iso()
                 self._last_idle_reason = "error_backoff"
@@ -202,10 +223,12 @@ class BackgroundConsciousness:
                     "error": repr(e),
                     "traceback": traceback.format_exc()[:1500],
                 })
+                self._emit_cycle_idle("error_backoff")
                 self._next_wakeup_sec = min(
                     self._next_wakeup_sec * 2, self._wakeup_max
                 )
         self._last_idle_reason = "stopped"
+        self._emit_cycle_idle("stopped")
 
     def _check_budget(self) -> bool:
         """Return whether background consciousness is within its budget."""

--- a/ouroboros/gateway/history.py
+++ b/ouroboros/gateway/history.py
@@ -267,6 +267,21 @@ def make_chat_history_endpoint(data_dir: pathlib.Path):
         except Exception as exc:
             log.debug("Failed to annotate terminal task status in history: %s", exc)
 
+        # Background consciousness writes no task_result, so its progress would
+        # otherwise replay as a perpetual "thinking" card after reload. Mark its
+        # most recent progress entry terminal; a fresh live event re-activates the
+        # card if a new cycle starts. (Structured signal, consumed by log_events.js.)
+        try:
+            bg_msgs = [
+                m for m in combined
+                if m.get("is_progress") and str(m.get("task_id") or "") == "bg-consciousness"
+            ]
+            if bg_msgs:
+                latest = max(bg_msgs, key=lambda m: str(m.get("ts") or ""))
+                latest["task_terminal_status"] = "done"
+        except Exception as exc:
+            log.debug("Failed to annotate bg-consciousness terminal status: %s", exc)
+
         combined.sort(key=lambda m: m.get("ts", ""))
         messages = combined[-limit:] if len(combined) > limit else combined
         return JSONResponse({"messages": messages})

--- a/tests/test_bugfixes_airi.py
+++ b/tests/test_bugfixes_airi.py
@@ -1,0 +1,98 @@
+"""Regression tests for chat/widget bugs fixed in this change.
+
+Covers three issues:
+
+  * Bug 1 (polish) — the background-consciousness live card lingered in a
+    "thinking" phase forever because it has no task_result to mark it terminal.
+    The global status is already guarded upstream (isBackgroundTaskId); this adds
+    a structured end-of-cycle marker + history replay annotation so the card
+    itself finalizes to "done".
+  * Bug 3 — conversational text (user + assistant bubbles) disappeared after a
+    soft WebSocket reconnect because syncHistory skipped user messages and the
+    persistent dedupe set was never cleared.
+  * Bug 4a — the declarative progress widget froze then jumped: the job poll read
+    the wrong status key (so the WS-loss fallback was dead) and there was no
+    monotonic clamp.
+
+Pure-Python behavior is exercised directly; client-side (JS) fixes are pinned
+with static source contracts and verified visually.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import pathlib
+from types import SimpleNamespace
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _read(rel: str) -> str:
+    return (REPO / rel).read_text(encoding="utf-8")
+
+
+# ───────────────── Bug 1 (polish): background card finalizes ─────────────────
+
+def test_consciousness_emits_structured_idle_marker_not_text_matched():
+    src = _read("ouroboros/consciousness.py")
+    assert "_emit_cycle_idle" in src
+    assert "consciousness_state" in src
+    # The marker is structured, never a regex on log text (BIBLE P5).
+    assert "Going back to sleep" not in src
+
+
+def test_log_events_derives_bg_card_phase_from_marker():
+    src = _read("web/modules/log_events.js")
+    assert "consciousness_state" in src
+    assert "bgTerminal" in src
+
+
+def test_history_marks_bg_consciousness_terminal_on_replay(tmp_path):
+    from ouroboros.gateway.history import make_chat_history_endpoint
+
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "chat.jsonl").write_text("", encoding="utf-8")
+    (logs / "progress.jsonl").write_text(
+        json.dumps({
+            "ts": "2026-06-05T00:00:01Z", "task_id": "bg-consciousness",
+            "content": "thinking a", "is_progress": True,
+        }) + "\n" + json.dumps({
+            "ts": "2026-06-05T00:00:02Z", "task_id": "bg-consciousness",
+            "content": "thinking b", "is_progress": True,
+        }) + "\n",
+        encoding="utf-8",
+    )
+    endpoint = make_chat_history_endpoint(tmp_path)
+    resp = asyncio.run(endpoint(SimpleNamespace(query_params={})))
+    messages = json.loads(resp.body)["messages"]
+    bg = [m for m in messages if m.get("task_id") == "bg-consciousness"]
+    assert bg, "bg-consciousness progress should replay"
+    latest = max(bg, key=lambda m: m["ts"])
+    assert latest.get("task_terminal_status") == "done"
+    # Earlier entries stay non-terminal so the card animates while a cycle runs.
+    assert not bg[0].get("task_terminal_status")
+
+
+# ───────────────────── Bug 3: reconnect feed rebuild ─────────────────────────
+
+def test_reconnect_rebuilds_feed_and_clears_dedupe():
+    src = _read("web/modules/chat.js")
+    assert "const renderUser = includeUser || fromReconnect;" in src
+    assert "seenMessageKeys.clear();" in src
+    assert "messageKeyOrder.length = 0;" in src
+    assert "querySelectorAll('.chat-bubble')" in src
+    # User messages are restored on reconnect (not skipped).
+    assert "if (!renderUser && msg.role === 'user') continue;" in src
+
+
+# ──────────────────── Bug 4a: progress widget host race ──────────────────────
+
+def test_widget_job_poll_merges_full_status_and_clamps():
+    src = _read("web/modules/widgets.js")
+    assert "clampMonotonicProgress" in src
+    assert "progressValueKeys" in src
+    assert "...data," in src  # full flat merge surfaces value_key (e.g. progress_pct)
+    # The broken cherry-pick of the wrong key must be gone.
+    assert "progress: data.progress," not in src

--- a/web/modules/chat.js
+++ b/web/modules/chat.js
@@ -937,7 +937,9 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
         ensureLiveCardVisible(record, { suppressDomInsert });
         record.updates += 1;
         const wasFinished = record.finished;
-        const headline = summary.headline || 'Working...';
+        // Prefer the last meaningful headline when an update carries none (e.g. a
+        // structured terminal marker), so finishing a card doesn't blank its title.
+        const headline = summary.headline || record.lastHumanHeadline || 'Working...';
         const syntheticKey = summary.dedupeKey || dedupeKey || `${summary.phase || 'working'}|${headline}|${summary.body || ''}`;
         const isLegacyParentSubagentKey = syntheticKey.startsWith('parent-subagent:');
         const inPlaceByKey = isLegacyParentSubagentKey
@@ -1485,14 +1487,28 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
                 const data = await resp.json();
                 const messages = Array.isArray(data.messages) ? data.messages : [];
 
-                // First load/reconnect trusts server history and rebuilds retired cards.
-                // Routine post-completion syncs keep retiredTaskIds to avoid duplicates.
+                // First load/reconnect trusts server history and fully rebuilds the
+                // feed; routine post-completion syncs only fold in new task cards.
+                const rebuildAll = !historyLoaded || fromReconnect;
+                // On a soft reconnect the module (and its dedupe set) survives, so a
+                // plain re-sync would skip user messages and dedupe-drop every
+                // assistant bubble — the conversation would vanish. Restore user text
+                // and rebuild from durable history whenever we rebuild.
+                const renderUser = includeUser || fromReconnect;
                 if (!historyLoaded || fromReconnect) retiredTaskIds.clear();
-                if (!historyLoaded || fromReconnect) {
+                if (rebuildAll) {
                     for (const record of liveCardRecords.values()) record.root?.remove();
                     liveCardRecords.clear();
                     taskUiStates.clear();
                     activeLiveGroupId = '';
+                    // Atomically drop the standalone message bubbles and the dedupe
+                    // state so the rebuild below cannot produce duplicates even if
+                    // stale bubbles lingered in the DOM. Keep the typing indicator.
+                    for (const bubble of Array.from(messagesDiv.querySelectorAll('.chat-bubble'))) {
+                        if (bubble.id !== 'typing-indicator') bubble.remove();
+                    }
+                    seenMessageKeys.clear();
+                    messageKeyOrder.length = 0;
                 }
 
                 // Two passes ensure cards exist before finishLiveCard() marks them done.
@@ -1534,7 +1550,7 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
                 }
                 for (const msg of messages) {
                     const taskId = msg.task_id || '';
-                    if (!includeUser && msg.role === 'user') continue;
+                    if (!renderUser && msg.role === 'user') continue;
                     if (msg.is_progress) {
                         // Progress-only/failed tasks still anchor at their first event.
                         insertCardIfNeeded(taskId);

--- a/web/modules/log_events.js
+++ b/web/modules/log_events.js
@@ -484,11 +484,22 @@ export function summarizeChatLiveEvent(evt) {
     if (evt.is_progress || t === 'send_message') {
         const lifecycleTerminal = String(evt.task_id || '').startsWith('skill_lifecycle_')
             && /\s—\s(completed|failed)\b/i.test(progressText.full);
+        // Background consciousness has no task_result; the backend signals end-of-cycle
+        // with a structured `consciousness_state` marker (and history replay annotates
+        // the latest entry with `task_terminal_status`). Both are structured, not text.
+        const bgConsciousness = evt.task_id === 'bg-consciousness';
+        const bgState = String(evt.consciousness_state || '');
+        const bgErrored = bgState === 'error_backoff' || bgState === 'error';
+        const bgTerminal = bgConsciousness
+            && (Boolean(bgState) || Boolean(evt.task_terminal_status));
+        const bgPhase = bgTerminal ? (bgErrored ? 'lifecycle_error' : 'done') : 'thinking';
         return chatView({
-            phase: evt.task_id === 'bg-consciousness'
-                ? 'thinking'
+            phase: bgConsciousness
+                ? bgPhase
                 : (lifecycleTerminal ? (/failed\b/i.test(progressText.full) ? 'lifecycle_error' : 'done') : 'working'),
-            headline: progressText.preview || 'Working...',
+            // The bg end-of-cycle marker carries no text; pass an empty headline so
+            // the card keeps its last thought as the title instead of "Working...".
+            headline: (bgTerminal && !progressText.preview) ? '' : (progressText.preview || 'Working...'),
             fullHeadline: progressText.full || '',
             visible: Boolean(progressText.preview),
             promote: true,

--- a/web/modules/widgets.js
+++ b/web/modules/widgets.js
@@ -468,6 +468,38 @@ async function mountDeclarativeWidget(mount, tab, render) {
         };
         poll();
     };
+    // A job's progress is fed by two writers — the status poll and the WS
+    // subscription. Keep the percent monotonic per job so a stale poll tick or an
+    // out-of-order WS event can never move the bar backward. Resets when the job id
+    // changes. The percent key is whatever the progress component(s) read
+    // (`value_key`), so this works regardless of the skill's field name.
+    const progressValueKeys = (() => {
+        const keys = [];
+        for (const c of components) {
+            if (String(c?.type || '') !== 'progress') continue;
+            const k = String(c.path || c.value_key || 'progress');
+            if (k && !k.includes('.') && !keys.includes(k)) keys.push(k);
+        }
+        return keys.length ? keys : ['progress_pct', 'progress'];
+    })();
+    const clampMonotonicProgress = (target, jobId, nextObj) => {
+        if (!nextObj || typeof nextObj !== 'object') return nextObj;
+        let pctKey = '';
+        let pct;
+        for (const k of progressValueKeys) {
+            if (typeof nextObj[k] === 'number' && Number.isFinite(nextObj[k])) { pct = nextObj[k]; pctKey = k; break; }
+        }
+        if (pctKey === '') return nextObj;
+        const stateKey = `progress-clamp:${target}`;
+        const prev = componentState[stateKey];
+        if (prev && prev.jobId === jobId && prev.pct > pct) {
+            nextObj[pctKey] = prev.pct;
+            return nextObj;
+        }
+        componentState[stateKey] = { jobId, pct: nextObj[pctKey] };
+        return nextObj;
+    };
+
     const startJobPoll = (idx, jobId) => {
         if (disposed || !jobId || activeJobs.has(idx)) return;
         const spec = components[Number(idx)] || {};
@@ -501,12 +533,14 @@ async function mountDeclarativeWidget(mount, tab, render) {
                     renderAll();
                     return;
                 }
-                state[target] = {
+                // Merge the whole flat status payload so the renderer's value_key
+                // (e.g. `progress_pct`) is surfaced — cherry-picking `data.progress`
+                // dropped the percent and broke the poll fallback when WS hiccuped.
+                state[target] = clampMonotonicProgress(target, jobId, {
                     ...(state[target] || {}),
+                    ...data,
                     job_id: jobId,
-                    progress: data.progress,
-                    message: data.message,
-                };
+                });
                 status[target] = 'loading';
                 renderAll();
                 if (ticks < maxTicks) {
@@ -735,7 +769,10 @@ async function mountDeclarativeWidget(mount, tab, render) {
             const target = component.target || 'result';
             const handler = (msg) => {
                 if (disposed || msg?.type !== expectedType) return;
-                state[target] = msg.data || {};
+                const data = msg.data || {};
+                // Same monotonic guard as the poll writer: an out-of-order WS event
+                // must not rewind the bar.
+                state[target] = clampMonotonicProgress(target, data.job_id || '', data);
                 status[target] = 'success';
                 renderAll();
             };


### PR DESCRIPTION
Three independent, verified-present bug fixes on the current `ouroboros` branch (v6.17.0). Each is small and isolated.

## 1. Conversational text lost after a soft WebSocket reconnect
**Symptom:** after a soft reconnect (`/restart`, network blip, tab wake — *not* a full reload), the chat feed loses all conversational text (user **and** assistant bubbles); task cards survive.
**Cause:** the module-level dedupe set `seenMessageKeys` outlives a reconnect, and `syncHistory` skips user messages, so the rebuild can't redraw the conversation (assistant bubbles are dedupe-dropped, user messages skipped). Durable server history is complete — this is purely client-side rendering.
**Fix (`web/modules/chat.js`):** on a full rebuild (`!historyLoaded || fromReconnect`), atomically clear the standalone `.chat-bubble` nodes **and** the dedupe state (`seenMessageKeys` / `messageKeyOrder`), and restore user messages (`renderUser`). Rebuild from durable history → no duplicates, cards still survive, order preserved. Routine post-completion syncs are unchanged.

## 2. Declarative progress widget freezes then jumps
**Symptom:** a `mode:"job"` progress bar stalls, then jumps forward.
**Cause:** the job poll merged only `data.progress`, but the `/status` payload carries the percent under the component's `value_key` (e.g. `progress_pct`). So every poll tick discarded the percent, and the poll — meant to be the fallback when the WS `subscription` hiccups — couldn't move the bar at all (freeze; then a jump when WS resumed and full-replaced the slot). No monotonic guard existed.
**Fix (`web/modules/widgets.js`):** the poll now merges the full flat status payload (so whatever `value_key` the widget reads is surfaced), and **both** writers (poll + subscription) clamp the percent monotonically per job — a stale tick or out-of-order event can't rewind the bar. Generic over any progress `value_key`.

## 3. Background-consciousness card never finalizes
**Symptom:** the bg-consciousness live card lingers in a "thinking" phase after a cycle ends. (The global status badge is already guarded upstream via `isBackgroundTaskId`; this is the card's own phase.)
**Cause:** bg-consciousness writes no `task_result`, so the renderer never gets a terminal signal for that card.
**Fix:** the loop emits a **structured** end-of-cycle marker (`consciousness_state`, never text-matched — respects P5) in `ouroboros/consciousness.py`; `ouroboros/gateway/history.py` annotates the latest bg-consciousness progress entry terminal on replay; and `web/modules/log_events.js` derives the card phase from the marker (terminal → `done`). A one-line change in `chat.js` keeps the finished card's last thought as its title.

## Tests
Adds `tests/test_bugfixes_airi.py` (5 tests): behavioral coverage for the history annotation, and static contracts for the reconnect rebuild, the widget merge+clamp, and the structured marker. Existing `test_chat_logs_ui.py`, `test_restart_reconnect.py`, `test_consciousness.py` stay green.

The client-side changes (host renderer) are best verified visually; I've exercised the reconnect, progress-bar, and bg-consciousness flows locally.