### PR TITLE
feat: support MiniMax Anthropic-compatible endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Settings now exposes tabbed provider cards for:
 - **OpenAI Compatible** — any custom OpenAI-style endpoint (use `openai-compatible::...`)
 - **Cloud.ru Foundation Models** — Cloud.ru OpenAI-compatible runtime (use `cloudru::...`)
 - **GigaChat** — Sber GigaChat via the `gigachat` library, OAuth key or user/password (use `gigachat::GigaChat-3-Ultra`, etc.)
-- **Anthropic** — direct runtime routing (`anthropic::claude-opus-4.8`, etc.) plus Claude Agent SDK tools
+- **Anthropic** — direct runtime routing (`anthropic::claude-opus-4.8`, etc.) plus Claude Agent SDK tools; Anthropic-compatible providers such as MiniMax Token Plan can use an Anthropic Base URL override with `anthropic::MiniMax-M3`
 
 If OpenRouter is not configured and only official OpenAI is present, untouched default model values are auto-remapped to `openai::gpt-5.5` / `openai::gpt-5.5-mini` so the first-run path does not strand the app on OpenRouter-only defaults.
 
@@ -217,6 +217,8 @@ The Settings page also includes:
 - optional `/api/model-catalog` lookup for configured providers
 - centralized Secrets storage for API keys, bridge tokens, passwords, and future skill-requested keys
 - a refactored desktop-first tabbed UI with searchable model pickers, segmented effort controls, task-result review mode, masked-secret toggles, explicit `Clear` actions, and local-model controls
+
+MiniMax Token Plan can be used through the Anthropic card without adding a separate MiniMax provider. Set the Anthropic API Key field to the MiniMax Token Plan key, set Anthropic Base URL override to `https://api.minimax.io/anthropic` (international) or `https://api.minimaxi.com/anthropic` (China), and use `anthropic::MiniMax-M3` in the runtime model slot. Ouroboros normalizes the direct runtime call to the provider's `/anthropic/v1/messages` endpoint and uses bearer-token Authorization for MiniMax-compatible direct Anthropic requests. Claude Agent SDK tooling receives `ANTHROPIC_AUTH_TOKEN` from the same saved secret, uses `MiniMax-M3[1m]` when the Claude Code model is still at the shipped default, and defaults `CLAUDE_CODE_AUTO_COMPACT_WINDOW` to `700000` for operational headroom. Set `CLAUDE_CODE_AUTO_COMPACT_WINDOW=1000000` only when you want the exact MiniMax Claude Code guide value. Clear conflicting shell `ANTHROPIC_AUTH_TOKEN` or `ANTHROPIC_BASE_URL` before launching Ouroboros because Claude Code gives shell env precedence over its settings.
 
 ### Run Tests
 
