### PR TITLE
fix(gateway): reap idle keys from host-service rate limiter to bound memory

### DIFF
--- a/ouroboros/gateway/host_service.py
+++ b/ouroboros/gateway/host_service.py
@@ -47,10 +47,31 @@ class _RateLimiter:
         self.window_sec = window_sec
         self._hits: Dict[str, Deque[float]] = defaultdict(deque)
         self._lock = threading.Lock()
+        self._last_sweep = time.monotonic()
+
+    def _sweep(self, now: float) -> None:
+        # Drop keys idle past the window so _hits does not grow unbounded as
+        # distinct skill keys ({skill}:{endpoint}) churn over the process
+        # lifetime. Must pop each key's stale timestamps FIRST, then delete the
+        # ones left empty (an idle key still holds stale, un-popped entries).
+        # Collect-then-delete avoids mutating the dict during iteration.
+        # Caller holds self._lock.
+        stale = []
+        for key, hits in self._hits.items():
+            while hits and now - hits[0] > self.window_sec:
+                hits.popleft()
+            if not hits:
+                stale.append(key)
+        for key in stale:
+            del self._hits[key]
 
     def allow(self, key: str) -> bool:
         now = time.monotonic()
         with self._lock:
+            # Amortized cleanup: at most once per window, under the existing lock.
+            if now - self._last_sweep > self.window_sec:
+                self._sweep(now)
+                self._last_sweep = now
             hits = self._hits[key]
             while hits and now - hits[0] > self.window_sec:
                 hits.popleft()

--- a/tests/test_host_service_rate_limiter.py
+++ b/tests/test_host_service_rate_limiter.py
@@ -1,0 +1,59 @@
+"""Regression tests for the host-service rate limiter (#27/#30).
+
+The `_RateLimiter._hits` defaultdict previously grew unbounded: keys (one per
+`{skill}:{endpoint}`) were never deleted, only their stale timestamps popped. A
+periodic sweep now frees keys that have gone idle past the window, without
+changing any rate-limit decision.
+"""
+
+from __future__ import annotations
+
+import time
+
+from ouroboros.gateway.host_service import _RateLimiter
+
+
+def test_sweep_frees_idle_keys():
+    rl = _RateLimiter(limit=10, window_sec=0.01)
+    for i in range(5):
+        assert rl.allow(f"k{i}") is True
+    assert len(rl._hits) == 5
+
+    # Sweep with a timestamp well past the window → every key is now idle/empty.
+    rl._sweep(time.monotonic() + 1.0)
+    assert len(rl._hits) == 0
+
+
+def test_allow_triggers_amortized_sweep():
+    rl = _RateLimiter(limit=10, window_sec=0.01)
+    for i in range(5):
+        rl.allow(f"k{i}")
+    assert len(rl._hits) == 5
+
+    # Make the existing keys stale and mark a sweep overdue, then a single allow()
+    # must reclaim the idle keys (only the new key remains).
+    rl._last_sweep = time.monotonic() - 100
+    time.sleep(0.02)  # > window_sec, so k0..k4 timestamps are stale
+    assert rl.allow("fresh") is True
+    assert set(rl._hits.keys()) == {"fresh"}
+
+
+def test_rate_limit_decisions_unchanged():
+    rl = _RateLimiter(limit=3, window_sec=60.0)
+    assert rl.allow("k") is True
+    assert rl.allow("k") is True
+    assert rl.allow("k") is True
+    assert rl.allow("k") is False  # 4th hit within the window is blocked
+    # A different key has its own independent budget.
+    assert rl.allow("other") is True
+
+
+def test_swept_key_is_recreated_cleanly():
+    rl = _RateLimiter(limit=2, window_sec=0.01)
+    rl.allow("k")
+    rl._sweep(time.monotonic() + 1.0)
+    assert "k" not in rl._hits
+    # Re-using a swept key works (defaultdict recreates it); budget is fresh.
+    assert rl.allow("k") is True
+    assert rl.allow("k") is True
+    assert rl.allow("k") is False


### PR DESCRIPTION
## Problem (#27/#30)
`_RateLimiter._hits` in `ouroboros/gateway/host_service.py` is a `defaultdict(deque)` keyed by `f"{skill}:{endpoint}"` (`tools`/`inject`/`ws`). `allow()` pops stale timestamps but **never deletes the key**, so every distinct key ever seen stays for the whole process lifetime — a slow **unbounded** memory leak as skills churn over a long-running session. A lazy `if not hits: del self._hits[key]` inside `allow()` can't fix it because `allow()` always `append`s before returning, so the current key's deque is never empty at return.

## Fix (~21 lines, behavior-preserving)
`allow()` now runs an **amortized sweep at most once per window**, under the existing lock:
- `_sweep(now)` pops each key's stale timestamps and deletes the ones left **empty** — note it must pop stale **first** (an idle key still holds stale, un-popped entries), then delete. Collect-then-delete avoids mutating the dict during iteration.
- Triggered from `allow()` only when `now - _last_sweep > window_sec`, so the O(keys) pass runs ≤ once per window and stays under `self._lock` (no new thread).

Rate-limit **decisions are identical** — only idle keys' memory is reclaimed. Memory goes from O(keys ever seen) to O(keys active in the last window).

## Scope
Only `_hits`. The sibling `_inflight` `defaultdict(int)` has the same never-deleted-key pattern but is intentionally **left out** of this change.

## Tests
Adds `tests/test_host_service_rate_limiter.py`: the sweep frees idle keys; a single `allow()` triggers the amortized sweep once overdue; rate-limit decisions (limit, per-key budgets) are unchanged; a swept key is recreated cleanly on reuse. Existing host-service/marketplace suites stay green.