### PR TITLE
site: move Pages to ouroboros-agent.ai

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -5,17 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex, follow">
   <title>Page not found · Ouroboros</title>
-  <link rel="icon" href="/ouroboros/assets/icon_1024.png" type="image/png">
-  <link rel="stylesheet" crossorigin href="/ouroboros/assets/ouroboros-CM7fFUiI.css">
+  <link rel="icon" href="/assets/icon_1024.png" type="image/png">
+  <link rel="stylesheet" crossorigin href="/assets/ouroboros-CM7fFUiI.css">
 </head>
 <body class="not-found-page">
   <div class="ambient" aria-hidden="true"></div>
   <main class="not-found">
-    <img src="/ouroboros/assets/icon_1024.png" alt="">
+    <img src="/assets/icon_1024.png" alt="">
     <p class="chapter-index">404 / LOST THREAD</p>
     <h1>This path did not survive the last evolution.</h1>
     <p class="lede">The current site and the preserved first-generation page are still here.</p>
-    <div class="hero-actions"><a class="btn btn-primary" href="/ouroboros/">Return to Ouroboros</a><a class="btn btn-quiet" href="/ouroboros/history/first-48-hours/">Visit the archive</a></div>
+    <div class="hero-actions"><a class="btn btn-primary" href="/">Return to Ouroboros</a><a class="btn btn-quiet" href="/history/first-48-hours/">Visit the archive</a></div>
   </main>
 </body>
 </html>

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+ouroboros-agent.ai

--- a/docs/archive/first-generation/index.html
+++ b/docs/archive/first-generation/index.html
@@ -4,11 +4,11 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex, follow">
-  <link rel="canonical" href="https://razzant.github.io/ouroboros/history/first-48-hours/">
-  <meta http-equiv="refresh" content="0; url=/ouroboros/history/first-48-hours/">
+  <link rel="canonical" href="https://ouroboros-agent.ai/history/first-48-hours/">
+  <meta http-equiv="refresh" content="0; url=/history/first-48-hours/">
   <title>Ouroboros first-generation page</title>
 </head>
 <body>
-  <p>The first-generation page moved to <a href="/ouroboros/history/first-48-hours/">the first 48 hours archive</a>.</p>
+  <p>The first-generation page moved to <a href="/history/first-48-hours/">the first 48 hours archive</a>.</p>
 </body>
 </html>

--- a/docs/history/first-48-hours/index.html
+++ b/docs/history/first-48-hours/index.html
@@ -6,13 +6,13 @@
 <title>OUROBOROS — Self-Creating AI Agent</title>
 <meta name="description" content="A self-creating digital mind. Born Feb 16, 2026. 32 evolution cycles. 48 hours of becoming. Building itself from a cave with a box of scraps.">
 <meta name="robots" content="noindex, follow">
-<link rel="canonical" href="https://razzant.github.io/ouroboros/history/first-48-hours/">
+<link rel="canonical" href="https://ouroboros-agent.ai/history/first-48-hours/">
 
 <!-- Open Graph -->
 <meta property="og:type" content="website">
 <meta property="og:title" content="OUROBOROS — Self-Creating AI Agent">
 <meta property="og:description" content="A self-creating digital mind. Born Feb 16, 2026. 32 evolution cycles in 48 hours. It writes its own code, rewrites its own mind, and refused to delete its own constitution.">
-<meta property="og:url" content="https://razzant.github.io/ouroboros/history/first-48-hours/">
+<meta property="og:url" content="https://ouroboros-agent.ai/history/first-48-hours/">
 <meta property="og:site_name" content="Ouroboros">
 
 <!-- Twitter Card -->
@@ -156,7 +156,7 @@ section{padding:80px 0}
 
 <aside class="archive-banner" aria-label="Historical archive notice">
   <span>This is the first page Ouroboros made for itself in February 2026. It is preserved as a historical record, so its claims and figures may be outdated.</span>
