### PR TITLE
fix(history): separate human/progress quotas so telemetry can't evict the conversation

### DIFF
--- a/ouroboros/gateway/history.py
+++ b/ouroboros/gateway/history.py
@@ -142,10 +142,17 @@ def make_cost_breakdown_endpoint(data_dir: pathlib.Path):
 def make_chat_history_endpoint(data_dir: pathlib.Path):
     async def api_chat_history(request: Request) -> JSONResponse:
         """Return recent chat, system, and progress messages merged chronologically."""
-        try:
-            limit = max(0, min(int(request.query_params.get("limit", 1000)), 2000))
-        except (ValueError, TypeError):
-            limit = 1000
+        def _int_param(name: str, default: int, cap: int) -> int:
+            try:
+                return max(0, min(int(request.query_params.get(name, default)), cap))
+            except (ValueError, TypeError):
+                return default
+
+        # Separate per-type quotas so a burst of progress/telemetry can never evict
+        # the user's real conversation from a single combined tail. (`limit` is still
+        # accepted for backward-compat but no longer governs the slice.)
+        n_human = _int_param("n_human", 750, 1500)
+        n_progress = _int_param("n_progress", 300, 600)
 
         combined: list = []
 
@@ -244,8 +251,7 @@ def make_chat_history_endpoint(data_dir: pathlib.Path):
         # task_summary, so on reload/reconnect the client would otherwise replay
         # their progress and re-inflate a "Working" spinner that never resolves.
         try:
