### PR TITLE
fix(colab): default workers to spawn — fork deadlocks on the import lock

### DIFF
--- a/ouroboros/colab_bootstrap.py
+++ b/ouroboros/colab_bootstrap.py
@@ -126,7 +126,12 @@ def write_colab_settings(data_dir: pathlib.Path, settings: Dict[str, Any]) -> pa
 
 
 def export_colab_env(repo_dir: pathlib.Path, data_dir: pathlib.Path, settings_path: pathlib.Path) -> Dict[str, str]:
-    env = {"OUROBOROS_APP_ROOT": str(pathlib.Path(data_dir).parent), "OUROBOROS_REPO_DIR": str(repo_dir), "OUROBOROS_DATA_DIR": str(data_dir), "OUROBOROS_SETTINGS_PATH": str(settings_path), "OUROBOROS_WORKER_START_METHOD": "fork", "PYTHONUNBUFFERED": "1", "PYTHONPATH": str(repo_dir)}
+    # Colab forks workers from the long-lived, multi-threaded supervisor; a forked
+    # child can deadlock on the CPython import lock the first time it lazily imports
+    # the OpenAI client (llm._make_no_proxy_client). spawn is the safe start method
+    # for fork-from-threads, so default to it here and respect an explicit override.
+    start_method = (os.environ.get("OUROBOROS_WORKER_START_METHOD") or "spawn").strip().lower()
+    env = {"OUROBOROS_APP_ROOT": str(pathlib.Path(data_dir).parent), "OUROBOROS_REPO_DIR": str(repo_dir), "OUROBOROS_DATA_DIR": str(data_dir), "OUROBOROS_SETTINGS_PATH": str(settings_path), "OUROBOROS_WORKER_START_METHOD": start_method, "PYTHONUNBUFFERED": "1", "PYTHONPATH": str(repo_dir)}
     os.environ.update(env)
     return env
 


### PR DESCRIPTION
## Problem
On the Colab path, `export_colab_env` (`ouroboros/colab_bootstrap.py`) hardcodes
`OUROBOROS_WORKER_START_METHOD="fork"` and `os.environ.update()`s it over any user value.

Workers are then forked from the long-lived, multi-threaded supervisor (uvicorn + telegram
poller + queue feeders). A forked child intermittently **deadlocks on the CPython 3.12 import
lock** the first time it lazily runs `from openai import OpenAI` inside
`llm._make_no_proxy_client`: if a parent thread held a module lock at `fork()`, the child
inherits it with a now-dead owner and blocks forever in `importlib._bootstrap` (the 3.12
per-module deadlock detector does not fire for a dead *holder*).

Symptom: a worker stuck `running` with zero progress, `spent=0`, no LLM calls; the supervisor
hard-timeout kills + retries it (self-heals but wastes a cycle). Reproduced live (py-spy: top
frame `acquire` in `importlib._bootstrap` under `_make_no_proxy_client`) and confirmed against
CPython 3.12 source. This is why it bites on Colab/Linux but not macOS/Windows (which already
default to spawn for this exact fork-from-threads reason — see `supervisor/workers.py`).

## Fix
Default the Colab worker start method to `spawn` (safe for fork-from-threads) while
**respecting an explicit `OUROBOROS_WORKER_START_METHOD` override**. One file, Colab-only
(`export_colab_env` is referenced solely from `notebooks/colab_quickstart.py`); the non-Colab
default in `supervisor/workers.py` is untouched. The value is planted in `os.environ` before
the server launches and is inherited through the self-restart re-exec.

## Deeper fixes (not in this PR)
- Default `spawn` on Linux in `supervisor/workers.py` too (broader change).
- Eagerly import `openai`/`httpx` in the parent before starting background threads to close
  the supervisor's own race window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)