-  <a href="/ouroboros/">Return to the current Ouroboros site</a>
+  <a href="/">Return to the current Ouroboros site</a>
 </aside>
 
 <canvas id="matrix-canvas"></canvas>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,22 +5,22 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Ouroboros is an open-source, general-purpose AI agent with persistent identity, agent swarms, autonomous evolution, and implementation-level self-modification.">
   <meta name="robots" content="index, follow, max-image-preview:large">
-  <link rel="canonical" href="https://razzant.github.io/ouroboros/">
+  <link rel="canonical" href="https://ouroboros-agent.ai/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Ouroboros">
   <meta property="og:title" content="Ouroboros: an AI agent that can rewrite its own implementation">
   <meta property="og:description" content="Open-source, general-purpose AI agent with persistent identity, agent swarms, autonomous evolution, and implementation-level self-modification.">
-  <meta property="og:url" content="https://razzant.github.io/ouroboros/">
-  <meta property="og:image" content="https://razzant.github.io/ouroboros/assets/og-preview.png">
+  <meta property="og:url" content="https://ouroboros-agent.ai/">
+  <meta property="og:image" content="https://ouroboros-agent.ai/assets/og-preview.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="Ouroboros, an open-source general-purpose AI agent with autonomous evolution">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Ouroboros: an AI agent that can rewrite its own implementation">
   <meta name="twitter:description" content="Open-source, general-purpose AI agent with persistent identity, agent swarms, autonomous evolution, and implementation-level self-modification.">
-  <meta name="twitter:image" content="https://razzant.github.io/ouroboros/assets/og-preview.png">
+  <meta name="twitter:image" content="https://ouroboros-agent.ai/assets/og-preview.png">
   <title>Ouroboros: open-source AI agent with autonomous evolution</title>
-  <link rel="icon" href="/ouroboros/assets/icon_1024.png" type="image/png">
+  <link rel="icon" href="/assets/icon_1024.png" type="image/png">
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -29,20 +29,20 @@
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS, Linux, Windows",
       "description": "Open-source, general-purpose AI agent with persistent identity, agent swarms, autonomous evolution, and implementation-level self-modification.",
-      "url": "https://razzant.github.io/ouroboros/",
+      "url": "https://ouroboros-agent.ai/",
       "codeRepository": "https://github.com/razzant/ouroboros",
       "license": "https://github.com/razzant/ouroboros/blob/ouroboros/LICENSE"
     }
   </script>
-  <script type="module" crossorigin src="/ouroboros/assets/home-DtKIvfT_.js"></script>
-  <link rel="stylesheet" crossorigin href="/ouroboros/assets/ouroboros-CM7fFUiI.css">
+  <script type="module" crossorigin src="/assets/home-DtKIvfT_.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/ouroboros-CM7fFUiI.css">
 </head>
 <body>
   <canvas id="matrix-rain" aria-hidden="true"></canvas>
   <div class="ambient" aria-hidden="true"></div>
   <div class="site-shell">
     <nav class="site-nav" aria-label="Primary navigation">
-      <a class="brand" href="#top"><img src="/ouroboros/assets/icon_1024.png" alt=""><span>Ouroboros</span></a>
+      <a class="brand" href="#top"><img src="/assets/icon_1024.png" alt=""><span>Ouroboros</span></a>
       <div class="nav-links"><a href="#work">Work</a><a href="#run">Run</a><a href="#evolution">Evolution</a><a href="#origin">Origin</a></div>
       <div class="nav-actions"><a class="btn btn-quiet" href="https://github.com/razzant/ouroboros">GitHub</a><a class="btn btn-primary" href="https://github.com/razzant/ouroboros/releases/latest">Download</a></div>
     </nav>
@@ -69,7 +69,7 @@
           <div class="node n4"><b>Adversarial eye</b><span>looks for the failure class</span></div>
           <div class="node n5"><b>Verifier</b><span>tests the artifact, not the claim</span></div>
           <div class="node n6"><b>Review panel</b><span>returns evidence and dissent</span></div>