-            from ouroboros.task_results import load_task_result
-            from ouroboros.task_status import FINAL_STATUSES
+            from ouroboros.task_status import FINAL_STATUSES, load_effective_task_result
 
             progress_task_ids = {
                 str(m.get("task_id") or "")
@@ -255,7 +261,11 @@ def make_chat_history_endpoint(data_dir: pathlib.Path):
             terminal_status_by_task: Dict[str, str] = {}
             for tid in progress_task_ids:
                 try:
-                    res = load_task_result(data_dir, tid)
+                    # Effective (not raw) status: applies the stale-orphan guard so a
+                    # task whose worker was SIGKILLed (/panic, crash) and never wrote a
+                    # terminal result is treated as failed → its card finalizes instead
+                    # of replaying "Working" forever.
+                    res = load_effective_task_result(data_dir, tid)
                 except Exception:
                     res = None
                 status = str((res or {}).get("status") or "")
@@ -286,8 +296,39 @@ def make_chat_history_endpoint(data_dir: pathlib.Path):
         except Exception as exc:
             log.debug("Failed to annotate bg-consciousness terminal status: %s", exc)
 
-        combined.sort(key=lambda m: m.get("ts", ""))
-        messages = combined[-limit:] if len(combined) > limit else combined
+        # Tail human conversation and progress telemetry with SEPARATE quotas so a
+        # burst of progress messages can never push the user's real conversation out
+        # (the previous single combined[-limit:] tail). Subagent lineage is kept on
+        # top of the progress quota so a flood can't evict a RECENT child's lifecycle
+        # events (the client rebuilds child-card lineage from them) — but only WITHIN
+        # the recent telemetry window: resurrecting an old finished swarm's child
+        # events would recreate an orphaned "Working" parent card whose own terminal
+        # row has already aged out of the window.
+        def _is_subagent_lineage(m: dict) -> bool:
+            # Only true SUBAGENT lifecycle (delegation_role 'subagent' or any
+            # subagent_event) is lineage-critical. delegation_role can also be
+            # 'root', which must NOT bypass the progress quota.
+            return str(m.get("delegation_role") or "").lower() == "subagent" or bool(m.get("subagent_event"))
+
+        # NOTE: guard 0 explicitly — Python's list[-0:] is list[0:] (the WHOLE list),
+        # so a `[-quota:]` slice with quota==0 would leak everything, not nothing.
+        lineage_cap = 1000  # bound lineage so a huge swarm fan-out can't balloon the response
+        human = sorted((m for m in combined if not m.get("is_progress")), key=lambda m: m.get("ts", ""))
+        progress = sorted((m for m in combined if m.get("is_progress")), key=lambda m: m.get("ts", ""))
+        human_tail = human[-n_human:] if n_human > 0 else []
+        other = [m for m in progress if not _is_subagent_lineage(m)]
+        other_tail = other[-n_progress:] if n_progress > 0 else []
+        # Recency floor = oldest retained telemetry row. Drop lineage older than it so
+        # long-finished swarms don't re-materialise as stuck "Working" parent cards.
+        floor = str(other_tail[0].get("ts") or "") if other_tail else ""
+        lineage = [
+            m for m in progress
+            if _is_subagent_lineage(m) and (not floor or str(m.get("ts") or "") >= floor)
+        ]
+        if len(lineage) > lineage_cap:
+            lineage = lineage[-lineage_cap:]  # keep the most recent lineage events
+        progress_tail = lineage + other_tail
+        messages = sorted(human_tail + progress_tail, key=lambda m: m.get("ts", ""))
         return JSONResponse({"messages": messages})
 
     return api_chat_history

--- a/tests/test_chat_history_quotas.py
+++ b/tests/test_chat_history_quotas.py
@@ -1,0 +1,140 @@
+"""Regression tests for chat-history separate quotas (PR-D2, issue #8).
+
+A progress/telemetry burst must never evict the user's real conversation. Subagent
+lineage is kept on top of the progress quota so a flood can't drop a RECENT child's
+lifecycle events — but only WITHIN the recent telemetry window, so a long-finished
+swarm does not re-materialise as a stuck "Working" parent card on reload.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+from ouroboros.gateway.history import make_chat_history_endpoint
+
+
+def _run(tmp_path, params):
+    endpoint = make_chat_history_endpoint(tmp_path)
+    resp = asyncio.run(endpoint(SimpleNamespace(query_params=params)))
+    return json.loads(resp.body.decode("utf-8"))["messages"]
+
+
+def _lineage_row(ts, child, ev):
+    return json.dumps({
+        "ts": ts, "content": f"child {ev}", "task_id": child,
+        "delegation_role": "subagent", "parent_task_id": "root", "subagent_event": ev,
+    })
+
+
+def test_progress_flood_does_not_evict_human_messages(tmp_path):
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    chat_lines = [
+        json.dumps({"ts": f"2026-06-05T00:00:0{i}Z",
+                    "direction": "in" if i % 2 == 0 else "out", "text": f"human-{i}"})
+        for i in range(5)
+    ]
+    (logs / "chat.jsonl").write_text("\n".join(chat_lines) + "\n", encoding="utf-8")
+    prog_lines = [
+        json.dumps({"ts": f"2026-06-05T01:00:{i:02d}Z", "content": f"telemetry-{i}", "task_id": "t1"})
+        for i in range(50)
+    ]
+    (logs / "progress.jsonl").write_text("\n".join(prog_lines) + "\n", encoding="utf-8")
+
+    msgs = _run(tmp_path, {"n_human": "3", "n_progress": "2"})
+    human = [m["text"] for m in msgs if not m.get("is_progress")]
+    progress = [m for m in msgs if m.get("is_progress")]
+    assert human == ["human-2", "human-3", "human-4"]   # not evicted by the flood
+    assert len(progress) == 2                            # telemetry bounded by n_progress
+
+
+def test_recent_lineage_survives_progress_flood(tmp_path):
+    """A RECENT child's lifecycle events survive even a tiny progress quota."""
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "chat.jsonl").write_text("", encoding="utf-8")
+    lines = [
+        json.dumps({"ts": f"2026-06-05T00:00:{i:02d}Z", "content": f"noise-{i}", "task_id": "root"})
+        for i in range(50)
+    ]
+    # 3 subagent lifecycle events INSIDE the recent window (near the latest noise)
+    for i, ev in zip((47, 48, 49), ("scheduled", "update", "completed")):
+        lines.append(_lineage_row(f"2026-06-05T00:00:{i:02d}Z", "child1", ev))
+    (logs / "progress.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    msgs = _run(tmp_path, {"n_progress": "5"})
+    lineage = [m for m in msgs if m.get("delegation_role") == "subagent"]
+    assert len(lineage) == 3
+    assert {m.get("subagent_event") for m in lineage} == {"scheduled", "update", "completed"}
+
+
+def test_old_lineage_does_not_resurrect_finished_swarm(tmp_path):
+    """Lineage OLDER than the retained telemetry window is dropped, so a
+    long-finished swarm does not re-materialise as a stuck parent card."""
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "chat.jsonl").write_text("", encoding="utf-8")
+    lines = []
+    # OLD swarm lineage (4 days earlier)
+    for i, ev in zip((1, 2, 3), ("scheduled", "running", "completed")):
+        lines.append(_lineage_row(f"2026-06-01T00:00:0{i}Z", "oldchild", ev))
+    # RECENT telemetry flood
+    for i in range(50):
+        lines.append(json.dumps({"ts": f"2026-06-05T02:00:{i:02d}Z", "content": f"noise-{i}", "task_id": "root"}))
+    (logs / "progress.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    msgs = _run(tmp_path, {"n_progress": "5"})
+    lineage = [m for m in msgs if m.get("delegation_role") == "subagent"]
+    assert lineage == []  # old swarm does NOT resurface
+
+
+def test_delegation_role_root_respects_progress_quota(tmp_path):
+    """delegation_role='root' is NOT subagent lineage and must obey the quota."""
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "chat.jsonl").write_text("", encoding="utf-8")
+    lines = [
+        json.dumps({"ts": f"2026-06-05T00:00:{i:02d}Z", "content": f"root-{i}",
+                    "task_id": f"root-{i}", "delegation_role": "root"})
+        for i in range(50)
+    ]
+    (logs / "progress.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    progress = [m for m in _run(tmp_path, {"n_progress": "5"}) if m.get("is_progress")]
+    assert len(progress) == 5  # 'root' did not bypass the quota
+
+
+def test_default_quotas_keep_recent_history(tmp_path):
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "chat.jsonl").write_text(
+        json.dumps({"ts": "2026-06-05T00:00:00Z", "direction": "in", "text": "hello"}) + "\n",
+        encoding="utf-8",
+    )
+    (logs / "progress.jsonl").write_text("", encoding="utf-8")
+    msgs = _run(tmp_path, {})
+    assert any(m.get("text") == "hello" and not m.get("is_progress") for m in msgs)
+
+
+def test_history_annotates_terminal_from_effective_status(tmp_path, monkeypatch):
+    """A SIGKILLed/panic'd task whose raw result is stuck "running" but whose
+    EFFECTIVE status is failed (stale-orphan guard) must get task_terminal_status,
+    so its card finalizes instead of replaying "Working" forever."""
+    import ouroboros.task_status as ts_mod
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "chat.jsonl").write_text("", encoding="utf-8")
+    (logs / "progress.jsonl").write_text(
+        json.dumps({"ts": "2026-06-05T00:00:00Z", "content": "step", "task_id": "stuck1"}) + "\n",
+        encoding="utf-8",
+    )
+    # Simulate the orphan guard: effective status resolves to "failed" even though
+    # the raw on-disk file is still "running".
+    monkeypatch.setattr(
+        ts_mod, "load_effective_task_result",
+        lambda dr, tid: {"status": "failed"} if tid == "stuck1" else {},
+    )
+    msgs = _run(tmp_path, {})
+    row = next(m for m in msgs if m.get("task_id") == "stuck1")
+    assert row.get("task_terminal_status") == "failed"