@@ -435,7 +437,7 @@ Created on first launch:
 | OpenAI Compatible API Key / Base URL | No | Any OpenAI-style endpoint (proxy, self-hosted gateway, third-party compatible API) |
 | Cloud.ru Foundation Models API Key | No | Cloud.ru Foundation Models provider |
 | GigaChat Authorization Key (or User/Password) | No | [developers.sber.ru/studio](https://developers.sber.ru/studio) — Sber GigaChat (`GIGACHAT_CREDENTIALS` + optional `GIGACHAT_SCOPE`, or `GIGACHAT_USER`/`GIGACHAT_PASSWORD`) |
-| Anthropic API Key | No | [console.anthropic.com](https://console.anthropic.com/settings/keys) — direct Anthropic runtime + Claude Agent SDK |
+| Anthropic API Key | No | [console.anthropic.com](https://console.anthropic.com/settings/keys) — direct Anthropic runtime + Claude Agent SDK; for MiniMax Token Plan, use the MiniMax key with Anthropic Base URL override `https://api.minimax.io/anthropic` or `https://api.minimaxi.com/anthropic` |
 | Telegram Bot Token | No | [@BotFather](https://t.me/BotFather) — used by the optional Telegram bridge skill |
 | GitHub Token | No | [github.com/settings/tokens](https://github.com/settings/tokens) — enables remote sync |
 
@@ -451,7 +453,7 @@ All keys are configured through the **Settings** page in the UI or during the fi
 | Vision | empty → Main | Caption/VLM lane (`OUROBOROS_MODEL_VISION`, empty falls back to Main for remote routes; local/blind routes need an explicit reachable vision slot for caption fallback); image input routing is controlled by `OUROBOROS_IMAGE_INPUT_MODE=auto|caption|inline|off` |
 | Consciousness | empty → Main | High-horizon background consciousness |
 | Fallbacks | `anthropic/claude-sonnet-4.6` | Comma-separated cross-model fallback chain when the primary fails (`OUROBOROS_MODEL_FALLBACKS`) |
-| Claude Agent SDK | `opus[1m]` | Anthropic model for Claude Agent SDK advisory/review internals; the `[1m]` suffix is a Claude Code selector that requests the 1M-context extended mode |
+| Claude Agent SDK | `opus[1m]` | Anthropic model for Claude Agent SDK advisory/review internals; the `[1m]` suffix is a Claude Code selector that requests the 1M-context extended mode. With a MiniMax Anthropic Base URL override, the default is translated to `MiniMax-M3[1m]`; direct runtime slots should use `anthropic::MiniMax-M3` instead. |
 | Scope Review | `openai/gpt-5.5` | Scope reviewer slot default; `OUROBOROS_SCOPE_REVIEW_MODELS` may configure multiple independent slots |
 | Web Search | `gpt-5.2` | OpenAI Responses API for web search |
 

--- a/ouroboros/anthropic_compat.py
+++ b/ouroboros/anthropic_compat.py
@@ -1,0 +1,59 @@
+"""Anthropic-compatible endpoint helpers.
+
+Shared by the handwritten Anthropic runtime, model-catalog loading, and Claude
+Code env setup so compatible base URLs normalize consistently without leaking
+secrets across those call sites.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit, urlunsplit
+
+OFFICIAL_ANTHROPIC_BASE_URL = "https://api.anthropic.com/v1"
+MINIMAX_ANTHROPIC_HOSTS = {"api.minimax.io", "api.minimaxi.com"}
+MINIMAX_CLAUDE_MODEL = "MiniMax-M3[1m]"
+MINIMAX_CLAUDE_AUTO_COMPACT_WINDOW = "700000"
+
+
+def normalize_anthropic_base_url(base_url: str | None) -> str:
+    raw = str(base_url or "").strip()
+    if not raw:
+        return OFFICIAL_ANTHROPIC_BASE_URL
+    parsed = urlsplit(raw)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("Anthropic Base URL must be an http(s) URL")
+    if parsed.username or parsed.password:
+        raise ValueError("Anthropic Base URL must not include credentials")
+    path = parsed.path.rstrip("/")
+    if not path.endswith("/v1"):
+        path = f"{path}/v1" if path else "/v1"
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+
+
+def anthropic_messages_url(base_url: str | None) -> str:
+    return f"{normalize_anthropic_base_url(base_url).rstrip('/')}/messages"
+
+
+def anthropic_models_url(base_url: str | None) -> str:
+    return f"{normalize_anthropic_base_url(base_url).rstrip('/')}/models"
+
+
+def is_minimax_anthropic_base_url(base_url: str | None) -> bool:
+    try:
+        parsed = urlsplit(normalize_anthropic_base_url(base_url))
+    except ValueError:
+        return False
+    return parsed.netloc.lower() in MINIMAX_ANTHROPIC_HOSTS
+
+
+def minimax_claude_compact_window(value: str | None) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return MINIMAX_CLAUDE_AUTO_COMPACT_WINDOW
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return MINIMAX_CLAUDE_AUTO_COMPACT_WINDOW
+    if parsed <= 0:
+        return MINIMAX_CLAUDE_AUTO_COMPACT_WINDOW
+    return str(parsed)

--- a/ouroboros/config.py
+++ b/ouroboros/config.py
@@ -18,6 +18,12 @@ from typing import Any, Optional
 from ouroboros.platform_layer import pid_lock_acquire as _compat_pid_lock_acquire
 from ouroboros.platform_layer import pid_lock_release as _compat_pid_lock_release
 from ouroboros.provider_models import compute_direct_review_models_fallback, migrate_model_value
+from ouroboros.anthropic_compat import (
+    MINIMAX_CLAUDE_MODEL,
+    is_minimax_anthropic_base_url,
+    minimax_claude_compact_window,
+    normalize_anthropic_base_url,
+)
 
 
 # Paths
@@ -78,6 +84,8 @@ SETTINGS_DEFAULTS = {
     "GIGACHAT_VERIFY_SSL_CERTS": "true",
     "GIGACHAT_PROFANITY_CHECK": "",
     "ANTHROPIC_API_KEY": "",
+    "ANTHROPIC_BASE_URL": "",
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "",
 
     "OUROBOROS_NETWORK_PASSWORD": "",
     "OUROBOROS_SERVER_HOST": "127.0.0.1",
@@ -1311,7 +1319,7 @@ def apply_settings_to_env(settings: dict) -> None:
         "GIGACHAT_CREDENTIALS", "GIGACHAT_USER", "GIGACHAT_PASSWORD",
         "GIGACHAT_SCOPE", "GIGACHAT_BASE_URL", "GIGACHAT_VERIFY_SSL_CERTS",
         "GIGACHAT_PROFANITY_CHECK",
-        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
         "OUROBOROS_NETWORK_PASSWORD",
         "OUROBOROS_MODEL", "OUROBOROS_MODEL_HEAVY", "OUROBOROS_MODEL_LIGHT", "OUROBOROS_MODEL_VISION",
         "OUROBOROS_MODEL_CONSCIOUSNESS",
@@ -1382,6 +1390,47 @@ def apply_settings_to_env(settings: dict) -> None:
             os.environ.pop(k, None)
         else:
             os.environ[k] = str(val)
+    try:
+        anthropic_base_url = normalize_anthropic_base_url(settings.get("ANTHROPIC_BASE_URL") or "")
+    except ValueError:
+        anthropic_base_url = str(settings.get("ANTHROPIC_BASE_URL") or "").strip()
+    if is_minimax_anthropic_base_url(anthropic_base_url):
+        raw_base_url = str(settings.get("ANTHROPIC_BASE_URL") or "").strip().rstrip("/")
+        api_key = str(settings.get("ANTHROPIC_API_KEY") or "").strip()
+        if api_key:
+            os.environ["ANTHROPIC_AUTH_TOKEN"] = api_key
+        else:
+            os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+        # Claude Code follows the documented owner-facing MiniMax base URL and
+        # appends its own API path; the handwritten direct runtime separately
+        # normalizes this to the /v1 Messages endpoint.
+        os.environ["ANTHROPIC_BASE_URL"] = raw_base_url or anthropic_base_url
+        compact_window = minimax_claude_compact_window(
+            settings.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW")
+        )
+        os.environ["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = compact_window
+        configured_model = str(settings.get("CLAUDE_CODE_MODEL") or "").strip()
+        default_model = str(SETTINGS_DEFAULTS.get("CLAUDE_CODE_MODEL") or "").strip()
+        claude_model = configured_model if configured_model and configured_model != default_model else MINIMAX_CLAUDE_MODEL
+        os.environ["CLAUDE_CODE_MODEL"] = claude_model
+        for key in (
+            "ANTHROPIC_MODEL",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+        ):
+            os.environ[key] = claude_model
+    else:
+        os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+        for key in (
+            "ANTHROPIC_MODEL",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+        ):
+            os.environ.pop(key, None)
+        if not str(settings.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW") or "").strip():
+            os.environ.pop("CLAUDE_CODE_AUTO_COMPACT_WINDOW", None)
     if not os.environ.get("OUROBOROS_REVIEW_MODELS"):
         os.environ["OUROBOROS_REVIEW_MODELS"] = str(SETTINGS_DEFAULTS["OUROBOROS_REVIEW_MODELS"])
     if not os.environ.get("OUROBOROS_REVIEW_ENFORCEMENT"):

--- a/ouroboros/gateway/models.py
+++ b/ouroboros/gateway/models.py
@@ -12,6 +12,11 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from ouroboros.config import load_settings
+from ouroboros.anthropic_compat import (
+    anthropic_models_url,
+    is_minimax_anthropic_base_url,
+    normalize_anthropic_base_url,
+)
 from ouroboros.gateway._helpers import json_error, json_exception
 
 log = logging.getLogger(__name__)
@@ -129,13 +134,26 @@ async def _fetch_openai_compatible_model_catalog(
 async def _fetch_anthropic_model_catalog(
     client: httpx.AsyncClient,
     api_key: str,
+    base_url: str = "",
 ) -> list[dict[str, str]]:
+    effective_base_url = normalize_anthropic_base_url(base_url)
+    if is_minimax_anthropic_base_url(effective_base_url):
+        return [
+            _build_model_catalog_entry(
+                "anthropic",
+                "MiniMax Token Plan",
+                "MiniMax-M3",
+                "MiniMax-M3",
+                source="MiniMax Anthropic-compatible",
+            )
+        ]
+    headers = {
+        "anthropic-version": "2023-06-01",
+    }
+    headers["x-api-key"] = api_key
     response = await client.get(
-        "https://api.anthropic.com/v1/models",
-        headers={
-            "x-api-key": api_key,
-            "anthropic-version": "2023-06-01",
-        },
+        anthropic_models_url(effective_base_url),
+        headers=headers,
     )
     response.raise_for_status()
     data = response.json()
@@ -222,7 +240,14 @@ def _provider_specs(
 
     anthropic_api_key = str(settings.get("ANTHROPIC_API_KEY", "") or "").strip()
     if anthropic_api_key:
-        specs.append(("anthropic", lambda client: _fetch_anthropic_model_catalog(client, anthropic_api_key)))
+        anthropic_base_url = str(settings.get("ANTHROPIC_BASE_URL", "") or "").strip()
+        if anthropic_base_url:
+            specs.append((
+                "anthropic",
+                lambda client: _fetch_anthropic_model_catalog(client, anthropic_api_key, anthropic_base_url),
+            ))
+        else:
+            specs.append(("anthropic", lambda client: _fetch_anthropic_model_catalog(client, anthropic_api_key)))
 
     compatible_api_key = str(settings.get("OPENAI_COMPATIBLE_API_KEY", "") or "").strip()
     compatible_base_url = str(settings.get("OPENAI_COMPATIBLE_BASE_URL", "") or "").strip()

--- a/ouroboros/gateway/settings.py
+++ b/ouroboros/gateway/settings.py
@@ -460,6 +460,13 @@ def _active_main_route(
         base_url = str(settings.get("OPENAI_BASE_URL") or "")
     elif provider == "openai-compatible":
         base_url = str(settings.get("OPENAI_COMPATIBLE_BASE_URL") or "")
+    elif provider == "anthropic":
+        try:
+            from ouroboros.anthropic_compat import normalize_anthropic_base_url
+
+            base_url = normalize_anthropic_base_url(settings.get("ANTHROPIC_BASE_URL") or "")
+        except Exception:
+            base_url = str(settings.get("ANTHROPIC_BASE_URL") or "")
     elif provider == "cloudru":
         base_url = str(settings.get("CLOUDRU_FOUNDATION_MODELS_BASE_URL") or "")
     elif provider == "gigachat":

--- a/ouroboros/llm.py
+++ b/ouroboros/llm.py
@@ -11,6 +11,11 @@ import time
 import copy
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+from ouroboros.anthropic_compat import (
+    anthropic_messages_url,
+    is_minimax_anthropic_base_url,
+    normalize_anthropic_base_url,
+)
 from ouroboros.provider_models import PROVIDER_PREFIXES, normalize_anthropic_model_id, normalize_model_identity
 from ouroboros.utils import in_worker_process
 
@@ -592,12 +597,15 @@ class LLMClient:
 
         if provider == "anthropic":
             resolved_model = normalize_anthropic_model_id(resolved_model)
+            raw_base_url = os.environ.get("ANTHROPIC_BASE_URL", "")
+            base_url = normalize_anthropic_base_url(raw_base_url)
             return {
                 "provider": provider,
                 "resolved_model": resolved_model,
                 "usage_model": self._qualified_model_name(provider, resolved_model),
                 "api_key": os.environ.get("ANTHROPIC_API_KEY", ""),
-                "base_url": "https://api.anthropic.com/v1",
+                "base_url": base_url,
+                "auth_scheme": "bearer" if is_minimax_anthropic_base_url(base_url) else "x-api-key",
                 "default_headers": {},
                 "supports_openrouter_extensions": False,
                 "supports_generation_cost": False,
@@ -2081,12 +2089,16 @@ class LLMClient:
             payload.get("tools"),
         )
 
-        url = f"{str(target.get('base_url') or '').rstrip('/')}/messages"
+        url = anthropic_messages_url(target.get("base_url") or "")
         headers = {
-            "x-api-key": str(target.get("api_key") or ""),
             "anthropic-version": "2023-06-01",
             "content-type": "application/json",
         }
+        api_key = str(target.get("api_key") or "")
+        if str(target.get("auth_scheme") or "").strip().lower() == "bearer":
+            headers["Authorization"] = f"Bearer {api_key}"
+        else:
+            headers["x-api-key"] = api_key
         request_timeout = float(timeout) if timeout and timeout > 0 else 120
 
         def _send(candidate: Dict[str, Any]):

--- a/ouroboros/review.py
+++ b/ouroboros/review.py
@@ -78,7 +78,11 @@ MAX_FUNCTION_LINES = 300
 # v6.53.0 benchmark-generalization hardening adds small typed helpers for Observable Acceptance Claims,
 # support_refs, GAIA profiles, media frame extraction, VLM timeout wrapping, and workspace inheritance.
 # Cap intentionally moves with a small headroom rather than hiding growth elsewhere.
-MAX_TOTAL_FUNCTIONS = 3636
+# MiniMax Anthropic-compatible support +5 = 3641: isolated URL/auth/env/catalog
+# helpers in anthropic_compat.py keep direct-runtime endpoint construction,
+# model-catalog routing, and Claude tooling env propagation shared and testable
+# rather than duplicating provider checks inline.
+MAX_TOTAL_FUNCTIONS = 3641
 GRANDFATHERED_OVERSIZED_FUNCTIONS = {
     ("agent_startup_checks.py", "verify_restart"),  # managed #53 boot diagnostic flow, 307 lines
     ("git.py", "_run_reviewed_stage_cycle"),  # reviewed-commit gate orchestration, 302 lines

--- a/tests/test_minimax_anthropic_compat.py
+++ b/tests/test_minimax_anthropic_compat.py
@@ -1,0 +1,194 @@
+"""MiniMax Token Plan via Anthropic-compatible base URL."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_resolve_anthropic_minimax_base_url_from_env(monkeypatch):
+    from ouroboros.llm import LLMClient
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-token")
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", " https://api.minimax.io/anthropic/ ")
+
+    target = LLMClient()._resolve_remote_target("anthropic::MiniMax-M3")
+
+    assert target["provider"] == "anthropic"
+    assert target["resolved_model"] == "MiniMax-M3"
+    assert target["base_url"] == "https://api.minimax.io/anthropic/v1"
+    assert target["auth_scheme"] == "bearer"
+
+
+def test_anthropic_minimax_chat_uses_v1_messages_and_bearer_auth(monkeypatch):
+    from ouroboros.llm import LLMClient
+
+    captured = {}
+
+    class _Response:
+        status_code = 200
+        reason = "OK"
+        url = "https://api.minimax.io/anthropic/v1/messages"
+        text = ""
+
+        def json(self):
+            return {
+                "content": [{"type": "text", "text": "ok"}],
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "stop_reason": "end_turn",
+            }
+
+    def fake_post(url, *, headers, json, timeout):
+        captured.update({"url": url, "headers": dict(headers), "json": dict(json), "timeout": timeout})
+        return _Response()
+
+    monkeypatch.setattr("requests.post", fake_post)
+    client = LLMClient()
+    target = {
+        "provider": "anthropic",
+        "resolved_model": "MiniMax-M3",
+        "usage_model": "anthropic/MiniMax-M3",
+        "api_key": "test-token",
+        "base_url": "https://api.minimax.io/anthropic/v1",
+        "auth_scheme": "bearer",
+    }
+
+    message, usage = client._chat_anthropic(
+        target,
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        reasoning_effort="medium",
+        max_tokens=8,
+        tool_choice="auto",
+    )
+
+    assert captured["url"] == "https://api.minimax.io/anthropic/v1/messages"
+    assert captured["headers"]["Authorization"] == "Bearer test-token"
+    assert "x-api-key" not in captured["headers"]
+    assert captured["json"]["model"] == "MiniMax-M3"
+    assert message["content"] == "ok"
+    assert usage["resolved_model"] == "anthropic/MiniMax-M3"
+
+
+def test_official_anthropic_route_remains_v1_x_api_key(monkeypatch):
+    from ouroboros.llm import LLMClient
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "official-token")
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+
+    target = LLMClient()._resolve_remote_target("anthropic::claude-opus-4-8")
+
+    assert target["base_url"] == "https://api.anthropic.com/v1"
+    assert target["auth_scheme"] == "x-api-key"
+
+
+def test_active_main_route_fingerprints_anthropic_base_url():
+    from ouroboros.gateway.settings import _active_main_route
+
+    route = _active_main_route({
+        "OUROBOROS_MODEL": "anthropic::MiniMax-M3",
+        "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
+    })
+
+    assert route["provider"] == "anthropic"
+    assert route["base_url"] == "https://api.minimax.io/anthropic/v1"
+
+
+def test_anthropic_base_url_is_non_secret_setting():
+    from ouroboros.config import SETTINGS_DEFAULTS
+    from ouroboros.gateway import settings as settings_api
+
+    assert "ANTHROPIC_BASE_URL" in SETTINGS_DEFAULTS
+    assert "ANTHROPIC_BASE_URL" not in settings_api._SECRET_SETTING_KEYS
+
+
+def test_minimax_model_catalog_does_not_call_official_anthropic():
+    from ouroboros.gateway.models import _provider_specs
+
+    specs = dict(_provider_specs({
+        "ANTHROPIC_API_KEY": "minimax-token",
+        "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
+    }))
+
+    assert "anthropic" in specs
+
+    class _Client:
+        async def get(self, *args, **kwargs):  # pragma: no cover - fail path
+            raise AssertionError("MiniMax catalog must not query official Anthropic")
+
+    import asyncio
+
+    async def _load():
+        return await specs["anthropic"](_Client())  # type: ignore[arg-type]
+
+    items = asyncio.run(_load())
+    assert items[0]["value"] == "anthropic::MiniMax-M3"
+    assert items[0]["provider"] == "MiniMax Token Plan"
+
+
+def test_apply_settings_to_env_derives_minimax_claude_tooling_env(monkeypatch):
+    from ouroboros.config import SETTINGS_DEFAULTS, apply_settings_to_env
+
+    for key in (
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_MODEL",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+        "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
+        "CLAUDE_CODE_MODEL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    settings = dict(SETTINGS_DEFAULTS)
+    settings.update({
+        "ANTHROPIC_API_KEY": "minimax-token",
+        "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
+    })
+
+    apply_settings_to_env(settings)
+
+    import os
+
+    assert os.environ["ANTHROPIC_BASE_URL"] == "https://api.minimax.io/anthropic"
+    assert os.environ["ANTHROPIC_AUTH_TOKEN"] == "minimax-token"
+    assert os.environ["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "700000"
+    assert os.environ["CLAUDE_CODE_MODEL"] == "MiniMax-M3[1m]"
+    assert os.environ["ANTHROPIC_MODEL"] == "MiniMax-M3[1m]"
+    assert os.environ["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "MiniMax-M3[1m]"
+    assert os.environ["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "MiniMax-M3[1m]"
+    assert os.environ["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "MiniMax-M3[1m]"
+
+
+def test_minimax_claude_tooling_allows_explicit_compact_override(monkeypatch):
+    from ouroboros.config import SETTINGS_DEFAULTS, apply_settings_to_env
+    import os
+
+    monkeypatch.delenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", raising=False)
+    settings = dict(SETTINGS_DEFAULTS)
+    settings.update({
+        "ANTHROPIC_API_KEY": "minimax-token",
+        "ANTHROPIC_BASE_URL": "https://api.minimaxi.com/anthropic",
+        "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "1000000",
+    })
+
+    apply_settings_to_env(settings)
+
+    assert os.environ["ANTHROPIC_BASE_URL"] == "https://api.minimaxi.com/anthropic"
+    assert os.environ["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "1000000"
+
+
+def test_settings_ui_documents_minimax_anthropic_values():
+    root = Path(__file__).resolve().parents[1]
+    settings_ui = (root / "web" / "modules" / "settings_ui.js").read_text(encoding="utf-8")
+    settings_js = (root / "web" / "modules" / "settings.js").read_text(encoding="utf-8")
+
+    assert "s-anthropic-base-url" in settings_ui
+    assert "ANTHROPIC_BASE_URL" in settings_js
+    assert "https://api.minimax.io/anthropic" in settings_ui
+    assert "https://api.minimaxi.com/anthropic" in settings_ui
+    assert "anthropic::MiniMax-M3" in settings_ui
+    assert "MiniMax-M3[1m]" in settings_ui
+    assert "700000" in settings_ui
+    assert "1000000" in settings_ui
+    assert "ANTHROPIC_AUTH_TOKEN" in settings_ui

--- a/web/modules/settings.js
+++ b/web/modules/settings.js
@@ -12,9 +12,9 @@ const BASE_SECRET_KEYS = new Set(SECRET_KEYS.map(([key]) => key));
 let setupContract = {};
 
 const INPUT_FIELDS = [
-    ['s-openai-base-url', 'OPENAI_BASE_URL'], ['s-openai-compatible-base-url', 'OPENAI_COMPATIBLE_BASE_URL'], ['s-cloudru-base-url', 'CLOUDRU_FOUNDATION_MODELS_BASE_URL'],
+    ['s-openai-base-url', 'OPENAI_BASE_URL'], ['s-openai-compatible-base-url', 'OPENAI_COMPATIBLE_BASE_URL'], ['s-anthropic-base-url', 'ANTHROPIC_BASE_URL'], ['s-cloudru-base-url', 'CLOUDRU_FOUNDATION_MODELS_BASE_URL'],
     ['s-gigachat-scope', 'GIGACHAT_SCOPE'], ['s-gigachat-user', 'GIGACHAT_USER'], ['s-gigachat-base-url', 'GIGACHAT_BASE_URL'], ['s-gigachat-verify-ssl', 'GIGACHAT_VERIFY_SSL_CERTS'],
-    ['s-server-host', 'OUROBOROS_SERVER_HOST', '127.0.0.1'], ['s-claude-code-model', 'CLAUDE_CODE_MODEL', 'opus[1m]'],
+    ['s-server-host', 'OUROBOROS_SERVER_HOST', '127.0.0.1'], ['s-claude-code-model', 'CLAUDE_CODE_MODEL', 'opus[1m]'], ['s-claude-auto-compact-window', 'CLAUDE_CODE_AUTO_COMPACT_WINDOW'],
     ['s-review-models', 'OUROBOROS_REVIEW_MODELS'], ['s-scope-review-models', 'OUROBOROS_SCOPE_REVIEW_MODELS'], ['s-deep-self-review-model', 'OUROBOROS_MODEL_DEEP_SELF_REVIEW'], ['s-skills-repo-path', 'OUROBOROS_SKILLS_REPO_PATH'],
     ['s-clawhub-registry-url', 'OUROBOROS_CLAWHUB_REGISTRY_URL'], ['s-websearch-model', 'OUROBOROS_WEBSEARCH_MODEL'], ['s-gh-repo', 'GITHUB_REPO'],
     ['s-local-source', 'LOCAL_MODEL_SOURCE'], ['s-local-filename', 'LOCAL_MODEL_FILENAME'], ['s-local-chat-format', 'LOCAL_MODEL_CHAT_FORMAT'],
@@ -274,6 +274,7 @@ const SETTINGS_FALLBACK_MODELS = [
     'openai::gpt-5.5-mini',
     'openai/gpt-5.5',
     'anthropic/claude-opus-4.6',
+    'anthropic::MiniMax-M3',
 ];
 
 let settingsModelCatalogItems = SETTINGS_FALLBACK_MODELS.map((value) => ({ value, label: 'Suggested model' }));

--- a/web/modules/settings_ui.js
+++ b/web/modules/settings_ui.js
@@ -102,8 +102,12 @@ const PROVIDER_CARDS = [
     },
     {
         id: 'anthropic', title: 'Anthropic', icon: '/static/providers/anthropic.png', hint: 'Direct runtime plus Claude tooling',
-        fields: [{ id: 's-anthropic', settingKey: 'ANTHROPIC_API_KEY', label: 'Anthropic API Key', placeholder: 'sk-ant-...' }],
-        note: 'Use model values like <code>anthropic::claude-sonnet-4-6</code> in the Models tab to route models directly through Anthropic. Claude tooling still reuses this key.',
+        fields: [
+            { id: 's-anthropic', settingKey: 'ANTHROPIC_API_KEY', label: 'Anthropic API Key / compatible auth token', placeholder: 'sk-ant-... or MiniMax Token Plan key' },
+            { id: 's-anthropic-base-url', label: 'Anthropic Base URL override', placeholder: 'https://api.minimax.io/anthropic' },
+            { id: 's-claude-auto-compact-window', label: 'Claude auto-compact window override', placeholder: 'blank = 700000 for MiniMax, 1000000 = exact MiniMax docs' },
+        ],
+        note: 'Use model values like <code>anthropic::claude-sonnet-4-6</code> for official Anthropic or <code>anthropic::MiniMax-M3</code> for MiniMax Token Plan. MiniMax documented base URLs are <code>https://api.minimax.io/anthropic</code> and <code>https://api.minimaxi.com/anthropic</code>; direct runtime calls their <code>/v1/messages</code> endpoint. Claude tooling receives <code>ANTHROPIC_AUTH_TOKEN</code>, <code>MiniMax-M3[1m]</code>, and a safer default auto-compact window of <code>700000</code>. Existing shell <code>ANTHROPIC_AUTH_TOKEN</code>/<code>ANTHROPIC_BASE_URL</code> can override Claude Code settings, so clear conflicting shell env vars before launch.',
         extra: `
             <div class="settings-toolbar" id="settings-claude-code-panel" hidden>
                 <button type="button" class="settings-ghost-btn" id="btn-claude-code-install">Repair Runtime</button>


### PR DESCRIPTION
## Summary

Closes #61.

Adds MiniMax Token Plan support through the existing Anthropic provider path by introducing a non-secret Anthropic Base URL override instead of a new first-class MiniMax provider.

- Adds shared Anthropic-compatible URL/env helpers.
- Routes `anthropic::MiniMax-M3` to MiniMax's Anthropic-compatible `/anthropic/v1/messages` endpoint.
- Uses bearer-token Authorization for MiniMax-compatible direct Anthropic calls while preserving official Anthropic `x-api-key` behavior when no override is set.
- Propagates MiniMax Claude Code-style env values for Claude tooling: `ANTHROPIC_AUTH_TOKEN`, `MiniMax-M3[1m]`, and default `CLAUDE_CODE_AUTO_COMPACT_WINDOW=700000` with `1000000` still supported as an explicit docs-exact override.
- Adds Anthropic Base URL and Claude auto-compact fields/copy to Settings.
- Makes model catalog avoid official Anthropic `/v1/models` for MiniMax-compatible endpoints and return `anthropic::MiniMax-M3` without surfacing an Anthropic provider failure.
- Documents the MiniMax Token Plan setup in README.

## Test Plan

- `PATH=/Users/alxy/Files/00_Inbox/ouroboros/.venv/bin:$PATH make lint`
- `.venv/bin/pytest tests/test_minimax_anthropic_compat.py tests/test_model_catalog_api.py tests/test_smoke.py::test_function_count_reasonable -q`
- `PATH=/Users/alxy/Files/00_Inbox/ouroboros/.venv/bin:$PATH make test`
- `npx --yes @fission-ai/openspec@1.4.1 validate add-anthropic-base-url-override --strict --no-interactive`
- `npx --yes @fission-ai/openspec@1.4.1 validate --all --strict --no-interactive`
- `git diff --check`
- Restart deps smoke: `.venv/bin/python3 -m pip install -q -r requirements.txt && echo restart-deps-ok`
- Live smoke against `http://127.0.0.1:8765/`: `/` returned ready; `/api/model-catalog` returned `errors []` and included `anthropic::MiniMax-M3`.

## Notes

A local OpenSpec change was used for planning/review and archived locally, but the `openspec/` tree is intentionally local-only/ignored and not included in this PR.