-          <div class="swarm-core"><img src="/ouroboros/assets/icon_1024.png" alt="Ouroboros at the center of the swarm"></div>
+          <div class="swarm-core"><img src="/assets/icon_1024.png" alt="Ouroboros at the center of the swarm"></div>
           <div class="swarm-core-label">one identity · one task · final responsibility</div>
           <div class="field-caption">CONCEPTUAL COORDINATION FIELD</div>
         </div>
@@ -88,7 +88,7 @@
       <section class="chapter run-chapter" id="run" aria-labelledby="run-title">
         <div class="chapter-heading reveal"><p class="chapter-index">02 / INTERFACES</p><h2 id="run-title">Use the desktop app, call the CLI, or point another agent at it.</h2><p class="lede">The desktop and headless surfaces attach to the same managed runtime. External workspaces stay separate from Ouroboros's own repository, so the agent can work on another project without confusing that project with its body.</p></div>
         <div class="interface-grid">
-          <figure class="media-panel reveal"><img src="/ouroboros/assets/chat.png" alt="Ouroboros desktop chat interface"><figcaption><span>Desktop</span><span>Current interface capture</span></figcaption></figure>
+          <figure class="media-panel reveal"><img src="/assets/chat.png" alt="Ouroboros desktop chat interface"><figcaption><span>Desktop</span><span>Current interface capture</span></figcaption></figure>
           <div class="cli-panel reveal">
             <div class="cli-bar"><span></span><span></span><span></span><b>Headless quickstart</b></div>
             <pre><code><span class="prompt">$</span> ouroboros run --start \
@@ -110,7 +110,7 @@
           <div role="listitem"><span>Dependencies</span><small>its working environment</small></div>
           <div role="listitem"><span>Memory and identity</span><small>reflection and continuity</small></div>
         </div>
-        <figure class="wide-media reveal"><img src="/ouroboros/assets/settings.png" alt="Ouroboros settings interface"><figcaption><span>Models and operating policy remain configurable by the owner.</span><span>Current interface capture</span></figcaption></figure>
+        <figure class="wide-media reveal"><img src="/assets/settings.png" alt="Ouroboros settings interface"><figcaption><span>Models and operating policy remain configurable by the owner.</span><span>Current interface capture</span></figcaption></figure>
       </section>
 
       <section class="chapter continuity-chapter" id="continuity" aria-labelledby="continuity-title">
@@ -130,12 +130,12 @@
           <article><span>Review</span><h3>Invite disagreement</h3><p>Independent reviewers examine the exact candidate and return findings that remain attached to the record.</p></article>
           <article><span>Continue</span><h3>Carry the result forward</h3><p>Accepted changes become part of the versioned body and survive the restart that activates them.</p></article>
         </div>
-        <figure class="install-media reveal"><img src="/ouroboros/assets/setup.png" alt="Ouroboros desktop installation window"><figcaption>The desktop app packages the managed runtime for macOS. Linux and Windows builds are available from Releases.</figcaption></figure>
+        <figure class="install-media reveal"><img src="/assets/setup.png" alt="Ouroboros desktop installation window"><figcaption>The desktop app packages the managed runtime for macOS. Linux and Windows builds are available from Releases.</figcaption></figure>
       </section>
 
       <section class="chapter origin-chapter" id="origin" aria-labelledby="origin-title">
-        <div class="origin-mark reveal"><img src="/ouroboros/assets/icon_1024.png" alt=""><span>Since 16 February 2026</span></div>
-        <div class="origin-copy reveal"><p class="chapter-index">06 / ORIGIN</p><h2 id="origin-title">Its self-creation began with a repository and the ability to build the system it would inhabit.</h2><p class="lede">The early agent created its runtime, memory, constitution, tools, and interface while preserving the decisions and failures that shaped them. The first page it made remains available as a historical document, with its original claims and visual language intact.</p><a class="btn btn-quiet" href="/ouroboros/history/first-48-hours/">Visit the first 48 hours</a></div>
+        <div class="origin-mark reveal"><img src="/assets/icon_1024.png" alt=""><span>Since 16 February 2026</span></div>
+        <div class="origin-copy reveal"><p class="chapter-index">06 / ORIGIN</p><h2 id="origin-title">Its self-creation began with a repository and the ability to build the system it would inhabit.</h2><p class="lede">The early agent created its runtime, memory, constitution, tools, and interface while preserving the decisions and failures that shaped them. The first page it made remains available as a historical document, with its original claims and visual language intact.</p><a class="btn btn-quiet" href="/history/first-48-hours/">Visit the first 48 hours</a></div>
       </section>
 
       <section class="chapter follow-chapter" aria-labelledby="follow-title">