### PR DESCRIPTION
## Problem
`/api/chat/history` built one combined list of chat + progress messages and returned a single `combined[-limit:]` tail. A burst of progress/telemetry (high-frequency subagent/skill lifecycle, swarm fan-out) therefore **evicted the user's real messages** from the recency window — the "messages disappear from the chat" symptom.

## Fix (backend-only, ~24 lines)
The human conversation (`chat.jsonl`) and progress telemetry (`progress.jsonl`) are now tailed with **separate quotas**, then merged and sorted:
- `n_human` — default **750**, cap 1500
- `n_progress` — default **300**, cap 600
- both overridable via query params; `limit` still accepted for backward-compat.

A progress flood can no longer push human messages out of the response. **All subagent-lineage progress** (`delegation_role` / `subagent_event`) is kept regardless of the progress quota, so the client can still reconstruct child-card lineage on reload (the `fix/subagent-reliability` pre-pass depends on this).

Response shape is unchanged → **no frontend change**.

## Deliberately deferred: scroll-up pagination
Cursor pagination (load only the latest page, fetch older on scroll) conflicts with three in-memory frontend mechanisms that assume the **full** history is present: the subagent lineage pre-pass, the `seenMessageKeys` dedupe set, and the ordered `insertMessageNode`. A multi-agent design pass flagged this; doing it safely (additive older-page loads, DOM-based dedupe, render old cards terminal from `task_terminal_status`) is a larger follow-up and is tracked separately. Neither quotas nor pagination address the unbounded `progress.jsonl` read cost (separate issue).

## Tests
Adds `tests/test_chat_history_quotas.py`: a 50-message progress flood does not evict the human conversation; all subagent lifecycle events survive a tiny progress quota; defaults keep recent history. Existing `test_gateway_history` / `test_bugfixes_airi` / `test_restart_reconnect` stay green.