### PR TITLE
fix(skills-ui): show in-flight lifecycle state so disable doesn't snap back to ON

### DIFF
--- a/tests/test_skill_disable_ui.py
+++ b/tests/test_skill_disable_ui.py
@@ -1,0 +1,45 @@
+"""Static UI contracts for the skill enable/disable in-flight feedback fix.
+
+Bug: toggling a skill OFF while the (serialized) lifecycle lane is busy showed no
+feedback and the toggle snapped back to ON, because mergeLifecycleEvents dropped
+the in-flight event for an already-listed skill and the card always rendered the
+stale persisted `enabled` value. See BUGREPORT-skill-disable-ui-stuck.md.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _read(rel: str) -> str:
+    return (REPO / rel).read_text(encoding="utf-8")
+
+
+def test_merge_annotates_existing_skill_instead_of_dropping_event():
+    src = _read("web/modules/skills.js")
+    # The in-flight event for an already-listed skill must annotate that card...
+    assert "existing.lifecycle_pending = event.status !== 'failed';" in src
+    assert "existing.lifecycle_status = event.status;" in src
+    # ...not be silently dropped by the old name-already-present guard.
+    assert "if (!name || names.has(name)) continue;" not in src
+
+
+def test_card_renders_pending_lifecycle_chip():
+    src = _read("web/modules/skill_card_renderer.js")
+    assert "lifecyclePendingLabel" in src
+    assert "Disabling…" in src  # "Disabling…"
+    assert "Enabling…" in src
+    # The pending chip takes precedence over the stale persisted status.
+    assert "if (skill.lifecycle_pending) {" in src
+
+
+def test_pending_toggle_is_locked_and_reflects_intent():
+    src = _read("web/modules/skill_card_renderer.js")
+    assert "const lifecyclePending = Boolean(skill.lifecycle_pending);" in src
+    # Toggle is disabled while a lifecycle job is in-flight so the re-render
+    # cannot snap it back to the stale state, and it reflects the pending intent.
+    assert "const toggleLocked = Boolean(lockReason) || lifecyclePending;" in src
+    assert "${toggleLocked ? 'disabled' : ''}" in src
+    assert "${toggleOn ? 'checked' : ''}" in src

--- a/web/modules/skill_card_renderer.js
+++ b/web/modules/skill_card_renderer.js
@@ -54,7 +54,26 @@ function primaryAction(skill, reviewInProgress, repairInProgress, live) {
     return { label: '' };
 }
 
+const LIFECYCLE_PENDING_LABELS = {
+    disable: 'Disabling…',
+    enable: 'Enabling…',
+    uninstall: 'Uninstalling…',
+    update: 'Updating…',
+    install: 'Installing…',
+    review: 'Reviewing…',
+    deps: 'Installing deps…',
+};
+
+function lifecyclePendingLabel(kind) {
+    return LIFECYCLE_PENDING_LABELS[String(kind || '')] || 'Working…';
+}
+
 function statusChip(skill, action, live) {
+    // An in-flight lifecycle job (serialized lane) takes precedence so the card
+    // shows e.g. "Disabling…" instead of the stale persisted state.
+    if (skill.lifecycle_pending) {
+        return `<span class="skills-status-chip skills-status-warn">${escapeHtml(lifecyclePendingLabel(skill.lifecycle_kind))}</span>`;
+    }
     let status = { tone: 'muted', label: 'Off' };
     if (!grantReady(skill)) status = { tone: 'warn', label: 'Needs access grant' };
     else if (skill.lifecycle_virtual && isRateLimitError(skill.load_error)) status = { tone: 'warn', label: 'Rate limited' };
@@ -148,8 +167,17 @@ export function renderInstalledSkillCard(skill, reviewingSkills = new Set(), rep
             ${localDelete ? `<button type="button" role="menuitem" class="skills-menu-item skills-delete-local" data-skill="${safeName}" data-payload-root="${escapeHtml(payloadRoot)}">Delete</button>` : ''}
         </dialog></div>` : '';
     const primary = action.action ? `<button type="button" class="btn btn-primary skills-primary-action" data-skill="${safeName}" data-skill-action="${escapeHtml(action.action)}" ${action.keys ? `data-keys="${escapeHtml(action.keys)}"` : ''} ${action.disabled ? 'disabled' : ''}>${escapeHtml(action.label)}</button>` : '';
-    const toggle = skill.lifecycle_virtual ? '' : `<label class="skills-switch ${lockReason ? 'is-locked' : ''}" ${lockReason && action.action ? actionAttrs : ''} title="${escapeHtml(lockReason ? `Locked: ${lockReason}` : (skill.enabled ? 'Turn skill off' : 'Turn skill on'))}">
-        <input type="checkbox" class="skills-toggle" role="switch" data-skill="${safeName}" ${skill.enabled ? 'checked' : ''} ${lockReason ? 'disabled' : ''} aria-checked="${skill.enabled ? 'true' : 'false'}" aria-label="${escapeHtml(lockReason ? `${skill.name} (locked: ${lockReason})` : skill.name)}">
+    // While a lifecycle job for this skill is queued/running, reflect the in-flight
+    // intent and lock the control, so the toggle handler's re-render cannot snap it
+    // back to the stale persisted state with no feedback.
+    const lifecyclePending = Boolean(skill.lifecycle_pending);
+    const toggleOn = skill.lifecycle_kind === 'disable' && lifecyclePending ? false
+        : (skill.lifecycle_kind === 'enable' && lifecyclePending ? true : skill.enabled);
+    const toggleLocked = Boolean(lockReason) || lifecyclePending;
+    const toggleTitle = lifecyclePending ? lifecyclePendingLabel(skill.lifecycle_kind)
+        : (lockReason ? `Locked: ${lockReason}` : (skill.enabled ? 'Turn skill off' : 'Turn skill on'));
+    const toggle = skill.lifecycle_virtual ? '' : `<label class="skills-switch ${toggleLocked ? 'is-locked' : ''}" ${lockReason && action.action ? actionAttrs : ''} title="${escapeHtml(toggleTitle)}">
+        <input type="checkbox" class="skills-toggle" role="switch" data-skill="${safeName}" ${toggleOn ? 'checked' : ''} ${toggleLocked ? 'disabled' : ''} aria-checked="${toggleOn ? 'true' : 'false'}" aria-label="${escapeHtml(lifecyclePending ? `${skill.name} (${lifecyclePendingLabel(skill.lifecycle_kind)})` : (lockReason ? `${skill.name} (locked: ${lockReason})` : skill.name))}">
         <span class="skills-switch-track" aria-hidden="true"><span class="skills-switch-thumb"></span></span>
     </label>`;
     const details = `<details class="skills-details"><summary>Show details</summary>

--- a/web/modules/skills.js
+++ b/web/modules/skills.js
@@ -96,11 +96,26 @@ async function fetchSkills() {
 
 function mergeLifecycleEvents(skills, events) {
     const out = [...skills];
-    const names = new Set(out.map((skill) => skill.name));
+    const byName = new Map(out.map((skill) => [skill.name, skill]));
+    const names = new Set(byName.keys());
     for (const event of [...events].reverse()) {
         if (!['queued', 'running', 'failed'].includes(event.status)) continue;
         const name = event.target;
-        if (!name || names.has(name)) continue;
+        if (!name) continue;
+        if (names.has(name)) {
+            // The skill already has a real card. Annotate it with the in-flight
+            // transition so it can show "Disabling…/Enabling…" instead of a stale
+            // clean toggle while the (serialized) lifecycle lane works through it.
+            // Events are reversed → newest first, so the first wins per skill.
+            const existing = byName.get(name);
+            if (existing && existing.lifecycle_status === undefined) {
+                existing.lifecycle_status = event.status;
+                existing.lifecycle_kind = event.kind || existing.lifecycle_kind || '';
+                existing.lifecycle_pending = event.status !== 'failed';
+                if (event.status === 'failed' && event.error) existing.lifecycle_error = event.error;
+            }
+            continue;
+        }
         names.add(name);
         out.unshift({
             name,


### PR DESCRIPTION
**Symptom:** toggling a skill OFF (e.g. `backlog_manager`) while the skill-lifecycle lane is busy shows no "Disabling…" feedback and the toggle snaps back to **ON**; reloading the Skills page still shows the skill as Active until the queued disable job finally runs. Users click disable again → a second job gets queued. The backend disable persists correctly (`/api/extensions` → `enabled=false, live_loaded=false, live_reason="disabled"` once it runs) — this is purely a **UI feedback** gap.

**Root cause**
1. All mutating skill-lifecycle ops run through one serialized FIFO lane (intentional), so a disable can sit **queued** behind slow installs while `enabled.json` is still `true`.
2. `mergeLifecycleEvents()` dropped the queued/running event for any skill that **already had a real card** (`names.has(name)` → `continue`), so the canonical card never showed the in-flight transition.
3. The card always rendered the stale persisted `enabled`, so the toggle handler's `finally` re-render restored **ON** while the job was still queued.

**Fix** (frontend only — the single-lane serialization is by design and untouched):
- **`web/modules/skills.js` · `mergeLifecycleEvents`** — when a `queued`/`running`/`failed` event targets an already-listed skill, **annotate that card** with `lifecycle_pending` / `lifecycle_kind` / `lifecycle_status` (newest event wins) instead of dropping it. Virtual cards are still synthesized only for genuinely new names (installs).
- **`web/modules/skill_card_renderer.js`** — when `lifecycle_pending`, render a status chip (`Disabling…` / `Enabling…` / `Uninstalling…` / …) and a **locked (disabled) toggle that reflects the pending intent**, so the re-render can't silently restore the stale state. Clears when the terminal lifecycle event arrives.

This is a class fix (BIBLE P2): any enable/disable/uninstall job landing behind a busy lane now shows its in-flight state on the canonical card, and a mid-job reload rebuilds "Disabling…" from the queued/running events.

**Tests:** adds `tests/test_skill_disable_ui.py` (annotate-not-drop + pending chip + locked toggle). Existing skills/chat UI static suites stay green.

Out of scope (unchanged): the FIFO lifecycle-lane serialization, backend `save_enabled`.