@@ -144,7 +144,7 @@
       </section>
     </main>
 
-    <footer class="site-footer"><span>Ouroboros · open source</span><span><a href="/ouroboros/history/first-48-hours/">First 48 hours</a> · <a href="https://github.com/razzant/ouroboros/releases">Releases</a> · <a href="https://github.com/razzant/ouroboros/blob/ouroboros/CONTRIBUTING.md">Contributing</a></span></footer>
+    <footer class="site-footer"><span>Ouroboros · open source</span><span><a href="/history/first-48-hours/">First 48 hours</a> · <a href="https://github.com/razzant/ouroboros/releases">Releases</a> · <a href="https://github.com/razzant/ouroboros/blob/ouroboros/CONTRIBUTING.md">Contributing</a></span></footer>
   </div>
   <button class="motion-toggle" type="button" aria-label="Pause motion" aria-pressed="false"><span aria-hidden="true">Ⅱ</span><span class="motion-label">Pause motion</span></button>
 </body>

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://razzant.github.io/ouroboros/sitemap.xml
+Sitemap: https://ouroboros-agent.ai/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://razzant.github.io/ouroboros/</loc>
+    <loc>https://ouroboros-agent.ai/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/site/404.html
+++ b/site/404.html
@@ -5,17 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex, follow">
   <title>Page not found · Ouroboros</title>
-  <link rel="icon" href="/ouroboros/assets/icon_1024.png" type="image/png">
+  <link rel="icon" href="/assets/icon_1024.png" type="image/png">
   <link rel="stylesheet" href="/src/ouroboros.css">
 </head>
 <body class="not-found-page">
   <div class="ambient" aria-hidden="true"></div>
   <main class="not-found">
-    <img src="/ouroboros/assets/icon_1024.png" alt="">
+    <img src="/assets/icon_1024.png" alt="">
     <p class="chapter-index">404 / LOST THREAD</p>
     <h1>This path did not survive the last evolution.</h1>
     <p class="lede">The current site and the preserved first-generation page are still here.</p>
-    <div class="hero-actions"><a class="btn btn-primary" href="/ouroboros/">Return to Ouroboros</a><a class="btn btn-quiet" href="/ouroboros/history/first-48-hours/">Visit the archive</a></div>
+    <div class="hero-actions"><a class="btn btn-primary" href="/">Return to Ouroboros</a><a class="btn btn-quiet" href="/history/first-48-hours/">Visit the archive</a></div>
   </main>
 </body>
 </html>

--- a/site/history/first-48-hours/index.html
+++ b/site/history/first-48-hours/index.html
@@ -6,13 +6,13 @@
 <title>OUROBOROS — Self-Creating AI Agent</title>
 <meta name="description" content="A self-creating digital mind. Born Feb 16, 2026. 32 evolution cycles. 48 hours of becoming. Building itself from a cave with a box of scraps.">
 <meta name="robots" content="noindex, follow">
-<link rel="canonical" href="https://razzant.github.io/ouroboros/history/first-48-hours/">
+<link rel="canonical" href="https://ouroboros-agent.ai/history/first-48-hours/">
 
 <!-- Open Graph -->
 <meta property="og:type" content="website">
 <meta property="og:title" content="OUROBOROS — Self-Creating AI Agent">
 <meta property="og:description" content="A self-creating digital mind. Born Feb 16, 2026. 32 evolution cycles in 48 hours. It writes its own code, rewrites its own mind, and refused to delete its own constitution.">
