### PR TITLE
docs(benchmarks/continual_learning): v6.71.1 validated baseline + operations runbook

### DIFF
--- a/devtools/benchmarks/continual_learning/METHODOLOGY.md
+++ b/devtools/benchmarks/continual_learning/METHODOLOGY.md
@@ -167,11 +167,11 @@ exclusion; any published number must say so.
 
 ## 7. Honest limits
 
-- **No leaderboard comparability claims.** Our runs to date are 1-seed,
-  DB-domain-only → `report_grade=local_low_seed`. A ranked submission needs
-  all 6 domains (two of them are Docker-in-Docker harnesses not yet
-  integrated), 5 rollouts + 1 baseline per task via the runner's `run-all`,
-  and the official analysis scripts.
+- **No leaderboard comparability claims yet.** The v6.71.1 campaign (§9)
+  produced the first submission-shaped artifact — all 6 domains, own
+  stateless baselines, `run-all --name` layout — but at 1 seed
+  (`report_grade=local_low_seed`). A ranked submission needs the default
+  5-rollout schedules and the official analysis scripts.
 - **The CC reference numbers** (DB baseline 0.205 / rollout 0.551,
   claude-sonnet-4.6) come from the published leaderboard artifacts embedded in
   the adapter; same-model same-protocol, but our 1-seed edge over them
@@ -189,3 +189,37 @@ v6.52.2 @ `a36e949`, adapter @ `56764d6`, bridge path, DB domain, 40q +
 schema_drift, 1 seed. Results: S46 baseline 0.243 / rollout **0.608** (CC ref
 0.551), S5 0.235 / 0.453; total cost $98 for both arms×both models. Failure
 analysis: §5.
+
+## 9. v6.71.1 full-suite validated baseline (2026-07-20)
+
+First full 6-domain campaign with own stateless baselines in the official
+`run-all --name` submission layout (bundle `clbench-671-full-2026-07-21`):
+Ouroboros v6.71.1 stack, adapter @ `3ec3761`, claude-sonnet-4.6, effort low,
+review gate required+blocking with `max_improvement_passes=1`, question-scope,
+1 seed, ~$530, ~7h wall-clock, <1% instance loss.
+
+Raw rewards (rollout / own baseline / gain):
+
+| Domain | Rollout | Baseline | Gain |
+|---|---|---|---|
+| database_exploration | 0.4917 | 0.1933 | +0.298 |
+| codebase_adaptation | 0.7289 | 0.3197 | +0.409 |
+| black_scholes (bsm) | 0.3453 | 0.2196 | +0.126 |
+| sales_analytics | 0.7286 | 0.4086 | +0.320 |
+| exploitable_poker | 2.0442 | 1.5233 | +0.521 |
+| cohort_studies | −0.0180 | −0.0093 | −0.009 |
+
+Normalized against the fixed leaderboard baseline, 6-domain average **+0.259**
+(published top-1 +0.196 after the cohort metric fix of
+pgasawa/continual-learning-bench#9; Claude Code sonnet-4.6 +0.185). 1 seed —
+suggestive, not significant. Three lost instances (one VM-OOM class, see
+RUNBOOK) cost ≈0.013 of the 6-domain average.
+
+**Review-mode ablation** (pinned 1 pass vs unbounded convergence, same seed):
+codebase — pin wins decisively (unbounded is 2.6× the cost and burns the full
+per-issue step budget on doomed issues, since the reviewer keeps demanding
+fixes the agent cannot land within budget); database — unbounded very slightly
+better AND cheaper (oracle-less domain, review converges fast); cohort arm was
+lost to a host reboot (inconclusive). Verdict: **pin 1 pass** for multi-seed
+campaigns. We deliberately do NOT inject the bench's remaining-step counter
+into the agent (Claude Code parity — reference systems don't see it either).

--- a/devtools/benchmarks/continual_learning/METHODOLOGY.md
+++ b/devtools/benchmarks/continual_learning/METHODOLOGY.md
@@ -57,7 +57,8 @@ own steps.
 
 `run_clb.py` (this dir) → external runner (`run_benchmark.py` standard path,
 or the `run_clbench_bridge_agent` whole-question bridge that produced the
-reference full40 numbers) → in-runner Ouroboros adapter (pinned `56764d6`) →
+reference full40 numbers) → in-runner Ouroboros adapter (`56764d6` for the
+§8 reference run; the v6.71.1 campaign pinned `3ec3761` — see README) →
 isolated Ouroboros server (throwaway sub-clone of a dedicated bench clone),
 agent in Docker on the docker path (leak-proof: the task + DB stay host-side;
 the agent reaches data only through counted QUERY actions).
@@ -73,10 +74,13 @@ the agent reaches data only through counted QUERY actions).
 
 ## 4. Scaffold disclosures (ours)
 
