### PR TITLE
fix: handle null origin in srcdoc iframe postMessage

### DIFF
--- a/web/modules/onboarding_wizard.js
+++ b/web/modules/onboarding_wizard.js
@@ -1147,11 +1147,14 @@
             });
             // Target our own origin explicitly (paired with the receiver's
             // origin check) instead of broadcasting to any embedding page.
+            const _targetOrigin = window.location.origin === 'null'
+                ? (window.parent?.location?.origin ?? '*')
+                : window.location.origin;
             window.parent?.postMessage({
                 type: 'ouroboros:onboarding-complete',
                 restart_required: Boolean(runtimeResult?.restart_required),
                 runtime_mode: runtimeResult?.runtime_mode || runtimeMode,
-            }, window.location.origin);
+            }, _targetOrigin);
             if (!window.parent || window.parent === window) {
                 window.location.replace('/');
             }


### PR DESCRIPTION
## Problem                                                                   
                                                                               
  During onboarding, the wizard runs inside an iframe created with `srcdoc`.   
  Because `window.location.href` is `about:srcdoc`, the browser computes       
  `window.location.origin` as the string `"null"`. Passing that string to      
  `window.parent.postMessage(data, "null")` throws:                            
                                                                               
  > Failed to execute 'postMessage' on 'Window': Invalid target origin 'null'  
                                                                               
  This prevents the onboarding completion signal from reaching the parent      
  window.                                                                      
                                                                               
  ## Root cause                                                                
                                                                               
  `onboarding_wizard.js:1154` unconditionally uses `window.location.origin` as 
  the `postMessage` target origin. This is correct in a normal page context but
  breaks inside any `srcdoc` iframe.                                           
                                                                               
  ## Fix                                                                       
                                                                               
  Before calling `postMessage`, check whether the current origin is `"null"`.  
  If so, use `window.parent.location.origin` as the target (accessible because 
  the iframe has `allow-same-origin`). Fall back to `"*"` only if the parent   
  origin is also unavailable.                                                  
                                                                            
<img width="1112" height="742" alt="image" src="https://github.com/user-attachments/assets/57b2975e-10be-46eb-a3ae-7ee18b1a9d7a" />