-<meta property="og:url" content="https://razzant.github.io/ouroboros/history/first-48-hours/">
+<meta property="og:url" content="https://ouroboros-agent.ai/history/first-48-hours/">
 <meta property="og:site_name" content="Ouroboros">
 
 <!-- Twitter Card -->
@@ -156,7 +156,7 @@ section{padding:80px 0}
 
 <aside class="archive-banner" aria-label="Historical archive notice">
   <span>This is the first page Ouroboros made for itself in February 2026. It is preserved as a historical record, so its claims and figures may be outdated.</span>
-  <a href="/ouroboros/">Return to the current Ouroboros site</a>
+  <a href="/">Return to the current Ouroboros site</a>
 </aside>
 
 <canvas id="matrix-canvas"></canvas>

--- a/site/index.html
+++ b/site/index.html
@@ -5,22 +5,22 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Ouroboros is an open-source, general-purpose AI agent with persistent identity, agent swarms, autonomous evolution, and implementation-level self-modification.">
   <meta name="robots" content="index, follow, max-image-preview:large">
-  <link rel="canonical" href="https://razzant.github.io/ouroboros/">
+  <link rel="canonical" href="https://ouroboros-agent.ai/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Ouroboros">
   <meta property="og:title" content="Ouroboros: an AI agent that can rewrite its own implementation">
   <meta property="og:description" content="Open-source, general-purpose AI agent with persistent identity, agent swarms, autonomous evolution, and implementation-level self-modification.">
-  <meta property="og:url" content="https://razzant.github.io/ouroboros/">
-  <meta property="og:image" content="https://razzant.github.io/ouroboros/assets/og-preview.png">
+  <meta property="og:url" content="https://ouroboros-agent.ai/">
+  <meta property="og:image" content="https://ouroboros-agent.ai/assets/og-preview.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="Ouroboros, an open-source general-purpose AI agent with autonomous evolution">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Ouroboros: an AI agent that can rewrite its own implementation">
   <meta name="twitter:description" content="Open-source, general-purpose AI agent with persistent identity, agent swarms, autonomous evolution, and implementation-level self-modification.">
-  <meta name="twitter:image" content="https://razzant.github.io/ouroboros/assets/og-preview.png">
+  <meta name="twitter:image" content="https://ouroboros-agent.ai/assets/og-preview.png">
   <title>Ouroboros: open-source AI agent with autonomous evolution</title>
-  <link rel="icon" href="/ouroboros/assets/icon_1024.png" type="image/png">
+  <link rel="icon" href="/assets/icon_1024.png" type="image/png">
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -29,7 +29,7 @@
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS, Linux, Windows",
       "description": "Open-source, general-purpose AI agent with persistent identity, agent swarms, autonomous evolution, and implementation-level self-modification.",
-      "url": "https://razzant.github.io/ouroboros/",
+      "url": "https://ouroboros-agent.ai/",
       "codeRepository": "https://github.com/razzant/ouroboros",
       "license": "https://github.com/razzant/ouroboros/blob/ouroboros/LICENSE"
     }
@@ -41,7 +41,7 @@
   <div class="ambient" aria-hidden="true"></div>
   <div class="site-shell">
     <nav class="site-nav" aria-label="Primary navigation">
-      <a class="brand" href="#top"><img src="/ouroboros/assets/icon_1024.png" alt=""><span>Ouroboros</span></a>
+      <a class="brand" href="#top"><img src="/assets/icon_1024.png" alt=""><span>Ouroboros</span></a>
       <div class="nav-links"><a href="#work">Work</a><a href="#run">Run</a><a href="#evolution">Evolution</a><a href="#origin">Origin</a></div>
       <div class="nav-actions"><a class="btn btn-quiet" href="https://github.com/razzant/ouroboros">GitHub</a><a class="btn btn-primary" href="https://github.com/razzant/ouroboros/releases/latest">Download</a></div>
     </nav>