-- **`OUROBOROS_MAX_WORKERS=4` is a WITHIN-task subagent pool**, not cross-task
-  parallelism. Cross-task order stays strictly sequential (`--instance-workers
-  1` enforced by the launcher; opt-out only for the independent stateless
-  baseline arm). Recorded in the manifest under `strict_sequential`.
+- **`OUROBOROS_MAX_WORKERS` is a WITHIN-task subagent pool**, not cross-task
+  parallelism: `4` in the 2026-07-01 reference run (§8), `3` validated at
+  scale by the v6.71.1 campaign (larger pools OOM the Docker VM — sizing
+  formula and failure signature in `RUNBOOK.md`). Cross-task order stays
+  strictly sequential (`--instance-workers 1` enforced by the launcher;
+  opt-out only for the independent stateless baseline arm). Recorded in the
+  manifest under `strict_sequential`.
 - **Safety mode `light`** (bench-template decision; see §6 fidelity).
 - **Single-model:** every model slot (main/heavy/light/fallback/review/scope)
   pinned to the solve model — no silent spend on stronger reviewers.
@@ -204,8 +208,8 @@ Raw rewards (rollout / own baseline / gain):
 |---|---|---|---|
 | database_exploration | 0.4917 | 0.1933 | +0.298 |
 | codebase_adaptation | 0.7289 | 0.3197 | +0.409 |
-| black_scholes (bsm) | 0.3453 | 0.2196 | +0.126 |
-| sales_analytics | 0.7286 | 0.4086 | +0.320 |
+| blind_spectrum_monitoring (bsm) | 0.3453 | 0.2196 | +0.126 |
+| sales_prediction | 0.7286 | 0.4086 | +0.320 |
 | exploitable_poker | 2.0442 | 1.5233 | +0.521 |
 | cohort_studies | −0.0180 | −0.0093 | −0.009 |
 

--- a/devtools/benchmarks/continual_learning/README.md
+++ b/devtools/benchmarks/continual_learning/README.md
@@ -11,6 +11,9 @@ agent with memory ON, evolution OFF by default.
 
 See `METHODOLOGY.md` for what the benchmark measures, official scoring, our
 scaffold disclosures, the known failure taxonomy, and honest limits.
+See `RUNBOOK.md` for the field-tested at-scale operating recipe (VM memory
+sizing, mandatory companion daemons, one-seed vs leaderboard-submission flow,
+known loss classes).
 
 ## External runner REQUIRED (not vendored)
 
@@ -24,9 +27,13 @@ separately:
   `scripts/generate_leaderboard.py`).
 - The **Ouroboros adapter** is the `src/systems/ouroboros/` subtree of that
   repo (`system.py`, `_launcher.py`, `_docker_launcher.py`,
-  `run_clbench_bridge_agent.py`, `clbench_step_shim.py`). The reference run
-  pinned it at commit `56764d6`; a full copy ships in the run handoff bundle
-  (`clbench-db-40q-2026-07-01.tar.gz`, under
+  `run_clbench_bridge_agent.py`, `clbench_step_shim.py`). The v6.71.1
+  reference campaign pinned it at commit `3ec3761` (adds a network-outage
+  hold that pauses the scope clock instead of forfeiting questions, a
+  format-repair round that re-emits a prose-final answer as typed JSON in the
+  same container, an `OUROBOROS_REVIEW_MAX_PASSES` override, and
+  extra-overrides passthrough); a full copy ships in the run handoff bundle
+  (`clbench-671-full-2026-07-21.tar.gz`, under
   `bench-config/external-adapters/ouroboros/`) together with the adapter's own
   METHODOLOGY. If the adapter is missing from your checkout, restore it from
   that bundle.
@@ -59,10 +66,13 @@ Two separate knobs, deliberately kept apart:
    baseline* arm — each parallel worker boots its own container, so watch
    disk: the runner's default schedules carry `max_workers: 12` and that has
    filled a disk before).
