### PR TITLE
fix(supervisor): atomic update_state (+toggle ImportError), visible event failures, temp sweep

### DIFF
--- a/ouroboros/utils.py
+++ b/ouroboros/utils.py
@@ -114,6 +114,38 @@ def atomic_write_json(
         raise
 
 
+def sweep_stale_temp_files(root: pathlib.Path, *, min_age_sec: float = 3600.0) -> int:
+    """Remove orphaned atomic-write temp files left behind by a hard kill.
+
+    ``atomic_write_json`` writes to a unique ``.{name}.tmp.<pid>.<tid>.<uuid>``
+    sibling then ``os.replace``s it into place; a SIGKILL between create and
+    rename can orphan the temp file (its try/finally cleanup never runs). This
+    sweeps the tree for such temp files older than ``min_age_sec`` — the age
+    guard avoids deleting a temp file from an in-flight write in another process.
+    Returns the number removed. Best-effort: never raises.
+    """
+    root = pathlib.Path(root)
+    if not root.is_dir():
+        return 0
+    removed = 0
+    now = time.time()
+    try:
+        candidates = list(root.rglob(".*.tmp.*"))
+    except OSError:
+        return 0
+    for tmp in candidates:
+        try:
+            if not tmp.is_file():
+                continue
+            if now - tmp.stat().st_mtime < min_age_sec:
+                continue
+            tmp.unlink()
+            removed += 1
+        except OSError:
+            continue
+    return removed
+
+
 def read_json_dict(path: pathlib.Path) -> Optional[Dict[str, Any]]:
     """Return a JSON object from ``path`` or ``None`` when absent/invalid."""
     path = pathlib.Path(path)

--- a/ouroboros/utils.py
+++ b/ouroboros/utils.py
@@ -123,10 +123,15 @@ def sweep_stale_temp_files(root: pathlib.Path, *, min_age_sec: float = 3600.0) -
     sweeps the tree for such temp files older than ``min_age_sec`` — the age
     guard avoids deleting a temp file from an in-flight write in another process.
     Returns the number removed. Best-effort: never raises.
+
+    Only files whose suffix after the final ``.tmp.`` is the atomic signature
+    (pid/tid/uuid → hex digits and dots) are reaped, so a legitimate user dotfile
+    such as ``.config.tmp.backup`` is never deleted.
     """
     root = pathlib.Path(root)
     if not root.is_dir():
         return 0
+    hex_chars = set("0123456789abcdef.")
     removed = 0
     now = time.time()
     try:
@@ -136,6 +141,11 @@ def sweep_stale_temp_files(root: pathlib.Path, *, min_age_sec: float = 3600.0) -
     for tmp in candidates:
         try:
             if not tmp.is_file():
+                continue
+            # Require the post-".tmp." suffix to be the atomic signature (hex/dot
+            # only) so we never delete an unrelated dotfile that happens to match.
+            suffix = tmp.name.rsplit(".tmp.", 1)
+            if len(suffix) != 2 or not suffix[1] or set(suffix[1]) - hex_chars:
                 continue
             if now - tmp.stat().st_mtime < min_age_sec:
                 continue

--- a/server.py
+++ b/server.py
@@ -564,9 +564,12 @@ def _run_supervisor(settings: dict) -> None:
         persist_queue_snapshot(reason="startup")
         try:
             from ouroboros.headless import prune_headless_task_drives, prune_task_drives
+            from ouroboros.utils import sweep_stale_temp_files
 
             prune_report = prune_headless_task_drives(DATA_DIR)
             task_drive_report = prune_task_drives(DATA_DIR)
+            # Reap orphaned atomic-write temp files (.*.tmp.*) left by a hard kill.
+            sweep_stale_temp_files(DATA_DIR)
             if (
                 prune_report.get("pruned")
                 or prune_report.get("errors")

--- a/supervisor/events.py
+++ b/supervisor/events.py
@@ -707,7 +707,9 @@ def _handle_task_done(evt: Dict[str, Any], ctx: Any) -> None:
     try:
         ctx.bridge.push_log(task_done_event)
     except Exception:
-        log.debug("Failed to forward task_done to live logs", exc_info=True)
+        # Visible at WARNING: if this terminal-event forward fails, the task's
+        # live card may never finalize, so it must not be silently swallowed.
+        log.warning("Failed to forward task_done to live logs (card may not finalize)", exc_info=True)
 
     try:
         from pathlib import Path
@@ -1733,6 +1735,7 @@ def dispatch_event(evt: Dict[str, Any], ctx: Any) -> None:
 
     handler = EVENT_HANDLERS.get(event_type)
     if handler is None:
+        log.warning("No handler for worker event type %r — event dropped", event_type)
         ctx.append_jsonl(
             ctx.DRIVE_ROOT / "logs" / "supervisor.jsonl",
             {
@@ -1747,6 +1750,10 @@ def dispatch_event(evt: Dict[str, Any], ctx: Any) -> None:
     try:
         handler(evt, ctx)
     except Exception as e:
+        # Surface the failure with a full traceback. Previously this only wrote a
+        # repr(e) to supervisor.jsonl, so a crashing handler (e.g. an ImportError
+        # in a task_done/heartbeat handler) was invisible and left the UI stuck.
+        log.warning("Worker event handler %r failed: %s", event_type, e, exc_info=True)
         ctx.append_jsonl(
             ctx.DRIVE_ROOT / "logs" / "supervisor.jsonl",
             {

--- a/supervisor/state.py
+++ b/supervisor/state.py
@@ -156,6 +156,30 @@ def save_state(st: Dict[str, Any]) -> None:
         release_file_lock(STATE_LOCK_PATH, lock_fd)
 
 
+def update_state(mutator) -> Dict[str, Any]:
+    """Atomically read-modify-write state under a single held lock.
+
+    Loads the current state, applies ``mutator(st)`` in place, and persists the
+    result while holding STATE_LOCK for the WHOLE operation, so concurrent
+    updates cannot lose each other (load and save are one critical section — the
+    racy ``st = load_state(); st[...] = ...; save_state(st)`` pattern drops the
+    other writer's change). Returns the saved state.
+
+    This is also the canonical home of ``update_state`` that
+    ``supervisor.events`` imports — it previously lived only in
+    ``ouroboros.review_state``, so ``from supervisor.state import update_state``
+    raised ImportError (e.g. toggling background consciousness via tool).
+    """
+    lock_fd = acquire_file_lock(STATE_LOCK_PATH)
+    try:
+        st = _load_state_unlocked()
+        mutator(st)
+        _save_state_unlocked(st)
+        return st
+    finally:
+        release_file_lock(STATE_LOCK_PATH, lock_fd)
+
+
 def init_state() -> Dict[str, Any]:
     """Initialize session snapshots for budget drift detection."""
     lock_fd = acquire_file_lock(STATE_LOCK_PATH)

--- a/supervisor/state.py
+++ b/supervisor/state.py
@@ -169,6 +169,9 @@ def update_state(mutator) -> Dict[str, Any]:
     ``supervisor.events`` imports — it previously lived only in
     ``ouroboros.review_state``, so ``from supervisor.state import update_state``
     raised ImportError (e.g. toggling background consciousness via tool).
+
+    ``mutator`` must NOT call ``load_state``/``save_state``/``update_state`` itself:
+    STATE_LOCK is not re-entrant within a process, so re-entering would block.
     """
     lock_fd = acquire_file_lock(STATE_LOCK_PATH)
     try:

--- a/tests/test_event_state_visibility.py
+++ b/tests/test_event_state_visibility.py
@@ -1,0 +1,95 @@
+"""Regression tests for PR-A: event/state robustness + temp cleanup.
+
+  * #10/#13 — supervisor.state.update_state exists (toggle-consciousness import no
+    longer crashes) and is an ATOMIC read-modify-write under a single lock.
+  * #12     — dispatch_event surfaces handler exceptions / unknown events at
+    WARNING (with traceback) instead of silently burying them.
+  * #32     — sweep_stale_temp_files reaps orphaned atomic-write temp files.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from types import SimpleNamespace
+
+
+# ───────────────────────── #10 / #13: atomic update_state ────────────────────
+
+def test_update_state_is_exported_and_atomic(tmp_path):
+    # The exact import that crashed toggling background consciousness (#10).
+    from supervisor.state import update_state  # noqa: F401
+    from supervisor import state
+
+    state.init(tmp_path)
+    (tmp_path / "state").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "locks").mkdir(parents=True, exist_ok=True)
+
+    out = state.update_state(lambda st: st.__setitem__("bg_consciousness_enabled", True))
+    assert out.get("bg_consciousness_enabled") is True
+    assert state.load_state().get("bg_consciousness_enabled") is True
+
+    # A second RMW preserves the first write (load+mutate+save is one critical
+    # section, so updates can't clobber each other).
+    state.update_state(lambda st: st.__setitem__("marker", 42))
+    reloaded = state.load_state()
+    assert reloaded.get("bg_consciousness_enabled") is True
+    assert reloaded.get("marker") == 42
+
+
+# ───────────────────────── #12: handler-failure visibility ───────────────────
+
+def test_dispatch_event_logs_handler_exception(tmp_path, caplog):
+    from supervisor import events
+
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+
+    def _boom(evt, ctx):
+        raise RuntimeError("kaboom")
+
+    events.EVENT_HANDLERS["__test_boom__"] = _boom
+    try:
+        ctx = SimpleNamespace(DRIVE_ROOT=tmp_path, append_jsonl=lambda p, o: None)
+        with caplog.at_level(logging.WARNING, logger="supervisor.events"):
+            events.dispatch_event({"type": "__test_boom__"}, ctx)
+        msgs = " ".join(r.getMessage() for r in caplog.records)
+        assert "__test_boom__" in msgs and "kaboom" in msgs
+    finally:
+        events.EVENT_HANDLERS.pop("__test_boom__", None)
+
+
+def test_dispatch_event_logs_unknown_event(tmp_path, caplog):
+    from supervisor import events
+
+    ctx = SimpleNamespace(DRIVE_ROOT=tmp_path, append_jsonl=lambda p, o: None)
+    with caplog.at_level(logging.WARNING, logger="supervisor.events"):
+        events.dispatch_event({"type": "__never_registered_handler__"}, ctx)
+    assert any("__never_registered_handler__" in r.getMessage() for r in caplog.records)
+
+
+# ───────────────────────── #32: stale temp sweep ─────────────────────────────
+
+def test_sweep_stale_temp_files(tmp_path):
+    from ouroboros.utils import sweep_stale_temp_files
+
+    sub = tmp_path / "state"
+    sub.mkdir()
+    old = sub / ".state.json.tmp.123.456.abcd1234"
+    old.write_text("x", encoding="utf-8")
+    fresh = sub / ".other.json.tmp.999.111.deadbeef"
+    fresh.write_text("y", encoding="utf-8")
+    real = sub / "state.json"
+    real.write_text("real", encoding="utf-8")
+
+    aged = time.time() - 7200
+    os.utime(old, (aged, aged))
+
+    removed = sweep_stale_temp_files(tmp_path, min_age_sec=3600)
+    assert removed == 1
+    assert not old.exists()      # stale temp reaped
+    assert fresh.exists()        # too young — kept (may be an in-flight write)
+    assert real.exists()         # not a temp file — untouched
+
+    # missing dir is a no-op, never raises
+    assert sweep_stale_temp_files(tmp_path / "does-not-exist") == 0

--- a/tests/test_event_state_visibility.py
+++ b/tests/test_event_state_visibility.py
@@ -81,15 +81,21 @@ def test_sweep_stale_temp_files(tmp_path):
     fresh.write_text("y", encoding="utf-8")
     real = sub / "state.json"
     real.write_text("real", encoding="utf-8")
+    # A legitimate user dotfile that merely contains ".tmp." — must NOT be deleted
+    # even when old (its suffix "backup" is not the atomic hex/dot signature).
+    userfile = sub / ".config.tmp.backup"
+    userfile.write_text("keep me", encoding="utf-8")
 
     aged = time.time() - 7200
     os.utime(old, (aged, aged))
+    os.utime(userfile, (aged, aged))
 
     removed = sweep_stale_temp_files(tmp_path, min_age_sec=3600)
     assert removed == 1
-    assert not old.exists()      # stale temp reaped
+    assert not old.exists()      # stale atomic temp reaped
     assert fresh.exists()        # too young — kept (may be an in-flight write)
     assert real.exists()         # not a temp file — untouched
+    assert userfile.exists()     # non-atomic-signature dotfile — never deleted
 
     # missing dir is a no-op, never raises
     assert sweep_stale_temp_files(tmp_path / "does-not-exist") == 0


### PR DESCRIPTION
Four robustness fixes in the supervisor event/state path, verified against 6.23.0-rc.1.

## #10 + #13 — toggle-consciousness ImportError + non-atomic state RMW
`_handle_toggle_consciousness` does `from supervisor.state import update_state`, but `update_state` lived **only** in `ouroboros.review_state` → **ImportError every time** background consciousness is toggled via tool.

Added `update_state(mutator)` to `supervisor/state.py` as an **atomic** read-modify-write: it loads, applies the mutator in place, and saves while holding `STATE_LOCK` for the whole operation. This fixes the crash (#10) **and** the non-atomic `st = load_state(); st[...] = ...; save_state(st)` pattern (#13), where two concurrent writers could lose each other's change.

## #12 (+#11) — swallowed event-handler failures
`dispatch_event` caught handler exceptions and wrote only a bare `repr(e)` to `supervisor.jsonl` — **no traceback, no log level**. A crashing handler (e.g. the ImportError above, or any `task_done`/heartbeat handler) was invisible and could leave a card stuck. It now `log.warning(..., exc_info=True)` on a handler exception and warns on an unknown event type.

Relatedly (#11), a failed `task_done` `push_log` is now logged at **WARNING** instead of `debug` — if that terminal-event forward fails the live card may never finalize, so it must be visible.

## #32 — orphaned atomic-write temp files
`atomic_write_json` can leave a `.{name}.tmp.<pid>.<tid>.<uuid>` file if SIGKILLed between create and `os.replace`. Added `utils.sweep_stale_temp_files(root, min_age_sec=3600)` and call it from the existing startup prune block in `server.py`. The age guard avoids deleting a temp file from an in-flight write in another process.

## Dropped from this PR: #22 (current_sha)
`current_sha` is already refreshed in the HEAD-changing `git_ops` paths (`checkout_and_reset`, `refresh_repo_state`, `rollback`), so the original "not updated after git operations" concern does not reproduce on 6.23 without a concrete repro. Left out rather than fix a non-bug.

## Tests
Adds `tests/test_event_state_visibility.py`: `update_state` is exported and atomic (sequential RMW preserves both writes); `dispatch_event` logs handler exceptions and unknown events at WARNING; `sweep_stale_temp_files` reaps stale temps but keeps fresh ones and non-temp files. Existing state/events/supervisor suites stay green.