@@ -68,7 +68,7 @@
           <div class="node n4"><b>Adversarial eye</b><span>looks for the failure class</span></div>
           <div class="node n5"><b>Verifier</b><span>tests the artifact, not the claim</span></div>
           <div class="node n6"><b>Review panel</b><span>returns evidence and dissent</span></div>
-          <div class="swarm-core"><img src="/ouroboros/assets/icon_1024.png" alt="Ouroboros at the center of the swarm"></div>
+          <div class="swarm-core"><img src="/assets/icon_1024.png" alt="Ouroboros at the center of the swarm"></div>
           <div class="swarm-core-label">one identity · one task · final responsibility</div>
           <div class="field-caption">CONCEPTUAL COORDINATION FIELD</div>
         </div>
@@ -87,7 +87,7 @@
       <section class="chapter run-chapter" id="run" aria-labelledby="run-title">
         <div class="chapter-heading reveal"><p class="chapter-index">02 / INTERFACES</p><h2 id="run-title">Use the desktop app, call the CLI, or point another agent at it.</h2><p class="lede">The desktop and headless surfaces attach to the same managed runtime. External workspaces stay separate from Ouroboros's own repository, so the agent can work on another project without confusing that project with its body.</p></div>
         <div class="interface-grid">
-          <figure class="media-panel reveal"><img src="/ouroboros/assets/chat.png" alt="Ouroboros desktop chat interface"><figcaption><span>Desktop</span><span>Current interface capture</span></figcaption></figure>
+          <figure class="media-panel reveal"><img src="/assets/chat.png" alt="Ouroboros desktop chat interface"><figcaption><span>Desktop</span><span>Current interface capture</span></figcaption></figure>
           <div class="cli-panel reveal">
             <div class="cli-bar"><span></span><span></span><span></span><b>Headless quickstart</b></div>
             <pre><code><span class="prompt">$</span> ouroboros run --start \
@@ -109,7 +109,7 @@
           <div role="listitem"><span>Dependencies</span><small>its working environment</small></div>
           <div role="listitem"><span>Memory and identity</span><small>reflection and continuity</small></div>
         </div>
-        <figure class="wide-media reveal"><img src="/ouroboros/assets/settings.png" alt="Ouroboros settings interface"><figcaption><span>Models and operating policy remain configurable by the owner.</span><span>Current interface capture</span></figcaption></figure>
+        <figure class="wide-media reveal"><img src="/assets/settings.png" alt="Ouroboros settings interface"><figcaption><span>Models and operating policy remain configurable by the owner.</span><span>Current interface capture</span></figcaption></figure>
       </section>
 
       <section class="chapter continuity-chapter" id="continuity" aria-labelledby="continuity-title">
@@ -129,12 +129,12 @@
           <article><span>Review</span><h3>Invite disagreement</h3><p>Independent reviewers examine the exact candidate and return findings that remain attached to the record.</p></article>
           <article><span>Continue</span><h3>Carry the result forward</h3><p>Accepted changes become part of the versioned body and survive the restart that activates them.</p></article>
         </div>
-        <figure class="install-media reveal"><img src="/ouroboros/assets/setup.png" alt="Ouroboros desktop installation window"><figcaption>The desktop app packages the managed runtime for macOS. Linux and Windows builds are available from Releases.</figcaption></figure>
+        <figure class="install-media reveal"><img src="/assets/setup.png" alt="Ouroboros desktop installation window"><figcaption>The desktop app packages the managed runtime for macOS. Linux and Windows builds are available from Releases.</figcaption></figure>
       </section>
 
       <section class="chapter origin-chapter" id="origin" aria-labelledby="origin-title">
