### PR TITLE
fix(chat-ui): chronological card insertion + scope composer hover to pointer devices

### DIFF
--- a/tests/test_chat_chronological_order.py
+++ b/tests/test_chat_chronological_order.py
@@ -1,0 +1,67 @@
+"""Static UI contracts for the mobile/chat fixes (see MOBILE_BUGS.md).
+
+BUG-1: composer :hover styling is scoped to pointer devices so iOS Safari's
+sticky :hover does not leave the Consilium button looking "still on" after a tap.
+
+BUG-3 (subsumes BUG-2): chat bubbles and live-card roots are stamped with a
+sortable epoch-ms data-ts derived from the RAW timestamp (not the lossy
+normalizeLogTs display string), and insertMessageNode inserts in chronological
+order — so replayed/finished cards (including the background-consciousness card)
+settle into their historical position instead of being pinned to the bottom.
+
+The behavioural assertion lives in the Playwright ui_browser lane; these are
+source-contract pins for the load-bearing pieces.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _read(rel: str) -> str:
+    return (REPO / rel).read_text(encoding="utf-8")
+
+
+# ───────────────────────── BUG-1: sticky hover on touch ─────────────────────
+
+def test_composer_hover_scoped_to_pointer_devices():
+    css = _read("web/style.css")
+    assert "@media (hover: hover)" in css
+    # The consilium hover rule must be inside a hover-capable media query.
+    idx = css.index(".chat-consilium:hover")
+    assert "@media (hover: hover)" in css[:idx][-200:], "consilium :hover not scoped"
+
+
+# ──────────────── BUG-3: chronological insertion (subsumes BUG-2) ───────────
+
+def test_nodes_stamped_with_raw_epoch_ts_not_normalized():
+    src = _read("web/modules/chat.js")
+    assert "function tsToMs(" in src
+    assert "function stampNodeTs(" in src
+    # Card root anchors at its earliest raw ts (set-once), bubbles stamp from ts.
+    assert "stampNodeTs(record.root, rawTs, { setOnce: true })" in src
+    assert "stampNodeTs(bubble, ts)" in src
+    # Must NOT stamp the sortable ts from the lossy normalized display string.
+    assert "stampNodeTs(record.root, normalizeLogTs" not in src
+    assert "stampNodeTs(bubble, normalizeLogTs" not in src
+
+
+def test_insert_message_node_orders_by_data_ts():
+    src = _read("web/modules/chat.js")
+    # Chronological scan: insert before the first child with a greater data-ts.
+    assert "const nodeTs = Number(node.dataset?.ts);" in src
+    assert "const childTs = Number(child.dataset?.ts);" in src
+    assert "if (childTs > nodeTs) {" in src
+    # Children without a parseable data-ts are skipped, not coerced.
+    assert "if (!Number.isFinite(childTs)) continue;" in src
+    # Typing indicator special-case + sticky scroll preserved.
+    assert "if (child === node || child === typing) continue;" in src
+    assert "if (shouldStick) messagesDiv.scrollTop = messagesDiv.scrollHeight;" in src
+
+
+def test_reused_card_anchor_reset_on_recycle():
+    src = _read("web/modules/chat.js")
+    # Reused (bg-consciousness) cards drop their anchor so a new cycle re-stamps.
+    assert "delete record.root.dataset.ts;" in src

--- a/web/modules/chat.js
+++ b/web/modules/chat.js
@@ -495,6 +495,30 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
         return remaining <= threshold;
     }
 
+    // Convert a raw ISO/epoch timestamp to a sortable epoch-ms number, or NaN.
+    // NEVER derive this from normalizeLogTs() output — that is a lossy, time-only
+    // display string (no date), so it cannot order across days.
+    function tsToMs(raw) {
+        if (raw == null || raw === '') return NaN;
+        const ms = typeof raw === 'number' ? raw : Date.parse(raw);
+        return Number.isFinite(ms) ? ms : NaN;
+    }
+
+    // Stamp a node with a sortable data-ts (epoch-ms). For cards, setOnce anchors
+    // the node at its earliest timestamp (task start) so later updates don't
+    // re-sort a long-running card to the bottom.
+    function stampNodeTs(node, raw, { setOnce = false } = {}) {
+        if (!node) return;
+        const ms = tsToMs(raw);
+        if (!Number.isFinite(ms)) return;
+        if (setOnce && node.dataset.ts) {
+            const prev = Number(node.dataset.ts);
+            node.dataset.ts = String(Number.isFinite(prev) ? Math.min(prev, ms) : ms);
+        } else {
+            node.dataset.ts = String(ms);
+        }
+    }
+
     function insertMessageNode(node, options = {}) {
         if (!node) return;
         const shouldStick = Boolean(options.forceStick) || isNearBottom();
@@ -503,8 +527,28 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
             return;
         }
         const typing = document.getElementById('typing-indicator');
-        if (typing && typing.parentNode === messagesDiv) messagesDiv.insertBefore(node, typing);
-        else messagesDiv.appendChild(node);
+        // Chronological insertion: place the node before the first existing child
+        // whose data-ts is greater. Children without a parseable data-ts
+        // (welcome/ephemeral bubbles, the typing indicator) are skipped, not
+        // coerced to 0/NaN. A node without its own data-ts falls back to append.
+        const nodeTs = Number(node.dataset?.ts);
+        let inserted = false;
+        if (Number.isFinite(nodeTs)) {
+            for (const child of messagesDiv.children) {
+                if (child === node || child === typing) continue;
+                const childTs = Number(child.dataset?.ts);
+                if (!Number.isFinite(childTs)) continue;
+                if (childTs > nodeTs) {
+                    messagesDiv.insertBefore(node, child);
+                    inserted = true;
+                    break;
+                }
+            }
+        }
+        if (!inserted) {
+            if (typing && typing.parentNode === messagesDiv) messagesDiv.insertBefore(node, typing);
+            else messagesDiv.appendChild(node);
+        }
         if (shouldStick) messagesDiv.scrollTop = messagesDiv.scrollHeight;
     }
 
@@ -559,11 +603,12 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
         }, delayMs);
     }
 
-    function bufferLiveUpdate(taskState, summary, ts, dedupeKey = '') {
+    function bufferLiveUpdate(taskState, summary, ts, dedupeKey = '', rawTs = '') {
         if (!taskState || !summary) return;
         taskState.bufferedLiveUpdates.push({
             summary,
             ts,
+            rawTs,
             dedupeKey: dedupeKey || summary.dedupeKey || '',
         });
 
@@ -581,7 +626,7 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
         const bufferedUpdates = [...taskState.bufferedLiveUpdates];
         taskState.bufferedLiveUpdates = [];
         for (const update of bufferedUpdates) {
-            applyLiveCardState(update.summary, taskState.taskId, update.ts, update.dedupeKey, { suppressDomInsert });
+            applyLiveCardState(update.summary, taskState.taskId, update.ts, update.dedupeKey, { suppressDomInsert, rawTs: update.rawTs });
         }
         if (taskState.completed) {
             finishLiveCard(taskState.taskId, taskState.completedPhase || 'done');
@@ -633,7 +678,7 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
     // Logical slots that may host multiple independent cycles.
     const REUSABLE_TASK_IDS = new Set(['bg-consciousness', 'active']);
 
-    function queueTaskLiveUpdate(summary, taskId, ts, dedupeKey = '') {
+    function queueTaskLiveUpdate(summary, taskId, ts, dedupeKey = '', rawTs = '') {
         const resolvedTaskId = taskId || activeLiveGroupId || '';
         if (!resolvedTaskId) return;
         const taskState = getTaskUiState(resolvedTaskId, true);
@@ -662,11 +707,11 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
             taskState.forceCard = true;
         }
         if (!taskState.cardVisible) {
-            bufferLiveUpdate(taskState, summary, ts, dedupeKey);
+            bufferLiveUpdate(taskState, summary, ts, dedupeKey, rawTs);
             revealBufferedCardIfNeeded(taskState);
             return;
         }
-        applyLiveCardState(summary, resolvedTaskId, ts, dedupeKey);
+        applyLiveCardState(summary, resolvedTaskId, ts, dedupeKey, { rawTs });
     }
 
     function createLiveCardRecord(groupId = '', options = {}) {
@@ -813,6 +858,9 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
         record.metaEl.innerHTML = '';
         record.timelineEl.innerHTML = '';
         record.root.dataset.finished = '0';
+        // Reused (REUSABLE_TASK_IDS, e.g. bg-consciousness) cards start a fresh
+        // cycle: drop the old anchor so the next update re-stamps the new ts.
+        delete record.root.dataset.ts;
         setLiveCardTypingVisible(record, true);
         setLiveCardExpanded(record, record.isSubagent && nestedSubagentsExpanded);
     }
@@ -1000,7 +1048,7 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
         }, 700);
     }
 
-    function applyLiveCardState(summary, groupId, ts, dedupeKey = '', { suppressDomInsert = false } = {}) {
+    function applyLiveCardState(summary, groupId, ts, dedupeKey = '', { suppressDomInsert = false, rawTs = '' } = {}) {
         const nextGroupId = groupId || activeLiveGroupId || 'active';
         const record = getLiveCardRecord(nextGroupId);
         const nextPhase = summary.phase || '';
@@ -1009,6 +1057,11 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
         }
 
         if (!record.isSubagent) activeLiveGroupId = nextGroupId;
+        // Anchor the card chronologically at its earliest timestamp (raw, not the
+        // lossy normalized display string) BEFORE it is inserted into the DOM, so a
+        // replayed/finished card lands at its historical position, not the bottom.
+        // Subagent child cards live in their own container and are not ts-ordered.
+        if (!record.isSubagent) stampNodeTs(record.root, rawTs, { setOnce: true });
         ensureLiveCardVisible(record, { suppressDomInsert });
         record.updates += 1;
         const wasFinished = record.finished;
@@ -1188,7 +1241,7 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
             taskId,
             normalizeLogTs(msg.ts || new Date().toISOString()),
             `task_done|${taskId}`,
-            { suppressDomInsert },
+            { suppressDomInsert, rawTs: msg.ts || new Date().toISOString() },
         );
         finishLiveCard(taskId, failedResult ? 'error' : 'done');
         scheduleTaskUiCleanup(taskState);
@@ -1261,7 +1314,7 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
             lifecycle: msg?.lifecycle || null,
         });
         if (!summary) return;
-        queueTaskLiveUpdate(summary, taskId, normalizeLogTs(msg.ts || new Date().toISOString()), summary.dedupeKey || '');
+        queueTaskLiveUpdate(summary, taskId, normalizeLogTs(msg.ts || new Date().toISOString()), summary.dedupeKey || '', msg.ts || new Date().toISOString());
     }
 
     function updateSubagentCardFromEvent(evt, tsValue) {
@@ -1426,7 +1479,7 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
             if (!summary) return;
             const info = subagentChildParents.get(taskId);
             if (info) getSubagentCardRecord(taskId, info.parentId, info.role);
-            queueTaskLiveUpdate(summary, taskId, normalizeLogTs(evt.ts || evt.timestamp), summary.dedupeKey || '');
+            queueTaskLiveUpdate(summary, taskId, normalizeLogTs(evt.ts || evt.timestamp), summary.dedupeKey || '', evt.ts || evt.timestamp);
             return;
         }
         if (eventType === 'tool_call_started') {
@@ -1444,7 +1497,7 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
         }
         const summary = summarizeChatLiveEvent(evt);
         if (!summary) return;
-        queueTaskLiveUpdate(summary, taskId, normalizeLogTs(evt.ts || evt.timestamp), summary.dedupeKey || '');
+        queueTaskLiveUpdate(summary, taskId, normalizeLogTs(evt.ts || evt.timestamp), summary.dedupeKey || '', evt.ts || evt.timestamp);
         updateSubagentCardFromEvent(evt, evt.ts || evt.timestamp || new Date().toISOString());
         if (eventType === 'task_done') {
             const taskState = getTaskUiState(taskId, false);
@@ -1528,6 +1581,7 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
                 requestAnimationFrame(() => updateMessagesPadding({ preserveStickiness: true }));
             });
         }
+        stampNodeTs(bubble, ts);
         insertMessageNode(bubble, { forceStick: !!opts.forceStick });
         rememberMessageKey(messageKey);
         if (pending && clientMessageId) pendingUserBubbles.set(clientMessageId, bubble);
@@ -2174,6 +2228,7 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
         if (img && imageUrl) {
             img.addEventListener('click', () => window.open(imageUrl, '_blank'));
         }
+        stampNodeTs(bubble, msg.ts || new Date().toISOString());
         insertMessageNode(bubble);
         incrementUnreadIfNeeded();
     });
@@ -2204,6 +2259,7 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
             <div class="message"><video class="chat-video" src="${escapeHtmlAttr(videoUrl)}" controls></video></div>
             ${timeHtml}
         `;
+        stampNodeTs(bubble, msg.ts || new Date().toISOString());
         insertMessageNode(bubble);
         incrementUnreadIfNeeded();
     });

--- a/web/style.css
+++ b/web/style.css
@@ -1895,10 +1895,14 @@ body {
     white-space: nowrap;
     transition: color 0.18s, background 0.18s, border-color 0.18s, box-shadow 0.18s;
 }
-.chat-consilium:hover {
-    color: var(--accent);
-    border-color: rgba(232, 93, 111, 0.40);
-    background: rgba(38, 25, 34, 0.58);
+/* Scope hover to pointer devices: iOS Safari keeps :hover stuck after a tap,
+   which made the Consilium button look "still on" after disarming (BUG-1). */
+@media (hover: hover) {
+    .chat-consilium:hover {
+        color: var(--accent);
+        border-color: rgba(232, 93, 111, 0.40);
+        background: rgba(38, 25, 34, 0.58);
+    }
 }
 .chat-consilium[data-armed="true"] {
     color: var(--accent);
@@ -1937,8 +1941,10 @@ body {
     cursor: pointer;
     transition: color 0.15s, background 0.15s;
 }
-.chat-context-mode .chat-seg:hover {
-    color: var(--text-primary);
+@media (hover: hover) {
+    .chat-context-mode .chat-seg:hover {
+        color: var(--text-primary);
+    }
 }
 /* Active segment: Max glows accent (full context); Low glows amber (reduced). */
 .chat-context-mode[data-context-mode="max"] .chat-seg[data-mode="max"] {
@@ -1986,10 +1992,12 @@ body {
     display: flex;
     align-items: center;
 }
-.chat-send-inline:hover {
-    opacity: 1;
-    background: var(--accent-18);
-    border-color: rgba(232, 93, 111, 0.48);
+@media (hover: hover) {
+    .chat-send-inline:hover {
+        opacity: 1;
+        background: var(--accent-18);
+        border-color: rgba(232, 93, 111, 0.48);
+    }
 }
 .chat-send-inline:active {
     background: var(--accent-18);


### PR DESCRIPTION
Two UI fixes from a mobile bug handoff (BUG-2 is subsumed by BUG-3).

## BUG-1 — Consilium button looks "stuck red" on iOS Safari
The second tap **does** disarm it (`data-armed="false"`); the leftover red is a sticky `:hover`. iOS Safari keeps `:hover` after a tap, and the composer hover rules weren't gated.
**Fix (`web/style.css`):** wrap `.chat-consilium:hover`, `.chat-context-mode .chat-seg:hover`, and `.chat-send-inline:hover` in `@media (hover: hover)` so hover styling applies only to pointer devices. The armed state (fill + glow ring) stays visually distinct from hover.

## BUG-3 — chat cards/messages not inserted chronologically (fixes BUG-2)
On load/reconnect, task/progress/skill-lifecycle cards and the finished **background-consciousness** card appear at the **bottom** instead of their historical position; "yesterday's" finished cards re-materialise at the bottom on every reload.

Root cause is frontend-only: `/api/chat/history` already returns history sorted by `ts`, but `insertMessageNode` never ordered by time, and several paths (terminal-status loop, disconnected-card fallback, `task_summary`-only cards) bypass the ordered walk and append at the bottom.

**Fix (`web/modules/chat.js`):** stamp every bubble and live-card root with a sortable epoch-ms `data-ts` and make `insertMessageNode` insert chronologically.
- `data-ts` is derived from the **raw** timestamp (`Date.parse`), **never** from `normalizeLogTs()` — verified to be a lossy, time-only display string that can't order across days.
- Card roots are stamped in `applyLiveCardState` (the convergence funnel) with the raw ts threaded through `queueTaskLiveUpdate`/`bufferLiveUpdate`; **set-once/`Math.min`** anchors a card at its start so updates don't re-sort it to the bottom.
- `insertMessageNode` scans only direct children, **skips** children without a parseable `data-ts` (welcome/ephemeral/typing) rather than coercing to `0`/`NaN`, keeps the typing-indicator special-case and sticky-scroll, inserts before the first greater `data-ts`, else appends (nodes lacking `data-ts` still append — live streaming not regressed).
- Reused (`bg-consciousness`) cards drop their anchor on recycle so a new cycle re-stamps; subagent child cards live in their own container and are intentionally not ts-ordered.

**BUG-2 for free:** the finished bg-consciousness card carries the bg entry's `ts` and now settles into its historical position on reload — no replay stripping in `history.py`/`log_events.js`.

## Tests / verification
Adds `tests/test_chat_chronological_order.py` (source contracts for the load-bearing pieces). The behavioural ordered-insertion assertion belongs in the Playwright `ui_browser` lane — this is a host-renderer change and should be verified visually (desktop hover still highlights; iOS tap toggles cleanly; reload places cards chronologically) before release. `GATEWAY_CONTRACT_VERSION` == `VERSION` parity preserved.