### PR TITLE
fix(llm-budget): lengthen LLM retry backoff (2**attempt*4, capped 30s)

### DIFF
--- a/ouroboros/loop_llm_call.py
+++ b/ouroboros/loop_llm_call.py
@@ -669,6 +669,6 @@ def call_llm_with_retry(
             ):
                 break
             if attempt < max_retries - 1:
-                time.sleep(min(2 ** attempt * 2, 30))
+                time.sleep(min(2 ** attempt * 4, 30))
 
     return None, 0.0

--- a/tests/test_llm_budget.py
+++ b/tests/test_llm_budget.py
@@ -1,0 +1,19 @@
+"""Regression test for PR-B: retry backoff (#15).
+
+(#14 — not billing provider-glitch empties — was moved to CONSULT-BUGS.md: doing
+it correctly requires deciding whether the durable usage SSOT in events.jsonl
+should exclude finish_reason=null responses, a provider-billing semantics call
+left to the maintainer.)
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+
+
+def test_backoff_doubled_with_cap():
+    src = (REPO / "ouroboros" / "loop_llm_call.py").read_text(encoding="utf-8")
+    assert "min(2 ** attempt * 4, 30)" in src      # doubled per-attempt backoff
+    assert "min(2 ** attempt * 2, 30)" not in src  # old value gone


### PR DESCRIPTION
## #15 — retry backoff
The per-attempt backoff after a non-retryable/empty failure was `time.sleep(min(2 ** attempt * 2, 30))`. Doubled to `min(2 ** attempt * 4, 30)` so attempts space out more under provider pressure; the 30s cap is unchanged so a worker is never blocked for minutes.

## #14 split out to a maintainer decision
The original PR-B also reversed cost for provider-glitch (`finish_reason=null`) empty responses. A review found that only corrected the in-memory `accumulated_usage`, while `emit_llm_usage_event` still writes the cost to `events.jsonl` — which is the budget SSOT (global `spent_usd` is summed from it, and `reconstruct_task_cost` re-derives per-task cost from it on cancel/timeout/crash). Making it consistent requires deciding whether `finish_reason=null` responses are billed by the provider at all — a budget-semantics call left to the maintainer (tracked in the repo's bug handoff, alongside the finish_reason classification question). So this PR is scoped to the safe backoff change only.

## Tests
`tests/test_llm_budget.py` asserts the backoff is `2**attempt*4` capped at 30.