-2. **`OUROBOROS_MAX_WORKERS=4`** (settings template) is the agent's *internal*
-   worker pool — subagent decomposition WITHIN one task. It does not (and must
-   not) create cross-task parallelism; it is disclosed as a scaffold parameter
-   in the manifest.
+2. **`max_workers` (settings template)** is the agent's *internal* worker
+   pool — subagent decomposition WITHIN one task. It does not (and must not)
+   create cross-task parallelism; it is disclosed as a scaffold parameter in
+   the manifest. The validated at-scale value is **3** (not the earlier
+   template's 4/10): pool size drives engine-container RSS, and larger pools
+   OOM the Docker VM when several containers run concurrently — see
+   `RUNBOOK.md` for the sizing formula and the failure signature.
 
 ## Launch
 

--- a/devtools/benchmarks/continual_learning/README.md
+++ b/devtools/benchmarks/continual_learning/README.md
@@ -40,7 +40,9 @@ separately:
 - The adapter needs a **dedicated Ouroboros clone** (`--ouroboros-clone`,
   never the live repo) whose `devtools/benchmarks/common/server_runner.py` it
   imports, plus (docker path) the `clbench-ouroboros:dev` image and the
-  runner-side `clbench_skill/clbench_remote` skill source.
+  runner-side `clbench_skill/remote_work` skill source (renamed from
+  `clbench_remote` 2026-07-09 — bench-identifying tells stripped from the
+  agent-visible surface; same tools get_observation/submit_action).
 - Run under a Python that has the runner's deps (litellm/pydantic/...) AND the
   Ouroboros deps; the launcher defaults to `<runner>/.venv/bin/python` when it
   exists.

--- a/devtools/benchmarks/continual_learning/RUNBOOK.md
+++ b/devtools/benchmarks/continual_learning/RUNBOOK.md
@@ -54,7 +54,8 @@ Both ship in the run handoff bundle (`bench-config/`).
   scores from `final_results`, public implementation link, eval date, Discord pre-contact.
   Two gotchas: the leaderboard scripts hard-code known run names (`DEFAULT_RUN_NAMES` /
   `SYSTEM_DEFS`) — ask maintainers to add yours in the submission PR; and cohort_studies
-  reference data mixes two reward metrics until pgasawa/continual-learning-bench#9 lands.
+  reference data mixed two reward metrics before pgasawa/continual-learning-bench#9
+  (merged 2026-07-19) — score against a leaderboard checkout that includes it.
 
 ## Known loss classes and their closures
 

--- a/devtools/benchmarks/continual_learning/RUNBOOK.md
+++ b/devtools/benchmarks/continual_learning/RUNBOOK.md
@@ -1,0 +1,65 @@
+# CL-Bench operations runbook — validated v6.71 recipe (one seed → 5-seed leaderboard submission)
+
+Field-tested configuration and operational hazards from the 2026-07-20 full 1-seed campaign
+(all 6 domains + own stateless baselines, run-all artifact, <1% instance loss). Complements
+`README.md` (launcher surface) and `METHODOLOGY.md` (what the bench measures + results).
+
+## Validated configuration
+
+- Model `openrouter/anthropic/claude-sonnet-4.6`, **effort low pinned uniformly** across every
+  engine task type (engine defaults drift between releases — v6.71 flipped review effort to
+  high; pin them all).
+- Review gate `OUROBOROS_TASK_REVIEW_MODE=required` + `OUROBOROS_REVIEW_ENFORCEMENT=blocking`
+  with **`max_improvement_passes` pinned to 1** (adapter does this automatically; see the
+  review-mode ablation in METHODOLOGY — unbounded convergence is 2.6× the cost for no measured
+  gain on the toolchain-oracle domain, and burns the full per-issue step budget on doomed issues).
+- **`max_workers: 3` in system-params — mandatory at scale.** Worker pool size drives engine
+  container RSS: 10 workers ≈ 0.8GB/container, 3 workers ≈ 0.35GB. Capacity formula:
+  `concurrent_containers × per-container-RSS ≤ 0.8 × Docker-VM memory limit`
+  (`docker info | grep "Total Memory"`). Violation symptom: tasks die `terminal (failed)` with
+  `worker process crashed (signal 9)` **visible only in the runroot's `task_results/*.json`,
+  not in bridge logs** — the VM's OOM reaper kills workers silently.
+- `OUROBOROS_TRANSIENT_RETRY_MAX=12` (engine-side provider-blip patience) and the bridge's
+  network-outage hold `OUROBOROS_NET_OUTAGE_HOLD_SEC=21600` (submits wait for connectivity;
+  in-flight questions pause their scope clock instead of forfeiting). Together they survive
+  short blips and multi-hour outages.
+- `OUROBOROS_TOTAL_BUDGET=200` per domain-seed (measured 1-seed domain costs:
+  poker $117 · bsm $60 · cohort $58 · code $33 · sales $26 · db $25 — a $60 cap silently
+  truncates poker mid-rollout).
+- Runner parallelism `--task-parallelism 5 --per-task-parallelism 2`: rollout phases hold ONE
+  container per domain, so all six domains can run concurrently; only stateless-baseline
+  workers multiply containers. One full seed ≈ $530 / ~7h wall-clock.
+
+## Mandatory companion daemons
+
+1. **clone-sweeper** — every baseline instance boots a fresh container whose runroot carries a
+   full git clone of the engine (~44MB). 300+ instances/seed ≈ 15GB of clones. Sweep `clone/`
+   from runroots whose `data/` has been idle >15 min (live containers write continuously).
+2. **container-reaper** — baseline pool workers can exit without stopping their container;
+   zombies accumulate and exhaust the VM (the OOM path above). Every ~3 min stop any
+   `clbench-obo-<pid>-*` container whose owner pid is dead.
+
+Both ship in the run handoff bundle (`bench-config/`).
+
+## One seed vs submission
+
+- **Smoke first** (~$3–5): db domain, `--task.schedule smoke --task.num-questions 3`, baseline
+  skipped. Confirms clone → image → container → bridge → typed final-answer delivery.
+- **One seed**: `run-all --name <name> --runs 1` → `final_results/runs/<name>/` (the same
+  artifact layout the leaderboard consumes; includes own baselines → mean gain).
+- **Submission** (per continual-learning-bench.com/docs/submitting): `run-all --name <name>`
+  WITHOUT `--runs` (default schedules = 5 rollouts/task), recovery via `--missing-only`
+  (task-granular; keep `--system-params` byte-identical between resume invocations).
+  PR checklist: system name + description, model (provider+version), mean gain + per-task
+  scores from `final_results`, public implementation link, eval date, Discord pre-contact.
+  Two gotchas: the leaderboard scripts hard-code known run names (`DEFAULT_RUN_NAMES` /
+  `SYSTEM_DEFS`) — ask maintainers to add yours in the submission PR; and cohort_studies
+  reference data mixes two reward metrics until pgasawa/continual-learning-bench#9 lands.
+
+## Known loss classes and their closures
+
+| Class | Signature | Closure |
+|---|---|---|
+| VM OOM worker kill | `signal 9` in runroot task_results | max_workers 3 + reaper + VM sizing |
+| Host network outage | engine silent, DNS dead | bridge outage-hold + retry 12 |
+| Prose final (payload left in agent workspace) | task `completed`, no parseable JSON | bridge format-repair round (same-container re-emission micro-task, review passes 0) |


### PR DESCRIPTION
Updates the CL-Bench devtools docs with everything learned from the first full 6-domain campaign on v6.71.1 (2026-07-20, submission-shaped `run-all` artifact, own stateless baselines).

- **New `RUNBOOK.md`** — field-tested at-scale recipe: validated configuration (uniform effort pinning, review gate with `max_improvement_passes=1`, `max_workers: 3` with the Docker-VM memory-sizing formula and the silent OOM failure signature), the two mandatory companion daemons (runroot clone-sweeper, orphan-container reaper), smoke → one-seed → 5-seed leaderboard-submission flow per continual-learning-bench.com/docs/submitting, and the known loss classes with their closures.
- **`METHODOLOGY.md`** — new §9: v6.71.1 full-suite 1-seed results (6-domain normalized average **+0.259** vs published top-1 +0.196 / Claude Code sonnet-4.6 +0.185; 1 seed, suggestive not significant) plus the review-mode ablation verdict (pin 1 pass; unbounded convergence is 2.6× the cost on the toolchain-oracle domain for no gain). Honest-limits section updated to match.
- **`README.md`** — points at the runbook, refreshes the external-adapter pin (`3ec3761`: network-outage hold, format-repair round, review-passes override, extra-overrides passthrough) and the current handoff-bundle name, and replaces the stale internal worker-pool guidance (4 → 3, with the OOM rationale).

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)