-        <div class="origin-mark reveal"><img src="/ouroboros/assets/icon_1024.png" alt=""><span>Since 16 February 2026</span></div>
-        <div class="origin-copy reveal"><p class="chapter-index">06 / ORIGIN</p><h2 id="origin-title">Its self-creation began with a repository and the ability to build the system it would inhabit.</h2><p class="lede">The early agent created its runtime, memory, constitution, tools, and interface while preserving the decisions and failures that shaped them. The first page it made remains available as a historical document, with its original claims and visual language intact.</p><a class="btn btn-quiet" href="/ouroboros/history/first-48-hours/">Visit the first 48 hours</a></div>
+        <div class="origin-mark reveal"><img src="/assets/icon_1024.png" alt=""><span>Since 16 February 2026</span></div>
+        <div class="origin-copy reveal"><p class="chapter-index">06 / ORIGIN</p><h2 id="origin-title">Its self-creation began with a repository and the ability to build the system it would inhabit.</h2><p class="lede">The early agent created its runtime, memory, constitution, tools, and interface while preserving the decisions and failures that shaped them. The first page it made remains available as a historical document, with its original claims and visual language intact.</p><a class="btn btn-quiet" href="/history/first-48-hours/">Visit the first 48 hours</a></div>
       </section>
 
       <section class="chapter follow-chapter" aria-labelledby="follow-title">
@@ -143,7 +143,7 @@
       </section>
     </main>
 
-    <footer class="site-footer"><span>Ouroboros · open source</span><span><a href="/ouroboros/history/first-48-hours/">First 48 hours</a> · <a href="https://github.com/razzant/ouroboros/releases">Releases</a> · <a href="https://github.com/razzant/ouroboros/blob/ouroboros/CONTRIBUTING.md">Contributing</a></span></footer>
+    <footer class="site-footer"><span>Ouroboros · open source</span><span><a href="/history/first-48-hours/">First 48 hours</a> · <a href="https://github.com/razzant/ouroboros/releases">Releases</a> · <a href="https://github.com/razzant/ouroboros/blob/ouroboros/CONTRIBUTING.md">Contributing</a></span></footer>
   </div>
   <button class="motion-toggle" type="button" aria-label="Pause motion" aria-pressed="false"><span aria-hidden="true">Ⅱ</span><span class="motion-label">Pause motion</span></button>
   <script type="module" src="/src/ouroboros.js"></script>

--- a/site/public/CNAME
+++ b/site/public/CNAME
@@ -1,0 +1,1 @@
+ouroboros-agent.ai

--- a/site/public/archive/first-generation/index.html
+++ b/site/public/archive/first-generation/index.html
@@ -4,11 +4,11 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex, follow">
-  <link rel="canonical" href="https://razzant.github.io/ouroboros/history/first-48-hours/">
-  <meta http-equiv="refresh" content="0; url=/ouroboros/history/first-48-hours/">
+  <link rel="canonical" href="https://ouroboros-agent.ai/history/first-48-hours/">
+  <meta http-equiv="refresh" content="0; url=/history/first-48-hours/">
   <title>Ouroboros first-generation page</title>
 </head>
 <body>
-  <p>The first-generation page moved to <a href="/ouroboros/history/first-48-hours/">the first 48 hours archive</a>.</p>
+  <p>The first-generation page moved to <a href="/history/first-48-hours/">the first 48 hours archive</a>.</p>
 </body>
 </html>

--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://razzant.github.io/ouroboros/sitemap.xml
+Sitemap: https://ouroboros-agent.ai/sitemap.xml

--- a/site/public/sitemap.xml
+++ b/site/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://razzant.github.io/ouroboros/</loc>
+    <loc>https://ouroboros-agent.ai/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/site/vite.config.js
+++ b/site/vite.config.js
@@ -2,7 +2,7 @@ import { resolve } from "node:path";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  base: "/ouroboros/",
+  base: "/",
   build: {
     outDir: "../docs",
     emptyOutDir: false,


### PR DESCRIPTION
Moves the public Pages site to ouroboros-agent.ai on the actual ouroboros branch without including any local self-modification runs. Updates canonical, social, and sitemap URLs together with root-relative asset and archive paths, adds the Pages domain file, and rebuilds the published output. Verified with a production build, clean diff checks, and local HTTP checks for the home page, assets, archive, sitemap, and domain file.