### PR TITLE
fix(supervisor): reap orphaned worker process groups + plug respawn/cleanup/child-drive leaks

### DIFF
--- a/ouroboros/headless.py
+++ b/ouroboros/headless.py
@@ -279,6 +279,31 @@ def prune_task_drives(
     return report
 
 
+def remove_subagent_task_drive(parent_drive_root: pathlib.Path, task_id: str) -> bool:
+    """Immediately remove a subagent's child drive (used on cancel/timeout).
+
+    ``prune_*_task_drives`` only frees a child drive on the next startup and after
+    the retention window, so a subagent cancelled mid-run would otherwise leave
+    its scratch drive under ``state/headless_tasks/<id>`` or ``task_drives/<id>``
+    for the rest of the session. A cancelled subagent produced no result to copy
+    back, so dropping its drive now is safe. Returns True if anything was removed.
+    """
+    parent = pathlib.Path(parent_drive_root)
+    try:
+        validate_task_id(task_id)
+    except Exception:
+        return False
+    removed = False
+    for base in (parent / HEADLESS_TASKS_DIR / task_id, parent / TASK_DRIVES_DIR / task_id):
+        try:
+            if base.is_dir():
+                shutil.rmtree(base)
+                removed = True
+        except Exception:
+            log.debug("Failed to remove subagent task drive %s", base, exc_info=True)
+    return removed
+
+
 def copy_child_task_result(parent_drive_root: pathlib.Path, task: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Copy a child-drive task result back to the parent data root."""
 

--- a/server.py
+++ b/server.py
@@ -1108,6 +1108,12 @@ def _emergency_process_cleanup(*, port_sweep: bool = True) -> None:
             force_kill_pid(child.pid)
         except (ProcessLookupError, PermissionError):
             pass
+        # Reap the Process object so it does not linger as a zombie / keep
+        # active_children non-empty if the main process exits before it dies.
+        try:
+            child.join(timeout=2)
+        except Exception:
+            pass
     if port_sweep:
         kill_process_on_port(DEFAULT_PORT)
         kill_process_on_port(8766)

--- a/supervisor/queue.py
+++ b/supervisor/queue.py
@@ -1022,6 +1022,14 @@ def cancel_task_by_id(task_id: str) -> bool:
                 except Exception:
                     log.debug("Failed to archive service logs for cancelled task %s", task_id, exc_info=True)
                 workers.respawn_worker(w.wid)
+                # Free a cancelled subagent's child drive now (the worker is dead);
+                # otherwise it lingers until the next startup prune + retention.
+                if str(task.get("delegation_role") or "") == "subagent":
+                    try:
+                        from ouroboros.headless import remove_subagent_task_drive
+                        remove_subagent_task_drive(DRIVE_ROOT, str(task_id))
+                    except Exception:
+                        log.debug("Failed to remove cancelled subagent drive for %s", task_id, exc_info=True)
                 persist_queue_snapshot(reason="cancel_running")
                 return True
 

--- a/supervisor/workers.py
+++ b/supervisor/workers.py
@@ -617,8 +617,88 @@ def _verify_worker_sha_after_spawn(events_offset: int, timeout_sec: float = 90.0
         )
 
 
+_WORKER_PIDS_FILENAME = "worker_pids.json"
+
+
+def _worker_pids_path() -> pathlib.Path:
+    return DRIVE_ROOT / "state" / _WORKER_PIDS_FILENAME
+
+
+def _record_worker_pids() -> None:
+    """Persist current worker PIDs so a later server instance can reap any that
+    survive an abrupt restart. Workers run in their own ``os.setsid`` session, so
+    when the parent server dies they are reparented to init and outlive it."""
+    try:
+        from ouroboros.utils import atomic_write_json
+        recs = [{"pid": int(w.proc.pid)} for w in WORKERS.values() if w.proc.pid]
+        atomic_write_json(
+            _worker_pids_path(),
+            {"server_pid": os.getpid(), "ts": utc_now_iso(), "workers": recs},
+            trailing_newline=True,
+        )
+    except Exception:
+        log.debug("Failed to record worker pids", exc_info=True)
+
+
+def reap_orphaned_workers() -> int:
+    """Kill leftover worker process groups left by a PRIOR server instance.
+
+    ``kill_workers`` only walks the in-memory ``WORKERS`` dict, so workers
+    orphaned by an abrupt restart (reparented to init, ~one Python interpreter
+    each) were never reaped and accumulated across restarts. On startup we read
+    the prior pid record and force-kill any that are still alive AND verifiably
+    ours — cmdline matches this interpreter/multiprocessing and the process is
+    its own session leader (``pgid == pid``) — which guards against PID reuse and
+    bounds the group kill to the worker's own setsid session."""
+    try:
+        from ouroboros.utils import read_json_dict
+        from ouroboros.platform_layer import (
+            force_kill_pid,
+            kill_process_group_id,
+            process_command,
+            process_group_id,
+        )
+    except Exception:
+        return 0
+    data = read_json_dict(_worker_pids_path()) or {}
+    prior = data.get("workers") or []
+    if not isinstance(prior, list) or not prior:
+        return 0
+    current = {w.proc.pid for w in WORKERS.values() if w.proc.pid}
+    killed: List[int] = []
+    for rec in prior:
+        try:
+            pid = int((rec or {}).get("pid") or 0)
+        except (TypeError, ValueError):
+            continue
+        if not pid or pid in current or pid == os.getpid():
+            continue
+        cmd = process_command(pid)
+        if not cmd:
+            continue  # already dead
+        if sys.executable not in cmd and "multiprocessing" not in cmd:
+            continue  # PID reused by an unrelated process — do not touch it
+        pgid = process_group_id(pid)
+        if pgid and pgid == pid:
+            kill_process_group_id(pgid)  # the worker's own setsid session
+        force_kill_pid(pid)
+        killed.append(pid)
+    if killed:
+        try:
+            append_jsonl(
+                DRIVE_ROOT / "logs" / "supervisor.jsonl",
+                {"ts": utc_now_iso(), "type": "orphaned_workers_reaped", "pids": killed},
+            )
+        except Exception:
+            log.debug("Failed to log orphaned worker reap", exc_info=True)
+    return len(killed)
+
+
 def spawn_workers(n: int = 0) -> None:
     global _CTX, _EVENT_Q
+    # Reap any workers left orphaned by a prior/abrupt server exit before we
+    # spawn fresh ones, so process groups do not accumulate across restarts.
+    reap_orphaned_workers()
     # Fresh context ensures workers use current code.
     _CTX = mp.get_context(_WORKER_START_METHOD)
     _EVENT_Q = _CTX.Queue()
@@ -648,6 +728,7 @@ def spawn_workers(n: int = 0) -> None:
         WORKERS[i] = Worker(wid=i, proc=proc, in_q=in_q, busy_task_id=None)
     global _LAST_SPAWN_TIME
     _LAST_SPAWN_TIME = time.time()
+    _record_worker_pids()
     # Verify asynchronously so spawn does not block the supervisor loop.
     threading.Thread(target=_verify_worker_sha_after_spawn, args=(events_offset,), daemon=True).start()
 
@@ -745,7 +826,20 @@ def respawn_worker(wid: int) -> None:
                        args=(wid, in_q, get_event_q(), str(REPO_DIR), str(DRIVE_ROOT)))
     proc.daemon = True
     proc.start()
-    WORKERS[wid] = Worker(wid=wid, proc=proc, in_q=in_q, busy_task_id=None)
+    # Swap under _queue_lock (an RLock — safe even when the caller already holds
+    # it) so a concurrent assign_tasks cannot enqueue into the slot mid-swap.
+    with _queue_lock:
+        old = WORKERS.get(wid)
+        WORKERS[wid] = Worker(wid=wid, proc=proc, in_q=in_q, busy_task_id=None)
+    # Close the crashed worker's old queue now that nothing can route to it,
+    # otherwise its file descriptors / semaphores leak on every respawn.
+    if old is not None and getattr(old, "in_q", None) is not None:
+        try:
+            old.in_q.close()
+            old.in_q.cancel_join_thread()
+        except Exception:
+            log.debug("Failed to close old worker queue on respawn", exc_info=True)
+    _record_worker_pids()
     # Do not reset _LAST_SPAWN_TIME here; respawn grace would hide crash storms.
 
 

--- a/tests/test_process_resource_leaks.py
+++ b/tests/test_process_resource_leaks.py
@@ -1,0 +1,126 @@
+"""Regression tests for process/resource leak fixes (PR-C).
+
+Covers:
+  * #9  — reap orphaned worker process groups from a prior server instance.
+  * #4/#6 — respawn closes the old worker queue under the queue lock.
+  * #7  — emergency cleanup joins killed children.
+  * #3  — a cancelled subagent's child drive is removed immediately.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _read(rel: str) -> str:
+    return (REPO / rel).read_text(encoding="utf-8")
+
+
+# ───────────────────────── #3: subagent drive cleanup ───────────────────────
+
+def test_remove_subagent_task_drive(tmp_path):
+    from ouroboros.headless import (
+        HEADLESS_TASKS_DIR,
+        TASK_DRIVES_DIR,
+        remove_subagent_task_drive,
+    )
+
+    tid = "abcd1234"
+    headless_dir = tmp_path / HEADLESS_TASKS_DIR / tid / "data"
+    drive_dir = tmp_path / TASK_DRIVES_DIR / tid / "data"
+    headless_dir.mkdir(parents=True)
+    drive_dir.mkdir(parents=True)
+
+    assert remove_subagent_task_drive(tmp_path, tid) is True
+    assert not (tmp_path / HEADLESS_TASKS_DIR / tid).exists()
+    assert not (tmp_path / TASK_DRIVES_DIR / tid).exists()
+
+    # idempotent / no error when nothing to remove
+    assert remove_subagent_task_drive(tmp_path, tid) is False
+    # invalid task id is rejected, not raised
+    assert remove_subagent_task_drive(tmp_path, "../escape") is False
+
+
+def test_cancel_running_subagent_removes_drive_source():
+    src = _read("supervisor/queue.py")
+    assert "remove_subagent_task_drive(DRIVE_ROOT, str(task_id))" in src
+    assert "delegation_role" in src  # gated on subagent role
+
+
+# ───────────────────────── #9: orphan worker reaping ────────────────────────
+
+def test_reap_orphaned_workers(tmp_path, monkeypatch):
+    import ouroboros.platform_layer as pl
+    from ouroboros.utils import atomic_write_json
+    from supervisor import workers
+
+    monkeypatch.setattr(workers, "DRIVE_ROOT", tmp_path, raising=False)
+    workers.WORKERS.clear()
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "state").mkdir(parents=True, exist_ok=True)
+    atomic_write_json(
+        workers._worker_pids_path(),
+        {"server_pid": 999999, "workers": [{"pid": 111}, {"pid": 222}, {"pid": 333}]},
+    )
+
+    # 111 = alive + ours (own session leader) → must be killed
+    # 222 = dead (empty cmdline) → skipped
+    # 333 = alive but unrelated process (pid reused) → skipped
+    cmds = {111: "python -B -c multiprocessing.spawn", 222: "", 333: "/usr/bin/SomethingElse"}
+    monkeypatch.setattr(pl, "process_command", lambda pid: cmds.get(int(pid), ""))
+    monkeypatch.setattr(pl, "process_group_id", lambda pid: int(pid))  # session leader
+    killed_groups, killed_pids = [], []
+    monkeypatch.setattr(pl, "kill_process_group_id", lambda pgid: killed_groups.append(int(pgid)))
+    monkeypatch.setattr(pl, "force_kill_pid", lambda pid: killed_pids.append(int(pid)))
+
+    n = workers.reap_orphaned_workers()
+
+    assert n == 1
+    assert killed_pids == [111]
+    assert killed_groups == [111]
+
+
+def test_record_worker_pids_roundtrip(tmp_path, monkeypatch):
+    from ouroboros.utils import read_json_dict
+    from supervisor import workers
+
+    monkeypatch.setattr(workers, "DRIVE_ROOT", tmp_path, raising=False)
+    (tmp_path / "state").mkdir(parents=True, exist_ok=True)
+
+    class _FakeProc:
+        def __init__(self, pid):
+            self.pid = pid
+
+    monkeypatch.setattr(
+        workers, "WORKERS",
+        {0: workers.Worker(wid=0, proc=_FakeProc(4242), in_q=None)},
+        raising=False,
+    )
+    workers._record_worker_pids()
+    data = read_json_dict(workers._worker_pids_path()) or {}
+    assert {"pid": 4242} in (data.get("workers") or [])
+
+
+# ───────────────────── #4/#6 + #7: source contracts ─────────────────────────
+
+def test_respawn_closes_old_queue_under_lock():
+    src = _read("supervisor/workers.py")
+    assert "with _queue_lock:" in src
+    assert "old.in_q.close()" in src
+    assert "old.in_q.cancel_join_thread()" in src
+
+
+def test_spawn_reaps_orphans_and_records_pids():
+    src = _read("supervisor/workers.py")
+    assert "reap_orphaned_workers()" in src
+    assert "_record_worker_pids()" in src
+    # reap guards against PID reuse and only group-kills its own setsid session
+    assert "if pgid and pgid == pid:" in src
+
+
+def test_emergency_cleanup_joins_children():
+    src = _read("server.py")
+    # force_kill is followed by a join so the Process object is reaped
+    assert "child.join(timeout=2)" in src


### PR DESCRIPTION
Four process/resource leaks in the worker lifecycle, found by audit and verified against 6.23.0-rc.1.

## #9 — Orphaned worker process groups (memory leak that grows per restart)
Workers run in their own `os.setsid` session, and `kill_workers()` only walks the in-memory `WORKERS` dict. So workers orphaned by an abrupt restart (reparented to init) were **never reaped** and accumulated on every restart (observed ~488 MB of stranded worker interpreters after a few restarts).

**Fix (`supervisor/workers.py`):** persist worker PIDs to `state/worker_pids.json`, and at the start of `spawn_workers` call `reap_orphaned_workers()`. It force-kills survivors from a prior instance — but **only** PIDs that are still alive **and** verifiably ours (`process_command` cmdline contains this interpreter / `multiprocessing`) **and** are their own session leader (`pgid == pid`). This guards against PID reuse and bounds the group kill to the worker's own setsid session. The previously-unused `process_group_id` / `kill_process_group_id` helpers are now wired in.

## #4 / #6 — Respawn leaks the old queue + has an enqueue race
`respawn_worker()` overwrote `WORKERS[wid]` **without** closing the crashed worker's old `multiprocessing.Queue` (FD/semaphore leak) and **without** holding the queue lock — a concurrent `assign_tasks()` could enqueue a task into the stale slot and lose it.

**Fix:** swap `WORKERS[wid]` under `_queue_lock` (an `RLock`, so it's safe even when the caller already holds it) and `close()` + `cancel_join_thread()` the old queue once nothing can route to it.

## #7 — Emergency cleanup leaves zombies
`_emergency_process_cleanup` SIGKILLed each child via `force_kill_pid` but never `join()`ed it, so `Process` objects lingered and `active_children()` stayed non-empty.

**Fix (`server.py`):** `child.join(timeout=2)` after the kill.

## #3 — Cancelled subagent drives orphan for the session
`prune_*_task_drives` only frees a child drive on the **next startup** (and after retention). A subagent cancelled mid-run left its scratch drive under `state/headless_tasks/<id>` or `task_drives/<id>` for the rest of the session.

**Fix:** `cancel_task_by_id` now removes a cancelled **subagent's** child drive immediately via the new `headless.remove_subagent_task_drive()` (safe — a cancelled subagent produced no result to copy back).

## Tests
Adds `tests/test_process_resource_leaks.py`: behavioral coverage for the orphan reaper (kills alive+ours, skips dead, skips PID-reuse), the PID record roundtrip, the subagent-drive removal, and source contracts for the respawn/cleanup changes. Existing worker/queue/headless/supervisor suites stay green (227 passed).

Out of scope (separate handoff): worker spawn-grace crash-storm masking (#5) and post-task daemon-thread tracking (#16/#24/#29) are policy decisions left for the maintainer.