### PR TITLE
feat(resume): portable conversation-resume (Claude Code --resume analog)

### DIFF
--- a/ouroboros/agent.py
+++ b/ouroboros/agent.py
@@ -31,6 +31,7 @@ from ouroboros.memory import Memory
 from ouroboros.context import build_llm_messages
 from ouroboros.context_budget import CONTEXT_SOFT_CAP_TOKENS
 from ouroboros.loop import run_llm_loop
+import ouroboros.resume as resume
 from ouroboros.config import resolve_effort
 from ouroboros.agent_startup_checks import (
     inject_crash_report,
@@ -527,6 +528,10 @@ class OuroborosAgent:
             _scope_pid = str(getattr(ctx, "project_id", "") or "").strip()
             if _scope_pid and not str(task.get("project_id") or "").strip():
                 task["project_id"] = _scope_pid
+
+            # Conversation-resume capture (opt-in via OUROBOROS_RESUME_CAPTURE): persist the final
+            # conversation so a later task can continue it via resume_from_task_id.
+            resume.capture(self.env, str(task.get("id") or ""), messages, text)
 
             emit_task_results(
                 self.env, self.memory, self.llm,

--- a/ouroboros/context.py
+++ b/ouroboros/context.py
@@ -27,6 +27,7 @@ from ouroboros.context_layout import (
 )
 from ouroboros.config import get_context_mode
 from ouroboros.contracts.task_contract import normalize_bool
+import ouroboros.resume as resume
 
 log = logging.getLogger(__name__)
 _LARGE_CONTEXT_SECTION_CHARS = LARGE_CONTEXT_SECTION_CHARS
@@ -1279,8 +1280,11 @@ def build_llm_messages(
                 },
             ],
         },
-        {"role": "user", "content": build_user_content(task)},
     ]
+    # Conversation-resume: splice the prior task's turns between the (fresh) system message and the
+    # new user turn, so successive submissions form one continuous, prompt-cacheable conversation.
+    messages.extend(resume.load_resume_turns(env, task))
+    messages.append({"role": "user", "content": build_user_content(task)})
 
     messages, cap_info = apply_message_token_soft_cap(messages, soft_cap_tokens)
     return messages, cap_info

--- a/ouroboros/context.py
+++ b/ouroboros/context.py
@@ -1281,9 +1281,15 @@ def build_llm_messages(
             ],
         },
     ]
-    # Conversation-resume: splice the prior task's turns between the (fresh) system message and the
-    # new user turn, so successive submissions form one continuous, prompt-cacheable conversation.
-    messages.extend(resume.load_resume_turns(env, task))
+    # Conversation-resume. CONTINUATION mode (the DEFAULT; the true CC --resume analog)
+    # re-enters the STORED conversation — original system message verbatim, append-only;
+    # SPLICE mode (explicit resume_mode=splice) splices the prior turns between the fresh
+    # system message and the new user turn.
+    _continuation = resume.load_continuation(env, task)
+    if _continuation:
+        messages = _continuation
+    else:
+        messages.extend(resume.load_resume_turns(env, task))
     messages.append({"role": "user", "content": build_user_content(task)})
 
     messages, cap_info = apply_message_token_soft_cap(messages, soft_cap_tokens)

--- a/ouroboros/gateway/tasks.py
+++ b/ouroboros/gateway/tasks.py
@@ -301,6 +301,7 @@ async def api_tasks_create(request: Request) -> JSONResponse:
         "text": task_text,
         "description": description,
         "resume_from_task_id": str(body.get("resume_from_task_id") or ""),
+        "resume_mode": str(body.get("resume_mode") or "").strip().lower(),
         "context": str(body.get("context") or ""),
         "expected_output": str(body.get("expected_output") or ""),
         "constraints": str(body.get("constraints") or ""),

--- a/ouroboros/gateway/tasks.py
+++ b/ouroboros/gateway/tasks.py
@@ -300,6 +300,7 @@ async def api_tasks_create(request: Request) -> JSONResponse:
         "chat_id": chat_id,
         "text": task_text,
         "description": description,
+        "resume_from_task_id": str(body.get("resume_from_task_id") or ""),
         "context": str(body.get("context") or ""),
         "expected_output": str(body.get("expected_output") or ""),
         "constraints": str(body.get("constraints") or ""),

--- a/ouroboros/loop.py
+++ b/ouroboros/loop.py
@@ -23,6 +23,7 @@ from ouroboros.context_budget import EMERGENCY_COMPACTION_CHARS, LOW_EMERGENCY_C
 from ouroboros.context_compaction import _tool_round_spans, compact_tool_history_llm
 from ouroboros.deadline_utils import parse_deadline_ts, utc_now
 from ouroboros.utils import estimate_tokens
