### PR TITLE
fix(chat): keep the background-consciousness live card expanded and its timeline scroll stable

### DIFF
--- a/web/modules/chat.js
+++ b/web/modules/chat.js
@@ -1194,9 +1194,26 @@ export function createChatInstance({
         `;
     }
 
+    // True when the timeline scroll sits at (or within a hair of) the bottom, or
+    // has not started overflowing yet. Drives whether live appends and rebuilds
+    // keep following the newest line or leave the owner where they scrolled to.
+    function isTimelinePinnedToBottom(record) {
+        const el = record?.timelineEl;
+        if (!el) return true;
+        return el.scrollHeight - el.scrollTop - el.clientHeight <= 24;
+    }
+
     // Full rebuild for initial render and expand/collapse toggles.
     function renderLiveCardTimeline(record) {
-        record.timelineEl.innerHTML = record.items.map((item) => buildTimelineItemHtml(item, record)).join('');
+        const el = record.timelineEl;
+        // Assigning innerHTML resets scrollTop to 0, which jerks the list to the
+        // top mid-read (toggling a line, fetched full output, patch fallbacks).
+        // Keep the owner's place: re-pin to the bottom if they were following the
+        // newest line, otherwise restore their prior offset.
+        const pinned = isTimelinePinnedToBottom(record);
+        const prevTop = el.scrollTop;
+        el.innerHTML = record.items.map((item) => buildTimelineItemHtml(item, record)).join('');
+        el.scrollTop = pinned ? el.scrollHeight : prevTop;
     }
 
     // P3: fetch the genuinely-full output for a server-truncated timeline line (the WS
@@ -1230,12 +1247,16 @@ export function createChatInstance({
 
     // Append without disturbing existing DOM nodes.
     function appendTimelineItem(item, record) {
+        // Capture BEFORE the DOM grows: only chase the newest line when the owner
+        // was already at the bottom. If they scrolled up to read (common now that
+        // the background card stays expanded across cycles), leave them put.
+        const pinned = isTimelinePinnedToBottom(record);
         const wrapper = document.createElement('div');
         wrapper.innerHTML = buildTimelineItemHtml(item, record).trim();
         const node = wrapper.firstElementChild;
         if (node) {
             record.timelineEl.appendChild(node);
-            if (record.root.dataset.expanded === '1') {
+            if (record.root.dataset.expanded === '1' && pinned) {
                 record.timelineEl.scrollTop = record.timelineEl.scrollHeight;
             }
         }

--- a/web/modules/chat.js
+++ b/web/modules/chat.js
@@ -343,6 +343,12 @@ export function createChatInstance({
     let historySyncPromise = null;
     let welcomeShown = false;
     const liveCardRecords = new Map();
+    // Reusable slots (bg-consciousness, active) destroy+recreate their card on every
+    // new cycle and auto-collapse on each cycle finish. That wipes an expand the owner
+    // just did within a second (the background-consciousness card cycles constantly).
+    // Remember the owner's explicit expand PER SLOT so a cycle finish or the next
+    // cycle's rebuild restores it instead of snapping shut.
+    const stickyExpandedSlots = new Set();
     // Cluster B: a proactively-coined name (task_named) can arrive BEFORE the card's
     // liveCardRecords entry exists (the namer broadcasts as the task starts). Buffer it
     // here so createLiveCardRecord can apply it when the card appears (no lost title).
@@ -837,7 +843,7 @@ export function createChatInstance({
             root.dataset.subagentRole = String(options.role || '');
         }
         root.dataset.finished = '0';
-        root.dataset.expanded = (options.isSubagent && nestedSubagentsExpanded) ? '1' : '0';
+        root.dataset.expanded = ((options.isSubagent && nestedSubagentsExpanded) || stickyExpandedSlots.has(normalizedGroupId)) ? '1' : '0';
         // No "Turn into project" for: subagent cards, non-main panels, or a task that
         // is ALREADY bound to a project (a project-chat follow-up) — see task_bindings
         // from /api/state, surfaced on window.__ouroTaskBindings (P2).
@@ -901,7 +907,14 @@ export function createChatInstance({
         };
         if (isMain && !options.isSubagent) _pendingCardObjective = '';
         record.summaryButtonEl?.addEventListener('click', () => {
-            setLiveCardExpanded(record, record.root.dataset.expanded !== '1');
+            const nowExpanded = record.root.dataset.expanded !== '1';
+            setLiveCardExpanded(record, nowExpanded);
+            // Persist the owner's explicit choice for reusable slots so the constant
+            // cycle churn (finish auto-collapse + next-cycle rebuild) doesn't undo it.
+            if (REUSABLE_TASK_IDS.has(record.groupId)) {
+                if (nowExpanded) stickyExpandedSlots.add(record.groupId);
+                else stickyExpandedSlots.delete(record.groupId);
+            }
         });
         record.turnProjectBtn?.addEventListener('click', (event) => {
             event.stopPropagation();
@@ -1026,7 +1039,7 @@ export function createChatInstance({
         record.timelineEl.innerHTML = '';
         record.root.dataset.finished = '0';
         setLiveCardTypingVisible(record, true);
-        setLiveCardExpanded(record, record.isSubagent && nestedSubagentsExpanded);
+        setLiveCardExpanded(record, (record.isSubagent && nestedSubagentsExpanded) || stickyExpandedSlots.has(record.groupId));
     }
 
     function ensureLiveCardVisible(record, { suppressDomInsert = false } = {}) {
@@ -1392,7 +1405,9 @@ export function createChatInstance({
             setLiveCardTypingVisible(record, false);
             markTaskComplete(nextGroupId, summary.phase || 'done');
             if (justFinished) {
-                setLiveCardExpanded(record, record.isSubagent && nestedSubagentsExpanded);
+                if (!stickyExpandedSlots.has(record.groupId)) {
+                    setLiveCardExpanded(record, record.isSubagent && nestedSubagentsExpanded);
+                }
                 scheduleHistorySync();
             }
             syncLiveCardToggle(record);
@@ -1427,7 +1442,9 @@ export function createChatInstance({
         setLiveCardTypingVisible(record, false);
         markTaskComplete(record.groupId, activePhase);
         if (!wasFinished) {
-            setLiveCardExpanded(record, record.isSubagent && nestedSubagentsExpanded);
+            if (!stickyExpandedSlots.has(record.groupId)) {
+                setLiveCardExpanded(record, record.isSubagent && nestedSubagentsExpanded);
+            }
             scheduleHistorySync();
         }
         syncLiveCardToggle(record);


### PR DESCRIPTION
> **Draft** — still being finished.

## Problem

The always-on **background-consciousness** live card (`task_id = bg-consciousness`) sits at the bottom of the main chat and cycles constantly. Two related UX bugs:

1. **Expanding it snapped shut within ~1s.** Reusable slots destroy and recreate their live card on every new cycle *and* auto-collapse on each cycle finish, so an owner's manual expand was wiped almost immediately.
2. **The expanded timeline jerked to the top / lost the reading position.** Once the card stayed open, its scrollable timeline (`.chat-live-timeline`, `max-height: 420px; overflow-y: auto`) kept resetting.

## Fix (2 commits)

**1. `stickyExpandedSlots` — keep reusable cards expanded.** Persist the owner's *explicit* expand per reusable slot (set on the summary-button toggle, cleared when they collapse again). The finish auto-collapse skips sticky slots, and both card-creation entry points restore the expanded state. Scope limited to reusable slots (`bg-consciousness`, `active`); one-shot task cards and subagent expand are unchanged.

**2. Sticky-bottom timeline.** Adopt the main transcript's scroll rule. `isTimelinePinnedToBottom` reports whether the owner is at/near the bottom (or the list has not overflowed). Appends only chase the newest line when already pinned; full rebuilds re-pin to bottom when pinned, otherwise restore the prior `scrollTop`.

## Verification

- Frontend-only, vanilla ES modules — no build step; static assets served with `Cache-Control: no-cache`, so a browser refresh suffices (no service restart).
- `node --check web/modules/chat.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)