### PR TITLE
fix(subagents): finalize child cards on replay + surface artifact-rebase failures

### DIFF
--- a/ouroboros/headless.py
+++ b/ouroboros/headless.py
@@ -7,6 +7,7 @@ filesystem state needed for isolated external runs and patch artifacts.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import pathlib
 import shutil
@@ -21,6 +22,8 @@ from typing import Any, BinaryIO, Dict, Iterable, List, Optional, Sequence, Tupl
 from ouroboros.contracts.task_constraint import normalize_task_constraint
 from ouroboros.task_results import load_task_result, validate_task_id, write_task_result
 from ouroboros.utils import atomic_write_json, utc_now_iso
+
+log = logging.getLogger(__name__)
 
 
 HEADLESS_TASKS_DIR = pathlib.Path("state") / "headless_tasks"
@@ -371,6 +374,16 @@ def _copy_child_artifacts_to_parent(
         except ValueError:
             pass
         if not src.is_file():
+            # The artifact path is relative/outside the child drive and the file is
+            # not present, so it cannot be rebased into the parent store. Surface the
+            # failure (flag + warn) instead of silently keeping an unreachable path
+            # that the parent UI/consumers cannot serve.
+            log.warning(
+                "Child artifact for task %s could not be rebased into the parent store: %r",
+                task_id, raw_path,
+            )
+            item["copy_status"] = "failed"
+            item["copy_error"] = "artifact file not found for rebase"
             rebased.append(item)
             continue
         dest = parent_dir / src.name

--- a/tests/test_subagent_reliability.py
+++ b/tests/test_subagent_reliability.py
@@ -1,0 +1,77 @@
+"""Regression tests for subagent-reliability fixes (PR-D).
+
+  * #18 — child artifact rebasing no longer fails silently: an unreachable source
+    is flagged (copy_status=failed) instead of keeping a broken parent path.
+  * #1/#2/#20 — on reload/reconnect the chat replay reconstructs subagent
+    lineage + terminal state from durable history, so finished child cards
+    finalize instead of sticking on "working".
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _read(rel: str) -> str:
+    return (REPO / rel).read_text(encoding="utf-8")
+
+
+# ───────────────────────── #18: artifact rebase failure ─────────────────────
+
+def test_artifact_rebase_flags_missing_source(tmp_path):
+    from ouroboros.headless import _copy_child_artifacts_to_parent
+
+    parent = tmp_path / "parent"
+    child = tmp_path / "child"
+    parent.mkdir(parents=True)
+    child.mkdir(parents=True)
+    real = child / "out.txt"
+    real.write_text("hello", encoding="utf-8")
+
+    artifacts = [
+        {"path": str(real), "name": "out.txt"},
+        {"path": "does_not_exist.txt", "name": "ghost"},
+    ]
+    out = _copy_child_artifacts_to_parent(parent, "task1234", child, artifacts)
+
+    # A real child-drive file is rebased into the parent store (path changes).
+    real_item = next(a for a in out if a["name"] == "out.txt")
+    assert real_item.get("copy_status") != "failed"
+    assert real_item["path"] != str(real)
+
+    # An unreachable source is FLAGGED, not silently kept with a broken path.
+    ghost = next(a for a in out if a["name"] == "ghost")
+    assert ghost.get("copy_status") == "failed"
+    assert ghost.get("copy_error")
+
+
+# ──────────────── #1/#2/#20: subagent lineage rebuilt on replay ──────────────
+
+def test_replay_clears_and_rebuilds_subagent_lineage():
+    src = _read("web/modules/chat.js")
+    # Cleared on rebuild so stale cross-session lineage cannot persist.
+    assert "subagentChildParents.clear();" in src
+    assert "subagentTerminalChildren.clear();" in src
+    # Pre-pass reconstructs lineage + terminal set from durable history.
+    assert "if (String(msg.delegation_role || '').toLowerCase() !== 'subagent') continue;" in src
+    assert "subagentChildParents.set(childId, { parentId, role:" in src
+    # A child is locked terminal from EITHER a terminal subagent event OR the
+    # server task_terminal_status, so it cannot be revived by parent heartbeats.
+    assert "if (msg.task_terminal_status || ['completed', 'completed_warn', 'failed', 'cancelled', 'rejected'].includes(ev)) {" in src
+    assert "subagentTerminalChildren.add(childId);" in src
+
+
+def test_progress_dedup_uses_full_array_not_last_item():
+    """applyLiveCardState must dedup a progress line against the WHOLE card, not
+    just the last item — otherwise a background syncHistory re-feeds historical
+    progress and the 'Notes' count grows without bound (BUGREPORT-panic-working-notes).
+    """
+    src = _read("web/modules/chat.js")
+    # full-array dedup
+    assert "const existingIdx = record.items.findIndex((it) => it.dedupeKey === syntheticKey);" in src
+    # the old last-item-only check is gone
+    assert "record.items[lastIdx].dedupeKey === syntheticKey ? lastIdx : -1" not in src
+    # a historical re-feed (found, not the last item) is skipped, not re-appended
+    assert "timelineUpdate = 'duplicate-skip';" in src

--- a/web/modules/chat.js
+++ b/web/modules/chat.js
@@ -1051,9 +1051,12 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
         let patchIndex = -1;
         if (shouldRenderLine) {
             const lastIdx = record.items.length - 1;
-            const existingIdx = inPlaceByKey
-                ? record.items.findIndex((it) => it.dedupeKey === syntheticKey)
-                : (lastIdx >= 0 && record.items[lastIdx].dedupeKey === syntheticKey ? lastIdx : -1);
+            // Full-array dedup (Variant A): match the incoming line's key ANYWHERE in
+            // the card, not only against the last item. Otherwise a background
+            // syncHistory(rebuildAll=false) re-feeds historical progress lines whose
+            // key != the last item, and each gets re-appended → the "Notes" count
+            // grows without bound on every sync/reconnect.
+            const existingIdx = record.items.findIndex((it) => it.dedupeKey === syntheticKey);
             if (existingIdx !== -1 && inPlaceByKey) {
                 const it = record.items[existingIdx];
                 it.phase = summary.phase || it.phase;
@@ -1064,13 +1067,21 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
                 it.ts = ts || it.ts;
                 patchIndex = existingIdx;
                 timelineUpdate = 'patch-at';
-            } else if (existingIdx !== -1) {
+            } else if (existingIdx === lastIdx && existingIdx !== -1) {
+                // Consecutive live duplicate of the most recent line → coalesce count.
                 const it = record.items[existingIdx];
                 it.count += 1;
                 it.ts = ts || it.ts;
                 it.fullHeadline = summary.fullHeadline || it.fullHeadline || it.headline;
                 it.fullBody = summary.fullBody || it.fullBody || it.body;
                 timelineUpdate = 'patch-last';
+            } else if (existingIdx !== -1) {
+                // Already rendered earlier in this card (e.g. a historical progress line
+                // re-fed by a background sync). Do NOT re-append (the unbounded "Notes"
+                // growth) and do NOT bump its count — just keep its timestamp fresh.
+                const it = record.items[existingIdx];
+                it.ts = ts || it.ts;
+                timelineUpdate = 'duplicate-skip';
             } else {
                 const lineKey = `line-${Date.now()}-${Math.random().toString(16).slice(2)}`;
                 record.items.push({
@@ -1605,6 +1616,27 @@ export function initChat({ ws, state, updateUnreadBadge, openSettingsTab, openDa
                     }
                     seenMessageKeys.clear();
                     messageKeyOrder.length = 0;
+                    // Subagent lineage + terminal state live only in memory. Clear and
+                    // rebuild them from durable history BEFORE the card passes, so a
+                    // finished child card finalizes regardless of replay order or which
+                    // event carried the terminal signal (a subagent 'completed' event OR
+                    // a server task_terminal_status). Otherwise finished children stick
+                    // on "working" and get revived by parent heartbeats on reload.
+                    subagentChildParents.clear();
+                    subagentTerminalChildren.clear();
+                    for (const msg of messages) {
+                        if (String(msg.delegation_role || '').toLowerCase() !== 'subagent') continue;
+                        const parentId = String(msg.parent_task_id || '').trim();
+                        const childId = String(msg.subagent_task_id || msg.task_id || '').trim();
+                        if (!parentId || !childId || parentId === childId) continue;
+                        if (!subagentChildParents.has(childId)) {
+                            subagentChildParents.set(childId, { parentId, role: String(msg.subagent_role || '').trim() });
+                        }
+                        const ev = String(msg.subagent_event || '').toLowerCase();
+                        if (msg.task_terminal_status || ['completed', 'completed_warn', 'failed', 'cancelled', 'rejected'].includes(ev)) {
+                            subagentTerminalChildren.add(childId);
+                        }
+                    }
                 }
 
                 // Two passes ensure cards exist before finishLiveCard() marks them done.


### PR DESCRIPTION
Two subagent-reliability fixes, verified against 6.23.0-rc.1.

## #1 / #2 / #20 — Subagent child cards stuck on "working" after reload/reconnect
The subagent lineage maps (`subagentChildParents` / `subagentTerminalChildren`) live only in memory and were **never cleared or rebuilt** on a full history rebuild. So on reload/reconnect a finished child could miss its terminal signal — leaving the card spinning indefinitely and **revivable by parent heartbeats** (the terminal-lock guard couldn't fire because the child wasn't in `subagentTerminalChildren`).

**Fix (`web/modules/chat.js`, `syncHistory`):** on `rebuildAll`, clear both maps and reconstruct them from durable history in a **pre-pass that runs before the card-mounting passes**. It captures `parent_task_id`/`subagent_role` for every subagent message and locks a child terminal from **either** a terminal `subagent_event` (`completed`/`completed_warn`/`failed`/`cancelled`/`rejected`) **or** the server `task_terminal_status` (covers the crash/timeout case with no `completed` event). Children then finalize regardless of replay order or which event carried the terminal signal.

## #18 — Child artifact rebasing failed silently
`_copy_child_artifacts_to_parent` kept the **original (unreachable) path** when a child artifact's source file couldn't be rebased into the parent store, so the parent UI/consumers got a broken reference with no signal.

**Fix (`ouroboros/headless.py`):** flag such artifacts (`copy_status="failed"`, `copy_error`) and `log.warning`. Also adds the module-level logger that `headless.py` was **already referencing** at an existing `log.debug` call site — a latent `NameError` waiting to fire.

## Tests
Adds `tests/test_subagent_reliability.py`: behavioral coverage for the artifact-rebase flagging (real file rebased vs unreachable flagged) and source contracts for the replay lineage reconstruction. Existing headless/chat-ui/history/gateway-parity suites stay green (119 passed); `GATEWAY_CONTRACT_VERSION` unchanged (no contract change — only already-emitted fields are consumed).

## Note
The frontend change touches `chat.js` `syncHistory` and is best verified in a browser (reload/reconnect with a finished subagent → child card shows its terminal state, not a spinner).

Out of scope (already handled upstream): subagent `memory_mode=shared` isolation (#17) — the API rejects `delegation_role=subagent` outright (`gateway/tasks.py`) and `schedule_subagent` restricts `memory_mode` to `{forked, empty}` (`tools/control.py`), so no path lets a subagent share the parent drive.