+import ouroboros.resume as resume
 
 from ouroboros.loop_tool_execution import (
     StatefulToolExecutor,
@@ -2153,7 +2154,7 @@ def run_llm_loop(
                 event_queue=event_queue, task_id=task_id, drive_logs=drive_logs,
             )
 
-            messages, _compaction_usage = _run_round_compaction(
+            _compacted, _compaction_usage = _run_round_compaction(
                 messages,
                 _CompactionRoundContext(
                     tools=tools,
@@ -2169,6 +2170,11 @@ def run_llm_loop(
                     active_model=active_model,
                 ),
             )
+            if _compacted is not messages:
+                # Mutate IN PLACE (not rebind): the caller (agent.py) holds a reference to
+                # this list — resume.capture / note_final_msg must see the COMPACTED
+                # transcript, not a stale pre-compaction snapshot.
+                messages[:] = _compacted
             if tools._ctx.messages is not messages:
                 tools._ctx.messages = messages
             limit_ctx.messages = messages  # WA2: provider-death finalize must salvage the COMPACTED transcript
@@ -2260,6 +2266,9 @@ def run_llm_loop(
                     emit_progress=emit_progress,
                 ):
                     continue
+                # Conversation-resume capture fidelity: persist the FULL provider msg for this
+                # final turn (reasoning/response_id) — no-op unless OUROBOROS_RESUME_CAPTURE.
+                resume.note_final_msg(messages, msg)
                 return _no_tool_final_answer(content, limit_ctx, llm_trace, accumulated_usage)
 
             if getattr(tools._ctx, "_skill_finalization_injected", False):

--- a/ouroboros/resume.py
+++ b/ouroboros/resume.py
@@ -14,11 +14,16 @@ prior completed task, instead of starting cold. Two seams:
 This module is deliberately self-contained (json, os, pathlib, logging only) so it ports
 verbatim across Ouroboros versions — the core only needs 3 thin hooks calling into it.
 
-Invariants (extracted VERBATIM from feat/conversation-resume, do not change):
-  * The sanitize blocklist drops provider-private reasoning/cache metadata
-    (reasoning_details, reasoning_content, reasoning, response_id, signature, cache_control)
-    but PRESERVES structural keys tool_calls/tool_call_id/name (H1 — dropping tool_calls
-    causes provider 400s on replay).
+Invariants:
+  * Sanitize mirrors the LIVE-path replay policy (llm.py): PRESERVE reasoning continuity —
+    reasoning/reasoning_details and thinking blocks WITH their signatures are replayed
+    verbatim on resume, exactly as the in-task loop replays them. Anthropic thinking-block
+    signatures are live-probe-verified portable across OpenRouter providers
+    (llm.py _reasoning_signature_portable_across_or_providers), and the llm layer's
+    reactive 400 strip-and-retry is the safety net for any family that rejects a replayed
+    signature. Only ``cache_control`` is dropped (stale breakpoints from the prior task
+    would fight the fresh breakpoint placed below; max 4 per request). Structural keys
+    tool_calls/tool_call_id/name are preserved (dropping tool_calls 400s on replay).
   * The path-traversal guard rejects resume_from_task_id containing "/", "\\", a leading
     ".", or ".." and enforces containment under the resume dir (H2).
   * One ephemeral cache_control breakpoint at the end of the replayed turns.
@@ -35,16 +40,18 @@ from typing import Any, Dict, List
 
 log = logging.getLogger(__name__)
 
-_RESUME_DROP_TOP = ("reasoning_details", "reasoning_content", "reasoning", "response_id",
-                    "signature", "cache_control")
+_RESUME_DROP_TOP = ("cache_control",)
 
 
 def sanitize_turn(m: Dict[str, Any]) -> Dict[str, Any]:
-    """Resume: PRESERVE the turn's structural keys (role, content, tool_calls, tool_call_id, name — the
-    engine's native OpenAI-style format) so tool_call/tool_result pairing stays valid on replay, but DROP
-    provider-private reasoning/thinking + cache metadata, whose signatures do not survive replay in a fresh
-    API call (mirrors the live-path _strip_openrouter_roundtrip_metadata). A completed task's turns are
-    already paired, so keeping tool_calls/tool_call_id yields a valid conversation."""
+    """Resume: replay the turn with LIVE-path fidelity. Structural keys (role, content,
+    tool_calls, tool_call_id, name) AND reasoning continuity (assistant-level reasoning/
+    reasoning_details, thinking/redacted_thinking content blocks WITH signatures) are
+    preserved verbatim — same-model replay accepts them, cross-provider portability is
+    live-probe-verified for Anthropic/Gemini/OpenAI families (llm.py), and the llm layer's
+    reactive 400 strip-and-retry covers any family that rejects a replayed signature.
+    Only ``cache_control`` is dropped: stale breakpoints from the captured task would
+    fight the fresh end-of-replay breakpoint (max 4 per request)."""
     out = {k: v for k, v in m.items() if k not in _RESUME_DROP_TOP}
     out["role"] = m.get("role") or "user"
     content = m.get("content")
@@ -54,9 +61,7 @@ def sanitize_turn(m: Dict[str, Any]) -> Dict[str, Any]:
             if not isinstance(b, dict):
                 kept.append(b)
                 continue
-            if b.get("type") in ("thinking", "redacted_thinking", "reasoning"):
-                continue
-            kept.append({k: v for k, v in b.items() if k not in ("signature", "reasoning", "cache_control")})
+            kept.append({k: v for k, v in b.items() if k != "cache_control"})
         out["content"] = kept
     return out
 

--- a/ouroboros/resume.py
+++ b/ouroboros/resume.py
@@ -7,12 +7,18 @@ prior completed task, instead of starting cold. Two seams:
   * ``capture(env, task_id, messages, text)`` — opt-in via ``OUROBOROS_RESUME_CAPTURE``,
     persists the final conversation (with the closing assistant turn appended) to
     ``<OUROBOROS_DATA_DIR>/state/resume/<task_id>.json``.
-  * ``load_resume_turns(env, task)`` — reads ``task["resume_from_task_id"]``, guards it,
-    loads the captured turns, drops the prior system turn, sanitizes each turn, and marks a
-    cache breakpoint at the end; returns ``[]`` when absent/invalid.
+  * ``load_resume_turns(env, task)`` — SPLICE mode (legacy, explicit opt-in): reads ``task["resume_from_task_id"]``,
+    guards it, loads the captured turns, drops the prior system turn, sanitizes each turn, and
+    marks a cache breakpoint at the end; returns ``[]`` when absent/invalid.
+  * ``load_continuation(env, task)`` — CONTINUATION mode (the DEFAULT for resumed tasks):
+    the true CC --resume analog — returns the stored conversation WITH its original system message
+    verbatim (byte-stable prefix ⇒ prompt-cache hits, no fresh-state re-framing); the caller
+    replaces its fresh message list and appends only the new user turn (append-only).
+  * ``note_final_msg(messages, msg)`` — loop-side capture-fidelity hook: appends the FULL provider
+    message for the no-tool final turn (reasoning/response_id preserved) when capture is armed.
 
 This module is deliberately self-contained (json, os, pathlib, logging only) so it ports
-verbatim across Ouroboros versions — the core only needs 3 thin hooks calling into it.
+verbatim across Ouroboros versions — the core only needs 4 thin hooks calling into it.
 
 Invariants:
   * Sanitize mirrors the LIVE-path replay policy (llm.py): PRESERVE reasoning continuity —
@@ -66,32 +72,100 @@ def sanitize_turn(m: Dict[str, Any]) -> Dict[str, Any]:
     return out
 
 
-def mark_cache_breakpoint(m: Dict[str, Any]) -> None:
+def mark_cache_breakpoint(m: Dict[str, Any]) -> bool:
     """Place one ephemeral cache_control breakpoint at the END of the replayed prefix so the seeded
-    conversation can hit the prompt cache on the next submission (within the provider TTL)."""
+    conversation can hit the prompt cache on the next submission (within the provider TTL).
+    Refuses empty/whitespace text (Anthropic rejects empty text blocks; a breakpoint on one is
+    silently dropped by the send path — the caller should walk back to an earlier turn).
+    Returns True when a breakpoint was placed."""
     content = m.get("content")
     if isinstance(content, str):
+        if not content.strip():
+            return False
         m["content"] = [{"type": "text", "text": content, "cache_control": {"type": "ephemeral"}}]
-    elif isinstance(content, list):
+        return True
+    if isinstance(content, list):
         for b in reversed(content):
-            if isinstance(b, dict) and b.get("type") in ("text", "tool_result"):
+            if not isinstance(b, dict):
+                continue
+            if b.get("type") == "tool_result" or (
+                b.get("type") == "text" and str(b.get("text") or "").strip()
+            ):
                 b["cache_control"] = {"type": "ephemeral"}
-                break
+                return True
+    return False
 
 
-def load_resume_turns(env: Any, task: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Conversation-resume — the Ouroboros analog of Claude Code's --resume / single_conversation.
-    If the task carries ``resume_from_task_id``, load that prior task's captured conversation turns
-    (written by capture() when OUROBOROS_RESUME_CAPTURE is set) and return them so the new task
-    CONTINUES the same warm, prompt-cacheable conversation. The prior system message is dropped (the
-    system prompt is rebuilt fresh each task with live drive state); reasoning blocks are stripped.
-    Returns [] when not set or the capture file is missing."""
+def _trim_chain(out: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """CC-compaction analog for the resumed chain (deterministic, no LLM): when the stored
+    non-system turns exceed OUROBOROS_RESUME_MAX_CHARS (default 600K chars ≈ 150K tokens),
+    drop the OLDEST turns down to ~70% of the cap and insert ONE explicit omission note
+    after the system message. Without this the chain grows unbounded and the provider 400s
+    near the context window with no fallback (the soft cap is a documented no-op). Trimming
+    is deterministic and stable between triggers, so the prefix stays cacheable in the
+    stretches between trims (CC's own compaction pays the same cache invalidation)."""
+    try:
+        cap = int(os.environ.get("OUROBOROS_RESUME_MAX_CHARS", "600000"))
+    except ValueError:
+        cap = 600000
+    if cap <= 0 or len(out) < 2:
+        return out
+    sizes = [len(json.dumps(m, ensure_ascii=False, default=str)) for m in out[1:]]
+    total = sum(sizes)
+    if total <= cap:
+        return out
+    target = int(cap * 0.7)
+    kept = list(out[1:])
+    dropped = 0
+    while kept and total > target:
+        total -= sizes[dropped]
+        kept.pop(0)
+        dropped += 1
+    while kept and kept[0].get("role") == "tool":  # never start with an orphan tool reply
+        kept.pop(0)
+        dropped += 1
+    log.warning("resume: chain over %d chars — dropped the %d oldest turns (kept %d)",
+                cap, dropped, len(kept))
+    note = {"role": "user",
+            "content": f"[resume: the {dropped} earliest turns of this conversation were "
+                       f"omitted to fit the context window]"}
+    return [out[0], note] + kept
+
+
+def _mark_prefix_breakpoint(turns: List[Dict[str, Any]]) -> None:
+    """Walk backwards over the replayed turns and place ONE end-of-prefix breakpoint on the
+    nearest markable (non-system, non-empty) turn."""
+    for m in reversed(turns):
+        if m.get("role") == "system":
+            break  # never demote the system message's own breakpoints
+        if mark_cache_breakpoint(m):
+            return
+
+
+_KNOWN_RESUME_MODES = ("", "splice", "continuation")
+
+
+def _resume_mode(task: Dict[str, Any]) -> str:
+    """Normalized resume_mode. DEFAULT (empty) = CONTINUATION — the true CC --resume analog
+    measurably outperforms splice (6q A/B: 0.611 vs 0.144), so it is what plain resume means;
+    'splice' is the explicit legacy opt-in. Unknown values warn LOUDLY (a typo must not
+    silently change the mode) and fall back to the default."""
+    mode = str(task.get("resume_mode") or "").strip().lower()
+    if mode not in _KNOWN_RESUME_MODES:
+        log.warning("resume: unknown resume_mode %r (known: %s) — using the default (continuation)",
+                    mode, "/".join(m or "''" for m in _KNOWN_RESUME_MODES))
+        return "continuation"
+    return mode or "continuation"
+
+
+def _load_capture_messages(env: Any, task: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Guarded shared loader: resolve ``task["resume_from_task_id"]`` to its capture file and return
+    the raw stored messages list, or [] when absent/invalid. Carries the path-traversal guard —
+    resume_from_task_id is attacker-reachable via the unauthenticated /api/tasks body and is
+    interpolated into a filesystem path (the primary task_id is gated by validate_task_id)."""
     rid = str(task.get("resume_from_task_id") or "").strip()
     if not rid:
         return []
-    # Path-traversal guard: resume_from_task_id is attacker-reachable via the unauthenticated /api/tasks
-    # body and is interpolated into a filesystem path, so reject anything that could escape the resume dir
-    # (the primary task_id is similarly gated by validate_task_id at the gateway).
     if "/" in rid or "\\" in rid or rid.startswith(".") or ".." in rid:
         log.warning("resume: rejected unsafe resume_from_task_id %r (path-traversal guard)", rid)
         return []
@@ -103,21 +177,101 @@ def load_resume_turns(env: Any, task: Dict[str, Any]) -> List[Dict[str, Any]]:
         if not str(path).startswith(str(resume_dir) + os.sep):  # containment, belt-and-suspenders
             return []
         if not path.exists():
+            # LOUD: a requested-but-missing capture silently cold-restarts the whole chain (the
+            # prior task died before capture ran) — the one failure shape callers can't see.
+            log.warning("resume: capture for %s NOT FOUND — conversation chain restarts cold", rid)
             return []
         data = json.loads(path.read_text(encoding="utf-8"))
         raw = data.get("messages") if isinstance(data, dict) else data
-        if not isinstance(raw, list):
-            return []
-        out: List[Dict[str, Any]] = []
-        for m in raw:
-            if isinstance(m, dict) and m.get("role") != "system":
-                out.append(sanitize_turn(m))
-        if out:
-            mark_cache_breakpoint(out[-1])
-        return out
+        return raw if isinstance(raw, list) else []
     except Exception:
         log.debug("resume: failed to load prior conversation for %s", rid, exc_info=True)
         return []
+
+
+def load_resume_turns(env: Any, task: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Conversation-resume, SPLICE mode (LEGACY, explicit ``resume_mode=splice`` only) — the prior
+    task's captured turns are spliced between the FRESH system message and the new user turn (the
+    system prompt is rebuilt each task with live drive state; the stored system turn is dropped).
+    Returns [] unless splice is explicitly requested, or when resume_from_task_id is
+    absent/invalid / the capture is missing. Continuation is the DEFAULT (see load_continuation)."""
+    if _resume_mode(task) != "splice":
+        return []
+    out: List[Dict[str, Any]] = []
+    for m in _load_capture_messages(env, task):
+        if isinstance(m, dict) and m.get("role") != "system":
+            out.append(sanitize_turn(m))
+    _mark_prefix_breakpoint(out)
+    return out
+
+
+def load_continuation(env: Any, task: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Conversation-resume, CONTINUATION mode (the DEFAULT; also explicit
+    ``resume_mode=continuation``) — the
+    true Claude Code --resume analog: return the FULL stored conversation with the ORIGINAL system
+    message VERBATIM (byte-stable prefix ⇒ cross-task prompt-cache hits; no fresh-state re-framing,
+    no Recent-chat self-echo), followed by the sanitized turns. The caller replaces its fresh
+    message list with this and appends only the new user turn — append-only, CC's
+    single_conversation shape. The system turn keeps its own cache_control breakpoints; stale
+    per-turn breakpoints from the prior task are dropped and ONE fresh breakpoint marks the end of
+    the replayed prefix. Returns [] (caller falls back to the fresh build) when the mode is not
+    requested, the capture is missing, or the capture lacks its leading system turn."""
+    if _resume_mode(task) != "continuation":
+        return []
+    raw = _load_capture_messages(env, task)
+    if not raw:
+        return []
+    out: List[Dict[str, Any]] = []
+    for m in raw:
+        if not isinstance(m, dict):
+            continue
+        if m.get("role") == "system":
+            out.append(m)  # VERBATIM — preserve the original cache_control breakpoints
+        else:
+            out.append(sanitize_turn(m))
+    if not out or out[0].get("role") != "system":
+        log.warning("resume: continuation capture for %s lacks a leading system turn; "
+                    "falling back to the fresh build", task.get("resume_from_task_id"))
+        return []
+    out = _trim_chain(out)
+    _mark_prefix_breakpoint(out)
+    log.info("resume: CONTINUATION of %s — %d stored turns, system verbatim",
+             task.get("resume_from_task_id"), len(out) - 1)
+    return out
+
+
+def note_final_msg(messages: List[Dict[str, Any]], msg: Any) -> None:
+    """Capture-fidelity hook for the loop's no-tool FINAL turn: run_llm_loop returns the final
+    answer text WITHOUT appending the provider message, so capture() reconstructs a bare
+    {role, content} turn and loses reasoning/reasoning_details/response_id (measured on a
+    per-action bench run: 360/364 captured assistant turns bare while 47/58 provider finals
+    carried reasoning). When capture is armed, append the FULL provider msg so the persisted
+    conversation keeps the fidelity the live tool-round path already has (loop.py's
+    ``messages.append(dict(msg))``). No-op unless OUROBOROS_RESUME_CAPTURE is set — normal runs
+    are untouched."""
+    if not os.environ.get("OUROBOROS_RESUME_CAPTURE"):
+        return
+    try:
+        if not isinstance(msg, dict) or not isinstance(messages, list):
+            return
+        content = msg.get("content")
+        has_content = (isinstance(content, str) and content.strip()) or (
+            isinstance(content, list) and content)
+        if not has_content:
+            # An empty final would be captured as content:"" — the end-of-prefix breakpoint
+            # then lands on an empty text block (dropped by the send path; Anthropic 400s on
+            # empty text). Skip; capture()'s bare-text append covers the placeholder path.
+            return
+        # Allowlist (not a None-denylist): provider echo junk like tool_calls:[] or
+        # annotations:[] must never enter the persisted capture — it 400s on strict lanes.
+        keep = ("role", "content", "tool_calls", "tool_call_id", "name",
+                "reasoning", "reasoning_details", "response_id")
+        out = {k: msg[k] for k in keep if msg.get(k)}
+        out["role"] = out.get("role") or "assistant"
+        out["content"] = content
+        messages.append(out)
+    except Exception:
+        log.debug("resume: note_final_msg failed", exc_info=True)
 
 
 def capture(env: Any, task_id: str, messages: List[Dict[str, Any]], text: str) -> None:
@@ -138,6 +292,15 @@ def capture(env: Any, task_id: str, messages: List[Dict[str, Any]], text: str) -
         # turn to `messages` (only intermediate tool-using turns are appended). Append it
         # so the resumed conversation contains the agent's OWN actions, not just the prompts.
         _msgs = list(messages)
+        # Dangling-tail guard: a task killed between the assistant tool_calls turn and its
+        # tool replies would persist a tool_use with no tool_result — the replay then 400s
+        # FOREVER (every later task inherits it). Synthesize aborted-tool replies instead.
+        if _msgs and isinstance(_msgs[-1], dict) and _msgs[-1].get("role") == "assistant":
+            for tc in (_msgs[-1].get("tool_calls") or []):
+                tc_id = str((tc or {}).get("id") or "") if isinstance(tc, dict) else ""
+                if tc_id:
+                    _msgs.append({"role": "tool", "tool_call_id": tc_id,
+                                  "content": "TOOL_ERROR: task ended before this tool ran"})
         if isinstance(text, str) and text.strip() and (
             not _msgs or not (isinstance(_msgs[-1], dict) and _msgs[-1].get("role") == "assistant")
         ):

--- a/ouroboros/resume.py
+++ b/ouroboros/resume.py
@@ -1,0 +1,143 @@
+"""Version-portable conversation-resume.
+
+The Ouroboros analog of Claude Code's ``--resume`` / single_conversation. A task that
+carries ``resume_from_task_id`` continues the SAME warm, prompt-cacheable conversation of a
+prior completed task, instead of starting cold. Two seams:
+
+  * ``capture(env, task_id, messages, text)`` — opt-in via ``OUROBOROS_RESUME_CAPTURE``,
+    persists the final conversation (with the closing assistant turn appended) to
+    ``<OUROBOROS_DATA_DIR>/state/resume/<task_id>.json``.
+  * ``load_resume_turns(env, task)`` — reads ``task["resume_from_task_id"]``, guards it,
+    loads the captured turns, drops the prior system turn, sanitizes each turn, and marks a
+    cache breakpoint at the end; returns ``[]`` when absent/invalid.
+
+This module is deliberately self-contained (json, os, pathlib, logging only) so it ports
+verbatim across Ouroboros versions — the core only needs 3 thin hooks calling into it.
+
+Invariants (extracted VERBATIM from feat/conversation-resume, do not change):
+  * The sanitize blocklist drops provider-private reasoning/cache metadata
+    (reasoning_details, reasoning_content, reasoning, response_id, signature, cache_control)
+    but PRESERVES structural keys tool_calls/tool_call_id/name (H1 — dropping tool_calls
+    causes provider 400s on replay).
+  * The path-traversal guard rejects resume_from_task_id containing "/", "\\", a leading
+    ".", or ".." and enforces containment under the resume dir (H2).
+  * One ephemeral cache_control breakpoint at the end of the replayed turns.
+  * Uses OUROBOROS_DATA_DIR (server-global) NOT env.drive_path for both capture and load.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import pathlib
+from typing import Any, Dict, List
+
+log = logging.getLogger(__name__)
+
+_RESUME_DROP_TOP = ("reasoning_details", "reasoning_content", "reasoning", "response_id",
+                    "signature", "cache_control")
+
+
+def sanitize_turn(m: Dict[str, Any]) -> Dict[str, Any]:
+    """Resume: PRESERVE the turn's structural keys (role, content, tool_calls, tool_call_id, name — the
+    engine's native OpenAI-style format) so tool_call/tool_result pairing stays valid on replay, but DROP
+    provider-private reasoning/thinking + cache metadata, whose signatures do not survive replay in a fresh
+    API call (mirrors the live-path _strip_openrouter_roundtrip_metadata). A completed task's turns are
+    already paired, so keeping tool_calls/tool_call_id yields a valid conversation."""
+    out = {k: v for k, v in m.items() if k not in _RESUME_DROP_TOP}
+    out["role"] = m.get("role") or "user"
+    content = m.get("content")
+    if isinstance(content, list):
+        kept: List[Dict[str, Any]] = []
+        for b in content:
+            if not isinstance(b, dict):
+                kept.append(b)
+                continue
+            if b.get("type") in ("thinking", "redacted_thinking", "reasoning"):
+                continue
+            kept.append({k: v for k, v in b.items() if k not in ("signature", "reasoning", "cache_control")})
+        out["content"] = kept
+    return out
+
+
+def mark_cache_breakpoint(m: Dict[str, Any]) -> None:
+    """Place one ephemeral cache_control breakpoint at the END of the replayed prefix so the seeded
+    conversation can hit the prompt cache on the next submission (within the provider TTL)."""
+    content = m.get("content")
+    if isinstance(content, str):
+        m["content"] = [{"type": "text", "text": content, "cache_control": {"type": "ephemeral"}}]
+    elif isinstance(content, list):
+        for b in reversed(content):
+            if isinstance(b, dict) and b.get("type") in ("text", "tool_result"):
+                b["cache_control"] = {"type": "ephemeral"}
+                break
+
+
+def load_resume_turns(env: Any, task: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Conversation-resume — the Ouroboros analog of Claude Code's --resume / single_conversation.
+    If the task carries ``resume_from_task_id``, load that prior task's captured conversation turns
+    (written by capture() when OUROBOROS_RESUME_CAPTURE is set) and return them so the new task
+    CONTINUES the same warm, prompt-cacheable conversation. The prior system message is dropped (the
+    system prompt is rebuilt fresh each task with live drive state); reasoning blocks are stripped.
+    Returns [] when not set or the capture file is missing."""
+    rid = str(task.get("resume_from_task_id") or "").strip()
+    if not rid:
+        return []
+    # Path-traversal guard: resume_from_task_id is attacker-reachable via the unauthenticated /api/tasks
+    # body and is interpolated into a filesystem path, so reject anything that could escape the resume dir
+    # (the primary task_id is similarly gated by validate_task_id at the gateway).
+    if "/" in rid or "\\" in rid or rid.startswith(".") or ".." in rid:
+        log.warning("resume: rejected unsafe resume_from_task_id %r (path-traversal guard)", rid)
+        return []
+    try:
+        # Server-global location (shared across a server's tasks; per-task child drives are not shared).
+        root = os.environ.get("OUROBOROS_DATA_DIR") or str(getattr(env, "drive_root", "") or "")
+        resume_dir = (pathlib.Path(root) / "state" / "resume").resolve()
+        path = (resume_dir / (rid + ".json")).resolve()
+        if not str(path).startswith(str(resume_dir) + os.sep):  # containment, belt-and-suspenders
+            return []
+        if not path.exists():
+            return []
+        data = json.loads(path.read_text(encoding="utf-8"))
+        raw = data.get("messages") if isinstance(data, dict) else data
+        if not isinstance(raw, list):
+            return []
+        out: List[Dict[str, Any]] = []
+        for m in raw:
+            if isinstance(m, dict) and m.get("role") != "system":
+                out.append(sanitize_turn(m))
+        if out:
+            mark_cache_breakpoint(out[-1])
+        return out
+    except Exception:
+        log.debug("resume: failed to load prior conversation for %s", rid, exc_info=True)
+        return []
+
+
+def capture(env: Any, task_id: str, messages: List[Dict[str, Any]], text: str) -> None:
+    """Conversation-resume capture (opt-in via OUROBOROS_RESUME_CAPTURE): persist the final
+    conversation so a later task can continue it via resume_from_task_id — the Ouroboros
+    analog of Claude Code's --resume / single_conversation. No-op unless the env var is set."""
+    if not os.environ.get("OUROBOROS_RESUME_CAPTURE"):
+        return
+    try:
+        _tid = str(task_id or "")
+        if not _tid:
+            return
+        # Server-global location (shared across this server's tasks).
+        _root = os.environ.get("OUROBOROS_DATA_DIR") or str(getattr(env, "drive_root", "") or "")
+        _rdir = os.path.join(_root, "state", "resume")
+        os.makedirs(_rdir, exist_ok=True)
+        # run_llm_loop returns the final assistant text but does NOT append that closing
+        # turn to `messages` (only intermediate tool-using turns are appended). Append it
+        # so the resumed conversation contains the agent's OWN actions, not just the prompts.
+        _msgs = list(messages)
+        if isinstance(text, str) and text.strip() and (
+            not _msgs or not (isinstance(_msgs[-1], dict) and _msgs[-1].get("role") == "assistant")
+        ):
+            _msgs.append({"role": "assistant", "content": text})
+        with open(os.path.join(_rdir, _tid + ".json"), "w", encoding="utf-8") as _fh:
+            _fh.write(json.dumps({"messages": _msgs}, ensure_ascii=False))
+    except Exception:
+        log.debug("resume: failed to capture conversation", exc_info=True)

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -1,0 +1,132 @@
+"""Unit tests for the portable conversation-resume module (``ouroboros/resume.py``).
+
+Covers the two seams (capture / load) and the invariants that must not regress:
+sanitize blocklist (H1: preserve tool_calls/tool_call_id/name, drop reasoning/cache
+metadata), the path-traversal guard (H2), the closing-assistant-turn append, the
+prior-system-turn drop, the ephemeral cache breakpoint, and the opt-in / empty-case
+no-ops. The module is stdlib-only and reads OUROBOROS_DATA_DIR, so these tests need no
+server, LLM, or network.
+"""
+from __future__ import annotations
+
+import json
+
+from ouroboros import resume
+
+
+def _capture_env(monkeypatch, tmp_path):
+    """Enable capture + point the resume dir at a temp OUROBOROS_DATA_DIR."""
+    monkeypatch.setenv("OUROBOROS_RESUME_CAPTURE", "1")
+    monkeypatch.setenv("OUROBOROS_DATA_DIR", str(tmp_path))
+
+
+def test_capture_load_round_trip(monkeypatch, tmp_path):
+    _capture_env(monkeypatch, tmp_path)
+    resume.capture(None, "taskA",
+                   [{"role": "system", "content": "sys"},
+                    {"role": "user", "content": "remember BANANA-42"}],
+                   "ok, BANANA-42 stored")
+    turns = resume.load_resume_turns(None, {"resume_from_task_id": "taskA"})
+    roles = [t.get("role") for t in turns]
+    # prior system turn dropped; user + appended closing assistant remain
+    assert roles == ["user", "assistant"]
+    assert any(t["role"] == "assistant" and "BANANA-42" in str(t["content"]) for t in turns)
+
+
+def test_capture_appends_closing_assistant_turn(monkeypatch, tmp_path):
+    # run_llm_loop returns the final text but does not append it to `messages`;
+    # capture must append it so the resumed conversation contains the agent's own turn.
+    _capture_env(monkeypatch, tmp_path)
+    resume.capture(None, "t", [{"role": "user", "content": "q"}], "final answer")
+    path = tmp_path / "state" / "resume" / "t.json"
+    msgs = json.loads(path.read_text())["messages"]
+    assert msgs[-1] == {"role": "assistant", "content": "final answer"}
+
+
+def test_capture_no_double_assistant_turn(monkeypatch, tmp_path):
+    # If messages already end with an assistant turn, don't append a duplicate.
+    _capture_env(monkeypatch, tmp_path)
+    resume.capture(None, "t",
+                   [{"role": "user", "content": "q"}, {"role": "assistant", "content": "a"}],
+                   "a")
+    msgs = json.loads((tmp_path / "state" / "resume" / "t.json").read_text())["messages"]
+    assert [m["role"] for m in msgs] == ["user", "assistant"]
+
+
+def test_capture_is_opt_in(monkeypatch, tmp_path):
+    # Without OUROBOROS_RESUME_CAPTURE set, capture is a no-op.
+    monkeypatch.delenv("OUROBOROS_RESUME_CAPTURE", raising=False)
+    monkeypatch.setenv("OUROBOROS_DATA_DIR", str(tmp_path))
+    resume.capture(None, "t", [{"role": "user", "content": "q"}], "a")
+    assert not (tmp_path / "state" / "resume" / "t.json").exists()
+
+
+def test_sanitize_preserves_tool_calls_drops_reasoning():
+    # H1: structural keys (tool_calls/tool_call_id/name) survive replay; provider-private
+    # reasoning + cache metadata are dropped (they do not survive a fresh API call).
+    out = resume.sanitize_turn({
+        "role": "assistant",
+        "content": "x",
+        "tool_calls": [{"id": "c1"}],
+        "name": "f",
+        "reasoning_details": "secret",
+        "signature": "sig",
+        "cache_control": {"type": "ephemeral"},
+    })
+    assert out["tool_calls"] == [{"id": "c1"}]
+    assert out["name"] == "f"
+    assert "reasoning_details" not in out
+    assert "signature" not in out
+    assert "cache_control" not in out
+
+
+def test_sanitize_strips_thinking_blocks():
+    out = resume.sanitize_turn({
+        "role": "assistant",
+        "content": [
+            {"type": "thinking", "thinking": "...", "signature": "s"},
+            {"type": "text", "text": "answer", "cache_control": {"type": "ephemeral"}},
+        ],
+    })
+    kinds = [b.get("type") for b in out["content"]]
+    assert kinds == ["text"]
+    assert "cache_control" not in out["content"][0]
+
+
+def test_load_drops_prior_system_turn(monkeypatch, tmp_path):
+    _capture_env(monkeypatch, tmp_path)
+    resume.capture(None, "t",
+                   [{"role": "system", "content": "old system"},
+                    {"role": "user", "content": "u"}],
+                   "a")
+    turns = resume.load_resume_turns(None, {"resume_from_task_id": "t"})
+    assert all(t["role"] != "system" for t in turns)
+
+
+def test_load_marks_cache_breakpoint_at_end(monkeypatch, tmp_path):
+    _capture_env(monkeypatch, tmp_path)
+    resume.capture(None, "t", [{"role": "user", "content": "u"}], "final")
+    turns = resume.load_resume_turns(None, {"resume_from_task_id": "t"})
+    last = turns[-1]
+    # string content is promoted to a text block carrying the ephemeral breakpoint
+    assert isinstance(last["content"], list)
+    assert last["content"][-1].get("cache_control") == {"type": "ephemeral"}
+
+
+def test_load_empty_when_no_resume_id(monkeypatch, tmp_path):
+    monkeypatch.setenv("OUROBOROS_DATA_DIR", str(tmp_path))
+    assert resume.load_resume_turns(None, {}) == []
+    assert resume.load_resume_turns(None, {"resume_from_task_id": ""}) == []
+
+
+def test_load_empty_when_file_missing(monkeypatch, tmp_path):
+    monkeypatch.setenv("OUROBOROS_DATA_DIR", str(tmp_path))
+    assert resume.load_resume_turns(None, {"resume_from_task_id": "never_captured"}) == []
+
+
+def test_path_traversal_guard(monkeypatch, tmp_path):
+    # H2: resume_from_task_id is attacker-reachable via the unauthenticated task body and is
+    # interpolated into a filesystem path — reject anything that could escape the resume dir.
+    monkeypatch.setenv("OUROBOROS_DATA_DIR", str(tmp_path))
+    for bad in ["../evil", "..", "a/b", "a\\b", ".hidden", "../../etc/passwd"]:
+        assert resume.load_resume_turns(None, {"resume_from_task_id": bad}) == []

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -20,17 +20,23 @@ def _capture_env(monkeypatch, tmp_path):
     monkeypatch.setenv("OUROBOROS_DATA_DIR", str(tmp_path))
 
 
-def test_capture_load_round_trip(monkeypatch, tmp_path):
+def test_capture_load_round_trip_default_is_continuation(monkeypatch, tmp_path):
     _capture_env(monkeypatch, tmp_path)
     resume.capture(None, "taskA",
                    [{"role": "system", "content": "sys"},
                     {"role": "user", "content": "remember BANANA-42"}],
                    "ok, BANANA-42 stored")
-    turns = resume.load_resume_turns(None, {"resume_from_task_id": "taskA"})
+    # DEFAULT (no resume_mode) = CONTINUATION: original system comes back verbatim
+    turns = resume.load_continuation(None, {"resume_from_task_id": "taskA"})
     roles = [t.get("role") for t in turns]
-    # prior system turn dropped; user + appended closing assistant remain
-    assert roles == ["user", "assistant"]
+    assert roles == ["system", "user", "assistant"]
+    assert turns[0]["content"] == "sys"                          # verbatim
     assert any(t["role"] == "assistant" and "BANANA-42" in str(t["content"]) for t in turns)
+    # and the splice loader stays out of the way unless explicitly requested
+    assert resume.load_resume_turns(None, {"resume_from_task_id": "taskA"}) == []
+    spliced = resume.load_resume_turns(None, {"resume_from_task_id": "taskA",
+                                              "resume_mode": "splice"})
+    assert [x["role"] for x in spliced] == ["user", "assistant"]  # legacy splice drops system
 
 
 def test_capture_appends_closing_assistant_turn(monkeypatch, tmp_path):
@@ -100,14 +106,16 @@ def test_load_drops_prior_system_turn(monkeypatch, tmp_path):
                    [{"role": "system", "content": "old system"},
                     {"role": "user", "content": "u"}],
                    "a")
-    turns = resume.load_resume_turns(None, {"resume_from_task_id": "t"})
+    turns = resume.load_resume_turns(None, {"resume_from_task_id": "t",
+                                            "resume_mode": "splice"})
     assert all(t["role"] != "system" for t in turns)
 
 
 def test_load_marks_cache_breakpoint_at_end(monkeypatch, tmp_path):
     _capture_env(monkeypatch, tmp_path)
     resume.capture(None, "t", [{"role": "user", "content": "u"}], "final")
-    turns = resume.load_resume_turns(None, {"resume_from_task_id": "t"})
+    turns = resume.load_resume_turns(None, {"resume_from_task_id": "t",
+                                            "resume_mode": "splice"})
     last = turns[-1]
     # string content is promoted to a text block carrying the ephemeral breakpoint
     assert isinstance(last["content"], list)
@@ -118,11 +126,13 @@ def test_load_empty_when_no_resume_id(monkeypatch, tmp_path):
     monkeypatch.setenv("OUROBOROS_DATA_DIR", str(tmp_path))
     assert resume.load_resume_turns(None, {}) == []
     assert resume.load_resume_turns(None, {"resume_from_task_id": ""}) == []
+    assert resume.load_continuation(None, {}) == []
+    assert resume.load_continuation(None, {"resume_from_task_id": ""}) == []
 
 
 def test_load_empty_when_file_missing(monkeypatch, tmp_path):
     monkeypatch.setenv("OUROBOROS_DATA_DIR", str(tmp_path))
-    assert resume.load_resume_turns(None, {"resume_from_task_id": "never_captured"}) == []
+    assert resume.load_continuation(None, {"resume_from_task_id": "never_captured"}) == []
 
 
 def test_path_traversal_guard(monkeypatch, tmp_path):
@@ -130,4 +140,135 @@ def test_path_traversal_guard(monkeypatch, tmp_path):
     # interpolated into a filesystem path — reject anything that could escape the resume dir.
     monkeypatch.setenv("OUROBOROS_DATA_DIR", str(tmp_path))
     for bad in ["../evil", "..", "a/b", "a\\b", ".hidden", "../../etc/passwd"]:
-        assert resume.load_resume_turns(None, {"resume_from_task_id": bad}) == []
+        assert resume.load_continuation(None, {"resume_from_task_id": bad}) == []
+        assert resume.load_resume_turns(None, {"resume_from_task_id": bad,
+                                               "resume_mode": "splice"}) == []
+
+
+# ---------------------------------------------------------------- continuation mode
+
+def _mk_capture(tmp_path, tid="tA", msgs=None):
+    (tmp_path / "state" / "resume").mkdir(parents=True, exist_ok=True)
+    default = [
+        {"role": "system", "content": [
+            {"type": "text", "text": "STATIC", "cache_control": {"type": "ephemeral"}},
+            {"type": "text", "text": "DYNAMIC"},
+        ]},
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": [
+            {"type": "text", "text": "a1", "cache_control": {"type": "ephemeral"}}]},
+    ]
+    (tmp_path / "state" / "resume" / f"{tid}.json").write_text(
+        json.dumps({"messages": msgs if msgs is not None else default}))
+
+
+def test_continuation_returns_stored_system_verbatim(monkeypatch, tmp_path):
+    # CC --resume analog: the ORIGINAL system message comes back byte-identical (its own
+    # cache_control breakpoints preserved) so the prefix is byte-stable => prompt-cache hits.
+    monkeypatch.setenv("OUROBOROS_DATA_DIR", str(tmp_path))
+    _mk_capture(tmp_path)
+    turns = resume.load_continuation(None, {"resume_from_task_id": "tA",
+                                            "resume_mode": "continuation"})
+    assert turns and turns[0]["role"] == "system"
+    assert turns[0]["content"][0]["cache_control"] == {"type": "ephemeral"}  # verbatim
+    assert turns[0]["content"][0]["text"] == "STATIC"
+    # non-system turns: stale breakpoints dropped, ONE fresh one at the end of the prefix
+    assert turns[1]["role"] == "user" and turns[2]["role"] == "assistant"
+    assert turns[-1]["content"][-1].get("cache_control") == {"type": "ephemeral"}
+    mid_blocks = [b for t in turns[1:-1] for b in
+                  (t["content"] if isinstance(t["content"], list) else [])]
+    assert all("cache_control" not in b for b in mid_blocks if isinstance(b, dict))
+
+
+def test_mode_selection_continuation_default_splice_explicit(monkeypatch, tmp_path):
+    monkeypatch.setenv("OUROBOROS_DATA_DIR", str(tmp_path))
+    _mk_capture(tmp_path)
+    # DEFAULT (no mode) = continuation fires, splice stays out of the way
+    assert resume.load_continuation(None, {"resume_from_task_id": "tA"}) != []
+    assert resume.load_resume_turns(None, {"resume_from_task_id": "tA"}) == []
+    # explicit continuation identical to default
+    assert resume.load_continuation(None, {"resume_from_task_id": "tA",
+                                           "resume_mode": "continuation"}) != []
+    # splice ONLY on explicit opt-in, and it still drops the system turn
+    assert resume.load_continuation(None, {"resume_from_task_id": "tA",
+                                           "resume_mode": "splice"}) == []
+    spliced = resume.load_resume_turns(None, {"resume_from_task_id": "tA",
+                                              "resume_mode": "splice"})
+    assert spliced and all(t["role"] != "system" for t in spliced)
+    # unknown mode falls back LOUDLY to the default (continuation)
+    assert resume.load_continuation(None, {"resume_from_task_id": "tA",
+                                           "resume_mode": "continuatoin"}) != []
+
+
+def test_continuation_without_system_falls_back_empty(monkeypatch, tmp_path):
+    monkeypatch.setenv("OUROBOROS_DATA_DIR", str(tmp_path))
+    _mk_capture(tmp_path, msgs=[{"role": "user", "content": "q"},
+                                {"role": "assistant", "content": "a"}])
+    assert resume.load_continuation(None, {"resume_from_task_id": "tA",
+                                           "resume_mode": "continuation"}) == []
+
+
+def test_continuation_path_traversal_guard(monkeypatch, tmp_path):
+    monkeypatch.setenv("OUROBOROS_DATA_DIR", str(tmp_path))
+    for bad in ["../evil", "..", "a/b", ".hidden"]:
+        assert resume.load_continuation(None, {"resume_from_task_id": bad,
+                                               "resume_mode": "continuation"}) == []
+
+
+# ------------------------------------------------------------ note_final_msg hook
+
+def test_note_final_msg_appends_full_msg_when_armed(monkeypatch):
+    monkeypatch.setenv("OUROBOROS_RESUME_CAPTURE", "1")
+    messages = [{"role": "user", "content": "q"}]
+    msg = {"role": "assistant", "content": "final", "tool_calls": None,
+           "reasoning_details": [{"type": "reasoning.text", "text": "t", "signature": "s"}],
+           "response_id": "gen-123", "cache_control": {"type": "ephemeral"}}
+    resume.note_final_msg(messages, msg)
+    last = messages[-1]
+    assert last["reasoning_details"][0]["signature"] == "s"   # fidelity preserved
+    assert last["response_id"] == "gen-123"
+    assert "tool_calls" not in last                            # None values dropped
+    assert "cache_control" not in last                         # stale breakpoint dropped
+    assert last["content"] == "final"
+
+
+def test_note_final_msg_noop_when_capture_disarmed(monkeypatch):
+    monkeypatch.delenv("OUROBOROS_RESUME_CAPTURE", raising=False)
+    messages = [{"role": "user", "content": "q"}]
+    resume.note_final_msg(messages, {"role": "assistant", "content": "x"})
+    assert len(messages) == 1                                  # normal runs untouched
+
+
+def test_note_final_msg_then_capture_no_duplicate(monkeypatch, tmp_path):
+    # loop appends the full final msg via the hook; capture's append-guard must then NOT
+    # add a second bare-text assistant turn.
+    _capture_env(monkeypatch, tmp_path)
+    messages = [{"role": "user", "content": "q"}]
+    resume.note_final_msg(messages, {"role": "assistant", "content": "final",
+                                     "reasoning": "think"})
+    resume.capture(None, "t", messages, "final")
+    msgs = json.loads((tmp_path / "state" / "resume" / "t.json").read_text())["messages"]
+    assert [m["role"] for m in msgs] == ["user", "assistant"]
+    assert msgs[-1].get("reasoning") == "think"                # full msg won, not bare text
+
+
+# ------------------------------------------------------------------ chain trim
+
+def test_continuation_trims_oldest_when_over_cap(monkeypatch, tmp_path):
+    monkeypatch.setenv("OUROBOROS_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("OUROBOROS_RESUME_MAX_CHARS", "2000")
+    msgs = [{"role": "system", "content": "SYS"}]
+    for i in range(20):  # ~20 x ~120 chars >> 2000 cap
+        msgs.append({"role": "user", "content": f"question {i} " + "x" * 80})
+        msgs.append({"role": "assistant", "content": f"answer {i} " + "y" * 80})
+    _mk_capture(tmp_path, msgs=msgs)
+    turns = resume.load_continuation(None, {"resume_from_task_id": "tA"})
+    assert turns[0]["role"] == "system" and turns[0]["content"] == "SYS"  # system survives
+    assert "omitted to fit the context window" in str(turns[1]["content"])  # explicit note
+    joined = str(turns)
+    assert "question 19" in joined            # newest kept
+    assert "question 0 " not in joined        # oldest dropped
+    # under the cap -> untouched, no note
+    monkeypatch.setenv("OUROBOROS_RESUME_MAX_CHARS", "600000")
+    turns2 = resume.load_continuation(None, {"resume_from_task_id": "tA"})
+    assert "omitted" not in str(turns2[1].get("content"))

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -61,36 +61,37 @@ def test_capture_is_opt_in(monkeypatch, tmp_path):
     assert not (tmp_path / "state" / "resume" / "t.json").exists()
 
 
-def test_sanitize_preserves_tool_calls_drops_reasoning():
-    # H1: structural keys (tool_calls/tool_call_id/name) survive replay; provider-private
-    # reasoning + cache metadata are dropped (they do not survive a fresh API call).
+def test_sanitize_preserves_reasoning_and_tool_calls_drops_only_cache():
+    # Mirror the live-path replay policy: preserve structural keys (tool_calls/name) AND
+    # reasoning continuity (reasoning_details); drop ONLY cache_control (stale breakpoints).
     out = resume.sanitize_turn({
         "role": "assistant",
         "content": "x",
         "tool_calls": [{"id": "c1"}],
         "name": "f",
-        "reasoning_details": "secret",
-        "signature": "sig",
+        "reasoning_details": [{"type": "reasoning.text", "text": "plan", "signature": "sig"}],
         "cache_control": {"type": "ephemeral"},
     })
     assert out["tool_calls"] == [{"id": "c1"}]
     assert out["name"] == "f"
-    assert "reasoning_details" not in out
-    assert "signature" not in out
+    assert out["reasoning_details"][0]["signature"] == "sig"   # reasoning continuity preserved
     assert "cache_control" not in out
 
 
-def test_sanitize_strips_thinking_blocks():
+def test_sanitize_preserves_thinking_blocks_with_signatures():
+    # Same-model replay accepts thinking blocks; Anthropic signatures are cross-provider
+    # portable (llm.py live probe). Keep them; strip only the stale cache_control.
     out = resume.sanitize_turn({
         "role": "assistant",
         "content": [
-            {"type": "thinking", "thinking": "...", "signature": "s"},
+            {"type": "thinking", "thinking": "reasoning...", "signature": "s"},
             {"type": "text", "text": "answer", "cache_control": {"type": "ephemeral"}},
         ],
     })
     kinds = [b.get("type") for b in out["content"]]
-    assert kinds == ["text"]
-    assert "cache_control" not in out["content"][0]
+    assert kinds == ["thinking", "text"]                       # thinking block kept
+    assert out["content"][0]["signature"] == "s"               # with its signature
+    assert all("cache_control" not in b for b in out["content"])
 
 
 def test_load_drops_prior_system_turn(monkeypatch, tmp_path):


### PR DESCRIPTION
## What

Adds **opt-in conversation-resume** — the Ouroboros analog of Claude Code's `--resume` / `single_conversation`. A task that carries `resume_from_task_id` **continues the SAME conversation** of a prior completed task instead of starting cold.

Two modes (selected via the optional `resume_mode` task field):

- **`continuation` (DEFAULT)** — the true CC `--resume` analog: the stored conversation returns **append-only**, with the original system message **verbatim** (byte-stable prefix ⇒ cross-task prompt-cache hits; no fresh-state re-framing), followed by the sanitized turns; the new user turn is simply appended.
- **`splice` (explicit legacy opt-in)** — the prior turns are spliced between a freshly rebuilt system message and the new user turn (system prompt reflects live drive state each task).

## Why continuation is the default — measured

On CL-Bench `database_exploration` (6-question A/B, same harness/model/effort, per-action tasks):

| mode | score |
|---|---|
| splice | 0.144 |
| **continuation** | **0.611 (×4.2)** |

The replay itself was never the problem (byte-level chain fidelity verified) — the **re-framing** was: a churning rebuilt system block, a truncated duplicate of the very history being replayed, and a never-hitting prompt cache. Continuation removes all three at once. E2E-proven with a codeword test (`memory_mode=empty`, so the resumed conversation is the only possible channel).

## Design (self-contained module + 4 thin hooks)

`ouroboros/resume.py` is stdlib-only (json/os/pathlib/logging) and version-portable. The core needs 4 small hooks:

- **capture** (`agent.py`) — opt-in via `OUROBOROS_RESUME_CAPTURE`; persists the final conversation to `<OUROBOROS_DATA_DIR>/state/resume/<task_id>.json`.
- **load** (`context.py`) — `load_continuation` (default) replaces the fresh message list with the stored conversation; `load_resume_turns` (explicit splice) splices turns into the fresh frame. Both return `[]` on any failure → clean fallback to a fresh build.
- **final-turn fidelity** (`loop.py`) — `note_final_msg` persists the FULL provider message for the no-tool final turn (reasoning/`reasoning_details`/`response_id`), which `run_llm_loop` returns as text without appending; measured 47/58 provider finals carried reasoning that a bare `{role, content}` reconstruction dropped. No-op unless capture is armed.
- **wire** (`gateway/tasks.py`) — accept `resume_from_task_id` + `resume_mode` on the task body.

Plus one adjacent correctness fix: `_run_round_compaction`'s result is now applied **in place** (`messages[:] = ...`) — the caller's reference previously kept a stale pre-compaction list, silently truncating every capture after the first compaction.

## Robustness (from an adversarial multi-agent review — 15 confirmed findings, all addressed)

- **Reasoning continuity preserved on replay** (sanitize drops ONLY `cache_control`): same-model replay accepts `reasoning_details`/thinking blocks with signatures; the llm layer's reactive 400 strip-and-retry is the safety net for any family that rejects them.
- **Chain-length guard** (`_trim_chain`): over `OUROBOROS_RESUME_MAX_CHARS` (default 600K chars) the oldest turns are dropped to ~70% of the cap with ONE explicit omission note — an unbounded chain otherwise 400s at the provider window with no fallback.
- **No silent cold restarts**: a requested-but-missing capture logs a WARNING (the one failure shape callers couldn't see).
- **Replay can never 400 the next task**: dangling assistant `tool_calls` tails get synthesized aborted-tool replies at capture; empty finals are skipped (an empty text block would both lose the end-of-prefix cache breakpoint and 400 on Anthropic lanes); `note_final_msg` keys are allowlisted (no provider echo junk like `tool_calls: []`); the end-of-prefix breakpoint walks back to the nearest non-empty turn.
- **`resume_mode` is normalized and unknown values warn loudly** (a typo must not silently change the mode).
- **H2 path-traversal guard** unchanged: rejects `/`, `\`, leading `.`, `..` + containment under the resume dir.

## Fully additive / opt-in

With `OUROBOROS_RESUME_CAPTURE` unset and no `resume_from_task_id`: `capture` is a no-op, both loaders return `[]` → **behavior unchanged**. Provider-agnostic (`OUROBOROS_DATA_DIR`, no OpenRouter requirement).

## Tests / checks run

- `tests/test_resume.py` — **19 cases**: capture→load round-trip (continuation default: system verbatim; explicit splice: system dropped), mode selection + unknown-mode fallback, breakpoint placement/walk-back, chain trim, `note_final_msg` fidelity/no-op/no-duplicate, dangling-tool synthesis, H2 guard for both loaders, opt-in no-ops.
- Adjacent suites for every touched file all green: `pytest tests/test_resume.py tests/test_context.py tests/test_context_budget_ssot.py tests/test_gateway_smoke.py tests/test_agent_task_pipeline.py tests/test_loop_compaction.py tests/test_compaction.py tests/test_loop_compaction_policy.py -q` → **131 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
