### PR TITLE
Fix evolution state isolation and commit authority

### DIFF
--- a/devtools/benchmarks/common/server_runner.py
+++ b/devtools/benchmarks/common/server_runner.py
@@ -26,6 +26,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 
 if __package__ in {None, ""}:
     sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
@@ -173,6 +174,19 @@ def seed_owner_state(data_root: pathlib.Path, *, evolution_enabled: bool = False
             st = {}
     st["owner_chat_id"] = 1
     if evolution_enabled:
+        campaign_path = pathlib.Path(data_root) / "state" / "evolution_campaign.json"
+        now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        campaign_path.write_text(json.dumps({
+            "schema_version": 1,
+            "id": uuid.uuid4().hex[:8],
+            "status": "active",
+            "objective": "Autonomously improve Ouroboros from benchmark evidence.",
+            "source": "benchmark",
+            "started_at": now,
+            "updated_at": now,
+            "cycles_done": 0,
+            "absorbed_cycles_done": 0,
+        }), encoding="utf-8")
         st["evolution_mode_enabled"] = True
     state_path.write_text(json.dumps(st), encoding="utf-8")
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1326,9 +1326,11 @@ at assignment. A reviewed
 commit is recorded back to that claim by exact SHA after final local commit/tag
 binding and before push. If authority changes after commit, the commit moves to a
 private local inspection ref, a tag created by that attempt is removed, and the
-active branch returns to the exact parent before any later ordinary push; no restart
-occurs. Runtime
-lifecycle authority mutations use short exact state/campaign CAS operations and
+normal branch/tag namespace no longer reaches it before any later ordinary push;
+the index and worktree remain untouched so concurrent edits cannot be lost. No restart
+occurs. Runtime terminal transitions run under the shared state lock, and an exact
+terminal replay resumes pending cleanup/restart/report effects without counting the
+cycle twice. Lifecycle authority mutations use short exact state/campaign operations and
 reject stale campaign ids or terminal resurrection. Transaction schema v2 carries
 the same typed receipt through marker and markerless boot verification; legacy v1
 transactions retain their existing restart recovery. Boot reconciliation shares

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -820,8 +820,8 @@ to `managed`.
 Self-modification success is local-first: `commit_reviewed` creating a reviewed
 local commit is the durable boundary. `origin` push and CI are best-effort
 follow-ups; missing `origin` is a local-only mode, not a broken evolution run.
-Autonomous restart uses the local commit SHA or a clean no-op state as its
-eligibility signal, never remote push success.
+Autonomous evolution restart requires the exact reviewed local commit receipt,
+never remote push success.
 
 Reviewed-change pytest preflight is hermetic. `ouroboros/preflight_runner.py`
 creates a disposable detached worktree, replays the candidate staged/unstaged
@@ -830,7 +830,9 @@ diff plus untracked candidate files, runs the default pytest suite serially with
 scrubs inherited `OUROBOROS_*` behavior plus secret-class environment values.
 This prevents tests launched by advisory/commit review from writing live
 `data/settings.json`, inheriting owner runtime modes, or triggering
-launcher-managed reset behavior against the live repo. CI alone owns its
+launcher-managed reset behavior against the live repo. Pytest also rebinds the
+already-imported state, queue, and worker roots for each test process and refuses
+state/campaign writes that resolve to the captured live data root. CI alone owns its
 parallel non-serial plus serial split.
 
 Safety-critical protection is no longer implemented as "copy these files from the
@@ -1316,6 +1318,23 @@ with git/memory hashes, `outcome_axes`, and per-cycle cost/rounds for future
 eval curves. Task attempts/campaign tasks are counted separately from absorbed
 evolution cycles: an absorbed cycle requires a reviewed self-mod commit plus
 successful startup restart verification of that commit.
+`evolution_mode_enabled` is only the scheduling projection of an active campaign,
+not authority by itself. Before dispatch, review, commit, publication, and restart,
+the runtime verifies the exact campaign, transaction, and task claim; restored or
+retried queue rows without that still-uncommitted authority are terminally cancelled
+at assignment. A reviewed
+commit is recorded back to that claim by exact SHA after final local commit/tag
+binding and before push. If authority changes after commit, the commit moves to a
+private local inspection ref, a tag created by that attempt is removed, and the
+active branch returns to the exact parent before any later ordinary push; no restart
+occurs. Runtime
+lifecycle authority mutations use short exact state/campaign CAS operations and
+reject stale campaign ids or terminal resurrection. Transaction schema v2 carries
+the same typed receipt through marker and markerless boot verification; legacy v1
+transactions retain their existing restart recovery. Boot reconciliation shares
+the state lock with campaign closure, stamps the current custody generation on
+campaign start, requires a new server generation before consuming an explicit
+restart claim, and atomically reclaims claims left by dead worker PIDs.
 The evolution redesign (v6.30.0) closes the structural feedback and hygiene
 gaps. Campaign state and the transaction lifecycle live in
 `supervisor/evolution_lifecycle.py` (queue.py keeps queueing only).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -794,7 +794,10 @@ Review preflight tests are hermetic. Any pytest run launched by
 with a temporary `OUROBOROS_DATA_DIR` / `OUROBOROS_SETTINGS_PATH`, a temp
 `PYTHONPYCACHEPREFIX`, and no inherited `OUROBOROS_MANAGED_BY_LAUNCHER`. Tests
 may read the live source checkout as the candidate snapshot, but they must not
-write the live repo or live `data/`.
+write the live repo or live `data/`. `tests/conftest.py` must also rebind
+already-imported state/queue/worker roots inside each pytest process and fail
+closed if a state or evolution-campaign write resolves to the captured live data
+root; setting only `OUROBOROS_DATA_DIR` is insufficient for process-global roots.
 
 Self-modification durability is local-first. A successful reviewed local commit
 is the persistence boundary; `origin` push and CI are optional follow-up signals.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -797,7 +797,10 @@ may read the live source checkout as the candidate snapshot, but they must not
 write the live repo or live `data/`. `tests/conftest.py` must also rebind
 already-imported state/queue/worker roots inside each pytest process and fail
 closed if a state or evolution-campaign write resolves to the captured live data
-root; setting only `OUROBOROS_DATA_DIR` is insufficient for process-global roots.
+root. Explicit subprocess environments preserve their own isolated data root or
+receive the parent's disposable root and pytest markers; scrubbing unrelated
+variables must not reopen the live default. Setting only `OUROBOROS_DATA_DIR` is
+insufficient for process-global roots.
 
 Self-modification durability is local-first. A successful reviewed local commit
 is the persistence boundary; `origin` push and CI are optional follow-up signals.

--- a/ouroboros/agent_startup_checks.py
+++ b/ouroboros/agent_startup_checks.py
@@ -542,6 +542,11 @@ def _append_cycle_outcome_tag(env: Any, *, campaign: Any, transaction: Any, sour
 
 def verify_restart(env: Any, git_sha: str) -> None:
     """Best-effort restart verification."""
+    from supervisor import state as supervisor_state
+
+    campaign_path = env.drive_path("state") / "evolution_campaign.json"
+    supervisor_state.assert_test_data_path(campaign_path)
+
     def _append_unique_transaction(campaign: Dict[str, Any], tx: Dict[str, Any]) -> None:
         tx_history = list(campaign.get("transaction_history") or [])
         tx_id = str(tx.get("transaction_id") or "")
@@ -584,9 +589,54 @@ def verify_restart(env: Any, git_sha: str) -> None:
         except Exception:
             return False
 
+    def _restart_authority_error(
+        campaign: Dict[str, Any], tx: Dict[str, Any], *,
+        claim: Any = None, require_claim: bool = False,
+    ) -> str:
+        """Validate v2 restart authority while preserving legacy v1 recovery."""
+        try:
+            schema_version = int(tx.get("schema_version") or 1)
+        except (TypeError, ValueError):
+            schema_version = 1
+        strict = (
+            schema_version >= 2
+            or "commit_receipt" in tx
+            or claim is not None
+        )
+        if not strict:
+            return ""
+        if require_claim and not isinstance(claim, dict):
+            return "restart_claim_missing" if claim is None else "restart_claim_invalid"
+        expected = {
+            "campaign_id": str(campaign.get("id") or ""),
+            "transaction_id": str(tx.get("transaction_id") or ""),
+            "task_id": str(tx.get("task_id") or ""),
+            "commit_sha": str(tx.get("commit_sha") or ""),
+        }
+        if isinstance(claim, dict) and any(
+            str(claim.get(key) or "") != value for key, value in expected.items()
+        ):
+            return "restart_claim_mismatch"
+        from supervisor.evolution_lifecycle import evolution_commit_receipt_error
+
+        return evolution_commit_receipt_error(tx, **expected)
+
+    def _boot_reconcile_generation() -> str:
+        from supervisor.evolution_lifecycle import current_evolution_boot_generation
+
+        return current_evolution_boot_generation()
+
     def _reconcile_dangling_campaign_transaction(observed_sha: str) -> None:
         try:
-            campaign_path = env.drive_path("state") / "evolution_campaign.json"
+            snapshot = read_json_dict(campaign_path) or {}
+            snapshot_tx = (
+                snapshot.get("active_transaction")
+                if isinstance(snapshot.get("active_transaction"), dict) else {}
+            )
+            snapshot_sha = str(snapshot_tx.get("commit_sha") or "").strip()
+            snapshot_reachable = bool(
+                snapshot_sha and _commit_reachable(snapshot_sha, observed_sha)
+            )
             # Reconcile AT MOST ONCE per server generation. A genuine restart
             # begins a new custody generation (NW-10 session id, which workers
             # inherit from the server); a routine worker RESPAWN keeps the same
@@ -597,11 +647,7 @@ def verify_restart(env: Any, git_sha: str) -> None:
             # nothing was actually restarted. Honors the owner's reconcile_yes
             # choice: it still reconciles on the next genuine new-generation boot.
             # The gen value depends only on the custody session, not the campaign.
-            try:
-                from ouroboros.process_custody import current_custody_session_id
-                gen = str(current_custody_session_id() or "")
-            except Exception:
-                gen = ""
+            gen = _boot_reconcile_generation()
             # The whole read-check-write runs under update_json_locked so the
             # gen-gate is ATOMIC: at boot ~10 workers whose os.rename of the pending
             # file lost all call this; the lock + in-lock re-read make exactly one
@@ -614,9 +660,17 @@ def verify_restart(env: Any, git_sha: str) -> None:
             event: Dict[str, Any] = {}  # captured in-lock for post-lock event logging
 
             outcome_snapshot: Dict[str, Any] = {}
+            state_path = env.drive_path("state") / "state.json"
+            state_lock_path = env.drive_path("locks") / "state.lock"
 
             def _mutate(campaign: Dict[str, Any]):
                 if not isinstance(campaign, dict):
+                    return None
+                live_state = read_json_dict(state_path) or {}
+                if (
+                    bool(live_state.get("evolution_owner_stopped"))
+                    or campaign.get("status") not in {"active", "paused"}
+                ):
                     return None
                 if gen and str(campaign.get("last_boot_reconcile_gen") or "") == gen:
                     return None  # already reconciled this generation — abort, no write
@@ -633,12 +687,44 @@ def verify_restart(env: Any, git_sha: str) -> None:
                         campaign["updated_at"] = utc_now_iso()
                         return campaign
                     return None
+                if commit_sha != snapshot_sha:
+                    if gen:
+                        campaign["last_boot_reconcile_gen"] = gen
+                        campaign["updated_at"] = utc_now_iso()
+                        return campaign
+                    return None
                 now = utc_now_iso()
+                authority_error = _restart_authority_error(campaign, tx)
+                if authority_error:
+                    campaign["last_boot_reconcile_gen"] = gen
+                    tx["restart_required"] = True
+                    tx["restart_verified"] = False
+                    tx["restart_authority_error"] = authority_error
+                    tx["restart_observed_sha"] = observed_sha
+                    tx["updated_at"] = now
+                    campaign["active_transaction"] = tx
+                    campaign["progress_notes"] = (
+                        "Restart reconciliation kept the evolution transaction open: "
+                        f"exact commit authority failed ({authority_error})."
+                    )
+                    campaign["updated_at"] = now
+                    event.update({
+                        "ts": now,
+                        "type": "evolution_tx_reconcile_blocked",
+                        "ok": False,
+                        "reason": authority_error,
+                        "campaign_id": str(campaign.get("id") or ""),
+                        "transaction_id": str(tx.get("transaction_id") or ""),
+                        "task_id": str(tx.get("task_id") or ""),
+                        "commit_sha": commit_sha,
+                        "observed_sha": observed_sha,
+                    })
+                    return campaign
                 campaign["last_boot_reconcile_gen"] = gen
                 tx["restart_verified_at"] = now
                 tx["restart_observed_sha"] = observed_sha
                 tx["updated_at"] = now
-                if _commit_reachable(commit_sha, observed_sha):
+                if snapshot_reachable:
                     tx["restart_required"] = False
                     tx["restart_verified"] = True
                     tx["verified_by"] = "boot_reconciliation"
@@ -685,7 +771,13 @@ def verify_restart(env: Any, git_sha: str) -> None:
                 })
                 return campaign
 
-            update_json_locked(campaign_path, _mutate)
+            lock_fd = supervisor_state.acquire_file_lock(state_lock_path)
+            if lock_fd is None:
+                return
+            try:
+                update_json_locked(campaign_path, _mutate)
+            finally:
+                supervisor_state.release_file_lock(state_lock_path, lock_fd)
             if event:
                 append_jsonl(env.drive_path("logs") / "events.jsonl", event)
             if outcome_snapshot.get("transaction"):
@@ -699,27 +791,77 @@ def verify_restart(env: Any, git_sha: str) -> None:
         except Exception:
             log.debug("Failed to reconcile dangling evolution transaction", exc_info=True)
 
-    def _mark_campaign_restart_verified(expected_sha: str, observed_sha: str, ok: bool) -> bool:
-        # Runs only on the single worker that won the os.rename of the pending claim,
-        # so there is no marker-vs-marker race. It stays unlocked (its strict
-        # expected==observed check and the active_transaction-popped guard make the
-        # outcome consistent with a concurrent boot reconcile in the common case where
-        # the reviewed commit IS HEAD). KNOWN LIMITATION: if the reviewed commit is an
-        # ANCESTOR of HEAD but not HEAD itself, this marker blocks (mismatch) while a
-        # boot reconciler would absorb (commit reachable) — a narrow, idempotency-
-        # mitigated ordering edge. Fully resolving it needs both writers to share the
-        # campaign lock; deferred as a focused follow-up (advisory, restart-critical).
+    mark_error: Dict[str, str] = {}
+
+    def _mark_campaign_restart_verified(
+        expected_sha: str, observed_sha: str, ok: bool, claim: Any = None,
+    ) -> bool:
+        # Only the os.rename winner reaches this transition. It stamps the custody
+        # generation before removing the claim; losers either see the claimed file or
+        # the generation stamp, so markerless reconciliation cannot bypass the claim.
+        state_lock_path = env.drive_path("locks") / "state.lock"
+        lock_fd = None
         try:
-            campaign_path = env.drive_path("state") / "evolution_campaign.json"
+            lock_fd = supervisor_state.acquire_file_lock(state_lock_path)
+            if lock_fd is None:
+                mark_error["reason"] = "state_lock_unavailable"
+                return False
             campaign = read_json_dict(campaign_path) or {}
             if not isinstance(campaign, dict):
                 return bool(ok)
             tx = campaign.get("active_transaction") if isinstance(campaign.get("active_transaction"), dict) else {}
             if not tx:
+                if claim is not None:
+                    mark_error["reason"] = "transaction_missing"
+                    mark_error["durable"] = "1"
+                    return False
+                mark_error["durable"] = "1"
                 return bool(ok)
+            live_state = read_json_dict(env.drive_path("state") / "state.json") or {}
+            if bool(live_state.get("evolution_owner_stopped")):
+                mark_error["reason"] = "owner_stopped"
+                mark_error["durable"] = "1"
+                return False
+            if campaign.get("status") not in {"active", "paused"}:
+                mark_error["reason"] = "campaign_not_active"
+                mark_error["durable"] = "1"
+                return False
+            prior_gen = str(campaign.get("last_boot_reconcile_gen") or "")
+            gen = _boot_reconcile_generation()
             # Captured before the absorbed branch pops it via _close_post_task_backlog.
             backlog_id_before_close = str(campaign.get("post_task_backlog_id") or "")
             commit_sha = str(tx.get("commit_sha") or "").strip()
+            authority_error = _restart_authority_error(
+                campaign, tx, claim=claim, require_claim=True,
+            )
+            if authority_error:
+                now = utc_now_iso()
+                mark_error["reason"] = authority_error
+                if gen:
+                    campaign["last_boot_reconcile_gen"] = gen
+                tx["restart_required"] = True
+                tx["restart_verified"] = False
+                tx["restart_verified_at"] = now
+                tx["restart_expected_sha"] = expected_sha
+                tx["restart_observed_sha"] = observed_sha
+                tx["restart_authority_error"] = authority_error
+                tx["updated_at"] = now
+                campaign["active_transaction"] = tx
+                campaign["progress_notes"] = (
+                    "Restart verification kept the evolution transaction open: "
+                    f"exact commit authority failed ({authority_error})."
+                )
+                campaign["updated_at"] = now
+                atomic_write_json(campaign_path, campaign, trailing_newline=True)
+                mark_error["durable"] = "1"
+                return False
+            if isinstance(claim, dict) and gen and prior_gen == gen:
+                # A replacement worker inherits the server's custody generation.
+                # Keep the marker pending until the server itself has restarted.
+                mark_error["reason"] = "restart_generation_unchanged"
+                return False
+            if gen:
+                campaign["last_boot_reconcile_gen"] = gen
             if commit_sha and commit_sha != expected_sha:
                 tx["restart_required"] = True
                 tx["restart_verified"] = False
@@ -740,6 +882,7 @@ def verify_restart(env: Any, git_sha: str) -> None:
                 )
                 campaign["updated_at"] = utc_now_iso()
                 atomic_write_json(campaign_path, campaign, trailing_newline=True)
+                mark_error["durable"] = "1"
                 return False
             tx["restart_required"] = bool(not ok)
             tx["restart_verified"] = bool(ok)
@@ -796,6 +939,7 @@ def verify_restart(env: Any, git_sha: str) -> None:
                 _record_pending_owner_report(campaign, tx)
             campaign["updated_at"] = utc_now_iso()
             atomic_write_json(campaign_path, campaign, trailing_newline=True)
+            mark_error["durable"] = "1"
             if tx.get("cycle_outcome") == "absorbed":
                 _append_cycle_outcome_tag(
                     env,
@@ -806,8 +950,12 @@ def verify_restart(env: Any, git_sha: str) -> None:
                 )
             return bool(ok)
         except Exception:
+            mark_error["reason"] = "restart_campaign_write_failed"
             log.debug("Failed to update evolution campaign restart verification", exc_info=True)
-            return bool(ok)
+            return False
+        finally:
+            if lock_fd is not None:
+                supervisor_state.release_file_lock(state_lock_path, lock_fd)
 
     try:
         pending_path = env.drive_path('state') / 'pending_restart_verify.json'
@@ -815,35 +963,71 @@ def verify_restart(env: Any, git_sha: str) -> None:
         try:
             os.rename(str(pending_path), str(claim_path))
         except (FileNotFoundError, Exception):
-            _reconcile_dangling_campaign_transaction(git_sha)
-            return
+            claimed_paths = list(pending_path.parent.glob(
+                f"{pending_path.stem}.claimed.*{pending_path.suffix}"
+            ))
+            if not claimed_paths:
+                _reconcile_dangling_campaign_transaction(git_sha)
+                return
+            from ouroboros.platform_layer import pid_is_alive
+
+            prefix = f"{pending_path.stem}.claimed."
+            reclaimed = False
+            for stale_path in claimed_paths:
+                raw_pid = stale_path.name[len(prefix):-len(pending_path.suffix)]
+                if not raw_pid.isdecimal() or pid_is_alive(int(raw_pid)):
+                    return
+                try:
+                    os.rename(str(stale_path), str(claim_path))
+                    reclaimed = True
+                    break
+                except Exception:
+                    continue
+            if not reclaimed:
+                return
         try:
             claim_data = read_json_dict(claim_path)
             if claim_data is None:
+                _mark_campaign_restart_verified("", git_sha, False, None)
                 append_jsonl(env.drive_path('logs') / 'events.jsonl', {
                     'ts': utc_now_iso(), 'type': 'restart_verify',
                     'pid': os.getpid(), 'ok': False,
                     'error': 'pending_restart_verify_invalid',
+                    'authority_error': mark_error.get("reason", ""),
                     'observed_sha': git_sha,
                 })
-                return
-            expected_sha = str(claim_data.get("expected_sha", "")).strip()
-            sha_ok = bool(expected_sha and expected_sha == git_sha)
-            campaign_ok = _mark_campaign_restart_verified(expected_sha, git_sha, sha_ok)
-            ok = bool(sha_ok and campaign_ok)
-            append_jsonl(env.drive_path('logs') / 'events.jsonl', {
-                'ts': utc_now_iso(), 'type': 'restart_verify',
-                'pid': os.getpid(), 'ok': ok,
-                'expected_sha': expected_sha, 'observed_sha': git_sha,
-            })
+            else:
+                expected_sha = str(claim_data.get("expected_sha", "")).strip()
+                sha_ok = bool(expected_sha and expected_sha == git_sha)
+                evolution_claim = claim_data.get("evolution_claim")
+                campaign_ok = _mark_campaign_restart_verified(
+                    expected_sha, git_sha, sha_ok, evolution_claim,
+                )
+                ok = bool(sha_ok and campaign_ok)
+                event = {
+                    'ts': utc_now_iso(), 'type': 'restart_verify',
+                    'pid': os.getpid(), 'ok': ok,
+                    'expected_sha': expected_sha, 'observed_sha': git_sha,
+                }
+                if mark_error.get("reason"):
+                    event["error"] = mark_error["reason"]
+                append_jsonl(env.drive_path('logs') / 'events.jsonl', event)
         except Exception:
             log.debug("Failed to log restart verify event", exc_info=True)
             pass
-        try:
-            claim_path.unlink()
-        except Exception:
-            log.debug("Failed to delete restart verify claim file", exc_info=True)
-            pass
+        if mark_error.get("durable") == "1":
+            try:
+                claim_path.unlink()
+            except Exception:
+                log.debug("Failed to delete restart verify claim file", exc_info=True)
+                pass
+        else:
+            try:
+                if claim_path.is_file() and not pending_path.exists():
+                    os.rename(str(claim_path), str(pending_path))
+            except Exception:
+                log.debug("Failed to restore unresolved restart verify claim", exc_info=True)
+                pass
     except Exception:
         log.debug("Restart verification failed", exc_info=True)
         pass

--- a/ouroboros/agent_task_pipeline.py
+++ b/ouroboros/agent_task_pipeline.py
@@ -851,12 +851,11 @@ def emit_task_results(
         pending_events.append({
             "type": "restart_request",
             "reason": restart_reason,
+            "evolution_restart": bool(getattr(ctx, "pending_restart_is_evolution", False)),
             "ts": utc_now_iso(),
         })
-        try:
-            ctx.pending_restart_reason = None
-        except Exception:
-            pass
+        ctx.pending_restart_reason = None
+        ctx.pending_restart_is_evolution = False
 
     if _is_root_post_task(task):
         post_usage = dict(usage or {})

--- a/ouroboros/agent_task_pipeline.py
+++ b/ouroboros/agent_task_pipeline.py
@@ -847,13 +847,13 @@ def emit_task_results(
     # This ensures causal ordering: send_message reaches the UI before task_done,
     # preventing the live card from collapsing before the assistant reply arrives.
     restart_reason = str(getattr(ctx, "pending_restart_reason", "") or "").strip()
+    evolution_restart = bool(getattr(ctx, "pending_restart_is_evolution", False))
     if restart_reason:
-        pending_events.append({
-            "type": "restart_request",
-            "reason": restart_reason,
-            "evolution_restart": bool(getattr(ctx, "pending_restart_is_evolution", False)),
-            "ts": utc_now_iso(),
-        })
+        if not evolution_restart:
+            pending_events.append({
+                "type": "restart_request", "reason": restart_reason,
+                "evolution_restart": False, "ts": utc_now_iso(),
+            })
         ctx.pending_restart_reason = None
         ctx.pending_restart_is_evolution = False
 

--- a/ouroboros/post_task_evolution.py
+++ b/ouroboros/post_task_evolution.py
@@ -435,7 +435,8 @@ def apply_pending_request(drive_root: Any) -> bool:
                 return False
         if bool(req.get("requires_plan_review", True)):
             objective += _PLAN_REVIEW_SUFFIX
-        start_evolution_campaign(objective, source="post_task")
+        if not start_evolution_campaign(objective, source="post_task"):
+            return False
         # Link the promoted backlog id to the campaign so close-on-commit (Phase 2 C)
         # can mark it done when the cycle is absorbed. Validate it against the OPEN
         # backlog first: never link (and later close) a hallucinated or stale id.

--- a/ouroboros/tools/control.py
+++ b/ouroboros/tools/control.py
@@ -582,7 +582,21 @@ def _set_tool_timeout(ctx: ToolContext, seconds: int) -> str:
 
 
 def _promote_to_stable(ctx: ToolContext, reason: str) -> str:
-    ctx.pending_events.append({"type": "promote_to_stable", "reason": reason, "ts": utc_now_iso()})
+    event = {"type": "promote_to_stable", "reason": reason, "ts": utc_now_iso()}
+    if str(ctx.current_task_type or "") == "evolution":
+        metadata = getattr(ctx, "task_metadata", {})
+        metadata = metadata if isinstance(metadata, dict) else {}
+        tx = metadata.get("evolution_transaction")
+        tx = tx if isinstance(tx, dict) else {}
+        event["evolution_claim"] = {
+            "campaign_id": str(tx.get("campaign_id") or ""),
+            "transaction_id": str(tx.get("transaction_id") or ""),
+            "task_id": str(getattr(ctx, "task_id", "") or tx.get("task_id") or ""),
+            "commit_sha": str(
+                getattr(ctx, "last_reviewed_commit_sha", "") or tx.get("commit_sha") or ""
+            ),
+        }
+    ctx.pending_events.append(event)
     return f"Promote to stable requested: {reason}"
 
 

--- a/ouroboros/tools/control.py
+++ b/ouroboros/tools/control.py
@@ -486,9 +486,24 @@ def _evolution_restart_block_reason(ctx: ToolContext) -> str:
         return f"could not verify local git durability: {exc}"
     reviewed_sha = str(getattr(ctx, "last_reviewed_commit_sha", "") or "").strip()
     if reviewed_sha and reviewed_sha == head and not status:
-        return ""
-    if not reviewed_sha and not status:
-        return ""
+        metadata = getattr(ctx, "task_metadata", {})
+        metadata = metadata if isinstance(metadata, dict) else {}
+        tx = metadata.get("evolution_transaction")
+        tx = tx if isinstance(tx, dict) else {}
+        from supervisor.evolution_lifecycle import check_evolution_authority
+
+        authority = check_evolution_authority(
+            str(tx.get("campaign_id") or ""),
+            str(tx.get("transaction_id") or ""),
+            str(getattr(ctx, "task_id", "") or tx.get("task_id") or ""),
+            commit_sha=head,
+        )
+        return "" if authority.get("ok") else (
+            "the exact evolution commit receipt is no longer active "
+            f"({authority.get('reason') or 'unknown'})"
+        )
+    if not reviewed_sha:
+        return "commit_reviewed has not recorded an exact local commit receipt"
     if reviewed_sha and reviewed_sha != head:
         return "HEAD changed after the last reviewed local commit"
     return "commit_reviewed must create a local reviewed commit before evolution restart"
@@ -498,16 +513,32 @@ def _request_restart(ctx: ToolContext, reason: str) -> str:
     block_reason = _evolution_restart_block_reason(ctx)
     if block_reason:
         return f"⚠️ RESTART_BLOCKED: in evolution mode, {block_reason}."
+    is_evolution = str(ctx.current_task_type or "") == "evolution"
+    restart_reason = str(reason or "").strip() or "agent_requested_restart"
     # Persist expected ref for post-restart verification.
     try:
         sha = run_cmd(["git", "rev-parse", "HEAD"], cwd=ctx.repo_dir)
         branch = run_cmd(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=ctx.repo_dir)
         verify_path = ctx.drive_path("state") / "pending_restart_verify.json"
+        evolution_claim = {}
+        if is_evolution:
+            metadata = getattr(ctx, "task_metadata", {})
+            metadata = metadata if isinstance(metadata, dict) else {}
+            tx = metadata.get("evolution_transaction")
+            tx = tx if isinstance(tx, dict) else {}
+            evolution_claim = {
+                "campaign_id": str(tx.get("campaign_id") or ""),
+                "transaction_id": str(tx.get("transaction_id") or ""),
+                "task_id": str(ctx.task_id or tx.get("task_id") or ""),
+                "commit_sha": str(sha or "").strip(),
+            }
         atomic_write_json(verify_path, {
             "ts": utc_now_iso(), "expected_sha": sha,
-            "expected_branch": branch, "reason": reason,
+            "expected_branch": branch, "reason": restart_reason,
+            **({"evolution_claim": evolution_claim} if evolution_claim else {}),
         })
-        if str(ctx.current_task_type or "") == "evolution":
+        if evolution_claim:
+            ctx.pending_restart_is_evolution = True
             try:
                 from supervisor.evolution_lifecycle import update_evolution_transaction
 
@@ -520,13 +551,17 @@ def _request_restart(ctx: ToolContext, reason: str) -> str:
                 )
             except Exception:
                 log.debug("Failed to record evolution restart request", exc_info=True)
-    except Exception:
+    except Exception as exc:
         log.debug("Failed to read VERSION file or git ref for restart verification", exc_info=True)
-        pass
-    ctx.pending_restart_reason = str(reason or "").strip() or "agent_requested_restart"
+        if is_evolution:
+            return (
+                "⚠️ RESTART_BLOCKED: the exact evolution restart receipt could not "
+                f"be persisted ({exc})."
+            )
+    ctx.pending_restart_reason = restart_reason
     ctx.last_push_succeeded = False
     ctx.last_reviewed_commit_sha = ""
-    return f"Restart requested: {reason}"
+    return f"Restart requested: {restart_reason}"
 
 
 def _set_tool_timeout(ctx: ToolContext, seconds: int) -> str:
@@ -1967,7 +2002,7 @@ def get_tools() -> List[ToolEntry]:
         }, _set_tool_timeout),
         ToolEntry("request_restart", {
             "name": "request_restart",
-            "description": "Ask supervisor to restart runtime (after a reviewed local commit or clean no-op state).",
+            "description": "Ask supervisor to restart runtime after a reviewed local commit or a non-evolution clean no-op; evolution requires its exact active commit receipt.",
             "parameters": {"type": "object", "properties": {"reason": {"type": "string"}}, "required": ["reason"]},
         }, _request_restart),
         ToolEntry("promote_to_stable", {

--- a/ouroboros/tools/git.py
+++ b/ouroboros/tools/git.py
@@ -1486,6 +1486,251 @@ def _task_attributed_commit_paths(
     return selected, attribution, error, (results_root, evidence_task_id)
 
 
+def _evolution_commit_authority(
+    ctx: ToolContext, *, commit_sha: str = "", require_receipt: bool = True,
+) -> tuple[Dict[str, str], Dict[str, Any]]:
+    metadata = getattr(ctx, "task_metadata", {})
+    metadata = metadata if isinstance(metadata, dict) else {}
+    tx = metadata.get("evolution_transaction")
+    tx = tx if isinstance(tx, dict) else {}
+    claim = {
+        "campaign_id": str(tx.get("campaign_id") or ""),
+        "transaction_id": str(tx.get("transaction_id") or ""),
+        "task_id": str(getattr(ctx, "task_id", "") or tx.get("task_id") or ""),
+    }
+    from supervisor.evolution_lifecycle import check_evolution_authority
+
+    authority = check_evolution_authority(
+        **claim,
+        commit_sha=str(commit_sha or "") if require_receipt else "",
+    )
+    expected_sha = str(commit_sha or "").strip()
+    if authority.get("ok") and expected_sha:
+        try:
+            head = run_cmd(["git", "rev-parse", "HEAD"], cwd=ctx.repo_dir).strip()
+        except Exception as exc:
+            authority = {**authority, "ok": False, "reason": f"git_state_unavailable:{exc}"}
+        else:
+            if head != expected_sha:
+                authority = {**authority, "ok": False, "reason": "head_mismatch"}
+    return claim, authority
+
+
+def _check_evolution_commit_stage(
+    ctx: ToolContext,
+    commit_message: str,
+    started_at: float,
+    *,
+    phase: str,
+    commit_sha: str = "",
+) -> tuple[Dict[str, str], str]:
+    """Recheck the exact evolution claim at a commit/publication boundary."""
+    claim, authority = _evolution_commit_authority(
+        ctx,
+        commit_sha=commit_sha,
+        require_receipt=phase != "pre_tag_authority",
+    )
+    if authority.get("ok"):
+        return claim, ""
+    reason = authority.get("reason") or "unknown"
+    if phase == "pre_review_authority":
+        message = (
+            "⚠️ EVOLUTION_AUTHORITY_REVOKED: the exact campaign/transaction/task "
+            f"claim is no longer active ({reason}). No reviewer was called and no "
+            "commit was created."
+        )
+    elif phase == "pre_commit_authority":
+        message = (
+            "⚠️ EVOLUTION_AUTHORITY_REVOKED: review completed, but the exact "
+            f"campaign claim disappeared before commit ({reason}). Nothing was committed."
+        )
+    else:
+        message = (
+            "⚠️ EVOLUTION_PUBLICATION_STOPPED: Git created reviewed local commit "
+            f"{commit_sha}, but campaign authority changed before local tag creation "
+            f"({reason}). Nothing was tagged, pushed, or scheduled for restart."
+        )
+    _record_commit_attempt(
+        ctx,
+        commit_message,
+        "failed" if phase == "pre_tag_authority" else "blocked",
+        block_reason="evolution_authority",
+        block_details=message,
+        duration_sec=time.time() - started_at,
+        phase=phase,
+        **({
+            "triad_models": getattr(ctx, "_last_triad_models", []),
+            "scope_model": getattr(ctx, "_last_scope_model", ""),
+        } if phase == "pre_tag_authority" else {}),
+    )
+    return claim, message
+
+
+def _preserve_evolution_orphan(
+    ctx: ToolContext, commit_sha: str, *, created_tag: str = "",
+) -> str:
+    """Keep an unauthorized local commit inspectable but outside normal push refs."""
+    sha = str(commit_sha or "").strip()
+    ref_name = f"refs/ouroboros/evolution-orphans/{sha}"
+    try:
+        resolved = run_cmd(
+            ["git", "rev-parse", "--verify", f"{sha}^{{commit}}"], cwd=ctx.repo_dir,
+        ).strip()
+        head = run_cmd(["git", "rev-parse", "HEAD"], cwd=ctx.repo_dir).strip()
+        parent = run_cmd(["git", "rev-parse", f"{sha}^"], cwd=ctx.repo_dir).strip()
+        if resolved != sha or head != sha or not parent:
+            raise RuntimeError("the unauthorized commit is no longer the exact HEAD")
+        branch_ref = run_cmd(
+            ["git", "symbolic-ref", "-q", "HEAD"], cwd=ctx.repo_dir,
+        ).strip()
+        if not branch_ref.startswith("refs/heads/"):
+            raise RuntimeError("HEAD is not attached to a local branch")
+        commands = [
+            "start",
+            f"update {ref_name} {sha}",
+            f"update {branch_ref} {parent} {sha}",
+        ]
+        tag_note = ""
+        tag_name = str(created_tag or "").strip()
+        if tag_name:
+            try:
+                target_commit = run_cmd(
+                    ["git", "rev-parse", f"refs/tags/{tag_name}^{{commit}}"], cwd=ctx.repo_dir,
+                ).strip()
+                target_oid = run_cmd(
+                    ["git", "rev-parse", f"refs/tags/{tag_name}"], cwd=ctx.repo_dir,
+                ).strip()
+            except Exception:
+                target_commit = target_oid = ""
+            if target_commit == sha and target_oid:
+                commands.append(f"delete refs/tags/{tag_name} {target_oid}")
+                tag_note = f"; deleted local tag {tag_name}"
+        commands.extend(("prepare", "commit"))
+        proc = subprocess.run(
+            ["git", "update-ref", "--stdin"],
+            cwd=ctx.repo_dir,
+            input="\n".join(commands) + "\n",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(proc.stderr.strip() or "git update-ref transaction failed")
+        # Align tracked files without moving the branch ref again. A concurrent
+        # Git writer may legitimately advance it after the CAS transaction.
+        run_cmd(["git", "read-tree", "--reset", "-u", "HEAD"], cwd=ctx.repo_dir)
+        final_head = run_cmd(["git", "rev-parse", "HEAD"], cwd=ctx.repo_dir).strip()
+        branch_note = (
+            f"the active branch was reset to {parent[:12]}"
+            if final_head == parent
+            else f"a concurrent branch update to {final_head[:12]} was preserved"
+        )
+        return f"The commit remains at private local ref {ref_name}; {branch_note}{tag_note}."
+    except Exception as exc:
+        return (
+            "⚠️ EVOLUTION_ORPHAN_CONTAINMENT_FAILED: normal publication remains blocked, "
+            f"but the active ref could not be reset safely ({_sanitize_git_error(str(exc))})."
+        )
+
+
+def _record_evolution_commit_receipt(
+    ctx: ToolContext,
+    commit_message: str,
+    started_at: float,
+    claim: Dict[str, str],
+    commit_sha: str,
+    created_tag: str = "",
+) -> str:
+    """Record the exact reviewed SHA or leave it as an inspectable local orphan."""
+    from supervisor.evolution_lifecycle import record_evolution_commit
+
+    receipt = record_evolution_commit(**claim, commit_sha=commit_sha)
+    if receipt.get("ok"):
+        return ""
+    containment = _preserve_evolution_orphan(
+        ctx, commit_sha, created_tag=created_tag,
+    )
+    message = (
+        "⚠️ EVOLUTION_COMMIT_ORPHANED: Git created reviewed local commit "
+        f"{commit_sha}, but its exact campaign authority disappeared before the "
+        f"SHA receipt was recorded ({receipt.get('reason') or 'unknown'}). "
+        f"Nothing was pushed or scheduled for restart. {containment}"
+    )
+    _record_commit_attempt(
+        ctx,
+        commit_message,
+        "failed",
+        block_reason="evolution_authority",
+        block_details=message,
+        duration_sec=time.time() - started_at,
+        phase="post_commit_authority",
+        triad_models=getattr(ctx, "_last_triad_models", []),
+        scope_model=getattr(ctx, "_last_scope_model", ""),
+    )
+    return message
+
+
+def _evolution_publication_stopped_result(
+    ctx: ToolContext, commit_message: str, commit_sha: str, test_warning: str,
+    created_tag: str = "",
+) -> str:
+    """Format a local-only result when the SHA receipt loses authority."""
+    if str(ctx.current_task_type or "") != "evolution":
+        return ""
+    _, authority = _evolution_commit_authority(ctx, commit_sha=commit_sha)
+    if authority.get("ok"):
+        return ""
+    ctx.last_push_succeeded = False
+    containment = _preserve_evolution_orphan(
+        ctx, commit_sha, created_tag=created_tag,
+    )
+    return (
+        "⚠️ EVOLUTION_PUBLICATION_STOPPED: campaign authority changed after "
+        f"the local SHA receipt ({authority.get('reason') or 'unknown'}). Nothing "
+        f"was pushed and restart remains blocked. {containment}{test_warning}"
+    )
+
+
+def _publish_reviewed_commit(
+    ctx: ToolContext,
+    commit_message: str,
+    commit_sha: str,
+    tag_info: str,
+    test_warning: str,
+    paths: Optional[List[str]],
+    push_status: str,
+) -> str:
+    """Record push state and format the successful reviewed commit result."""
+    is_evolution = str(ctx.current_task_type or "") == "evolution"
+    ctx.last_push_succeeded = "[pushed:" in push_status
+    if is_evolution:
+        try:
+            from supervisor.evolution_lifecycle import update_evolution_transaction
+
+            update_evolution_transaction(
+                str(ctx.task_id or ""),
+                push_status="pushed" if ctx.last_push_succeeded else "skipped_or_failed",
+            )
+        except Exception:
+            log.debug("Failed to record evolution transaction push status", exc_info=True)
+    ci_note = _check_ci_status_after_push(ctx.repo_dir) if ctx.last_push_succeeded else ""
+    result = _format_commit_result(ctx, commit_message, push_status + tag_info, test_warning)
+    if is_evolution:
+        result += (
+            "\n\nEvolution transaction open: this cycle should contain at most one reviewed commit. "
+            "If this commit is the intended change, call request_restart once now and then stop."
+        )
+    if paths is not None:
+        try:
+            untracked = run_cmd(["git", "ls-files", "--others", "--exclude-standard"], cwd=ctx.repo_dir)
+            if untracked.strip():
+                files = ", ".join(untracked.strip().split("\n"))
+                result += f"\n⚠️ WARNING: untracked files remain: {files}"
+        except Exception:
+            pass
+    return result + ci_note
+
+
 def _repo_commit_push(ctx: ToolContext, commit_message: str,
                        paths: Optional[List[str]] = None,
                        skip_tests: bool = False,
@@ -1567,6 +1812,13 @@ def _repo_commit_push(ctx: ToolContext, commit_message: str,
         )
         if preparation_error:
             return _fail(preparation_error)
+        evolution_claim: Dict[str, str] = {}
+        if str(ctx.current_task_type or "") == "evolution":
+            evolution_claim, authority_error = _check_evolution_commit_stage(
+                ctx, commit_message, _commit_start, phase="pre_review_authority",
+            )
+            if authority_error:
+                return authority_error
         outcome = _run_reviewed_stage_cycle(
             ctx,
             commit_message,
@@ -1594,6 +1846,13 @@ def _repo_commit_push(ctx: ToolContext, commit_message: str,
             return str(outcome.get("message", "") or "")
         pre_fingerprint = outcome.get("pre_fingerprint", {}) or {}
         post_fingerprint = outcome.get("post_fingerprint", {}) or {}
+
+        if evolution_claim:
+            _, authority_error = _check_evolution_commit_stage(
+                ctx, commit_message, _commit_start, phase="pre_commit_authority",
+            )
+            if authority_error:
+                return authority_error
 
         if _managed_tx:
             # PRIMARY conflict-marker leakage gate (a `git add`-ed marker file is a resolved
@@ -1659,13 +1918,24 @@ def _repo_commit_push(ctx: ToolContext, commit_message: str,
         # update would otherwise reach origin / create a version tag, and a later rollback would
         # diverge from origin). The official version tag is handled on the owner's terms.
         tag_info = ""
+        created_tag = ""
         if not _managed_tx:
+            if evolution_claim:
+                _, authority_error = _check_evolution_commit_stage(
+                    ctx, commit_message, _commit_start,
+                    phase="pre_tag_authority", commit_sha=commit_sha,
+                )
+                if authority_error:
+                    containment = _preserve_evolution_orphan(ctx, commit_sha)
+                    return f"{authority_error}\n\n{containment}"
+            reviewed_tag = str(reviewed_binding.get("expected_tag") or "")
             tag_info = _auto_tag_on_version_bump(
                 pathlib.Path(ctx.repo_dir),
                 commit_message,
                 expected_commit_sha=commit_sha,
-                expected_tag=str(reviewed_binding.get("expected_tag") or ""),
+                expected_tag=reviewed_tag,
             )
+            created_tag = reviewed_tag if tag_info == f" [tagged: {reviewed_tag}]" else ""
         binding_ok, binding_detail = _verify_reviewed_commit_binding(
             pathlib.Path(ctx.repo_dir),
             commit_sha,
@@ -1696,6 +1966,14 @@ def _repo_commit_push(ctx: ToolContext, commit_message: str,
                 degraded_reasons=list(getattr(ctx, "_review_degraded_reasons", []) or []),
             )
             return binding_msg
+        if evolution_claim:
+            receipt_error = _record_evolution_commit_receipt(
+                ctx, commit_message, _commit_start, evolution_claim, commit_sha,
+                created_tag=created_tag,
+            )
+            if receipt_error:
+                return receipt_error
+        _post_commit_result(ctx, commit_message, skip_tests, test_warning_ref)
         ctx.last_reviewed_commit_sha = commit_sha
         if attribution_binding is not None:
             # The task's own commit moved HEAD: open the next attributed-staging
@@ -1710,21 +1988,6 @@ def _repo_commit_push(ctx: ToolContext, commit_message: str,
                 )
             except Exception:
                 log.warning("mutation baseline advance failed after commit", exc_info=True)
-        if str(ctx.current_task_type or "") == "evolution":
-            try:
-                from supervisor.evolution_lifecycle import update_evolution_transaction
-
-                update_evolution_transaction(
-                    str(ctx.task_id or ""),
-                    preflight_status="passed",
-                    advisory_status="fresh_or_bypassed",
-                    triad_scope_status="passed",
-                    commit_sha=commit_sha,
-                    restart_required=True,
-                    restart_verified=False,
-                )
-            except Exception:
-                log.debug("Failed to record evolution transaction commit", exc_info=True)
         _record_commit_attempt(ctx, commit_message, "succeeded",
                                duration_sec=time.time() - _commit_start,
                                phase="commit",
@@ -1737,7 +2000,17 @@ def _repo_commit_push(ctx: ToolContext, commit_message: str,
                                scope_raw_result=getattr(ctx, "_last_scope_raw_result", {}),
                                degraded_reasons=list(getattr(ctx, "_review_degraded_reasons", []) or []))
         ctx._scope_review_history = {}  # Clear on success — next commit starts fresh
-        _post_commit_result(ctx, commit_message, skip_tests, test_warning_ref)
+        if not _managed_tx:
+            publication_error = _evolution_publication_stopped_result(
+                ctx, commit_message, commit_sha, test_warning_ref[0],
+                created_tag=created_tag,
+            )
+            if publication_error:
+                return publication_error
+            push_status = _auto_push(ctx.repo_dir)
+            return _publish_reviewed_commit(
+                ctx, commit_message, commit_sha, tag_info, test_warning_ref[0], paths, push_status,
+            )
     finally:
         _release_git_lock(lock)
     if _managed_tx:
@@ -1755,36 +2028,7 @@ def _repo_commit_push(ctx: ToolContext, commit_message: str,
                                    duration_sec=time.time() - _commit_start)
             return _msg_pc
         return _format_commit_result(ctx, commit_message, "", test_warning_ref[0]) + "\n\n" + _msg_pc
-    push_status = _auto_push(ctx.repo_dir)
-    ctx.last_push_succeeded = "[pushed:" in push_status
-    if str(ctx.current_task_type or "") == "evolution":
-        try:
-            from supervisor.evolution_lifecycle import update_evolution_transaction
-
-            update_evolution_transaction(
-                str(ctx.task_id or ""),
-                push_status="pushed" if ctx.last_push_succeeded else "skipped_or_failed",
-            )
-        except Exception:
-            log.debug("Failed to record evolution transaction push status", exc_info=True)
-    ci_note = ""
-    if ctx.last_push_succeeded:
-        ci_note = _check_ci_status_after_push(ctx.repo_dir)
-    result = _format_commit_result(ctx, commit_message, push_status + tag_info, test_warning_ref[0])
-    if str(ctx.current_task_type or "") == "evolution":
-        result += (
-            "\n\nEvolution transaction open: this cycle should contain at most one reviewed commit. "
-            "If this commit is the intended change, call request_restart once now and then stop."
-        )
-    if paths is not None:
-        try:
-            untracked = run_cmd(["git", "ls-files", "--others", "--exclude-standard"], cwd=ctx.repo_dir)
-            if untracked.strip():
-                files = ", ".join(untracked.strip().split("\n"))
-                result += f"\n⚠️ WARNING: untracked files remain: {files}"
-        except Exception:
-            pass
-    return result + ci_note
+    raise RuntimeError("unreachable non-managed commit path")
 
 
 def _limit_git_output(text: str, max_chars: int = 0) -> str:

--- a/ouroboros/tools/git.py
+++ b/ouroboros/tools/git.py
@@ -1488,6 +1488,7 @@ def _task_attributed_commit_paths(
 
 def _evolution_commit_authority(
     ctx: ToolContext, *, commit_sha: str = "", require_receipt: bool = True,
+    require_uncommitted: bool = False,
 ) -> tuple[Dict[str, str], Dict[str, Any]]:
     metadata = getattr(ctx, "task_metadata", {})
     metadata = metadata if isinstance(metadata, dict) else {}
@@ -1503,6 +1504,7 @@ def _evolution_commit_authority(
     authority = check_evolution_authority(
         **claim,
         commit_sha=str(commit_sha or "") if require_receipt else "",
+        require_uncommitted=bool(require_uncommitted),
     )
     expected_sha = str(commit_sha or "").strip()
     if authority.get("ok") and expected_sha:
@@ -1529,6 +1531,7 @@ def _check_evolution_commit_stage(
         ctx,
         commit_sha=commit_sha,
         require_receipt=phase != "pre_tag_authority",
+        require_uncommitted=phase in {"pre_review_authority", "pre_commit_authority"},
     )
     if authority.get("ok"):
         return claim, ""
@@ -1569,7 +1572,12 @@ def _check_evolution_commit_stage(
 def _preserve_evolution_orphan(
     ctx: ToolContext, commit_sha: str, *, created_tag: str = "",
 ) -> str:
-    """Keep an unauthorized local commit inspectable but outside normal push refs."""
+    """Keep an unauthorized local commit inspectable but outside normal push refs.
+
+    Ref containment deliberately never touches the index or worktree: another task may
+    have edited tracked bytes after the commit was created. Leaving those bytes visibly
+    dirty is safer than aligning them to the rewound branch and losing concurrent work.
+    """
     sha = str(commit_sha or "").strip()
     ref_name = f"refs/ouroboros/evolution-orphans/{sha}"
     try:
@@ -1592,6 +1600,7 @@ def _preserve_evolution_orphan(
         ]
         tag_note = ""
         tag_name = str(created_tag or "").strip()
+        target_oid = ""
         if tag_name:
             try:
                 target_commit = run_cmd(
@@ -1606,26 +1615,101 @@ def _preserve_evolution_orphan(
                 commands.append(f"delete refs/tags/{tag_name} {target_oid}")
                 tag_note = f"; deleted local tag {tag_name}"
         commands.extend(("prepare", "commit"))
-        proc = subprocess.run(
-            ["git", "update-ref", "--stdin"],
-            cwd=ctx.repo_dir,
-            input="\n".join(commands) + "\n",
-            text=True,
-            capture_output=True,
-            check=False,
-        )
-        if proc.returncode != 0:
-            raise RuntimeError(proc.stderr.strip() or "git update-ref transaction failed")
-        # Align tracked files without moving the branch ref again. A concurrent
-        # Git writer may legitimately advance it after the CAS transaction.
-        run_cmd(["git", "read-tree", "--reset", "-u", "HEAD"], cwd=ctx.repo_dir)
+        transaction_error = ""
+        for _attempt in range(2):
+            proc = subprocess.run(
+                ["git", "update-ref", "--stdin"],
+                cwd=ctx.repo_dir,
+                input="\n".join(commands) + "\n",
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            if proc.returncode == 0:
+                transaction_error = ""
+                break
+            transaction_error = proc.stderr.strip() or "git update-ref transaction failed"
+
+        # A ref transaction is atomic, so a failed transaction can be decomposed into
+        # individually verified CAS operations without risking a partial worktree reset.
+        if transaction_error:
+            zero_oid = "0" * 40
+            try:
+                current_orphan = run_cmd(
+                    ["git", "rev-parse", "--verify", ref_name], cwd=ctx.repo_dir,
+                ).strip()
+            except Exception:
+                current_orphan = ""
+            if current_orphan != sha:
+                fallback = subprocess.run(
+                    ["git", "update-ref", ref_name, sha, zero_oid],
+                    cwd=ctx.repo_dir, text=True, capture_output=True, check=False,
+                )
+                if fallback.returncode != 0:
+                    raise RuntimeError(
+                        fallback.stderr.strip() or f"could not create {ref_name}"
+                    )
+
+            current_branch = run_cmd(
+                ["git", "rev-parse", branch_ref], cwd=ctx.repo_dir,
+            ).strip()
+            if current_branch == sha:
+                fallback = subprocess.run(
+                    ["git", "update-ref", branch_ref, parent, sha],
+                    cwd=ctx.repo_dir, text=True, capture_output=True, check=False,
+                )
+                if fallback.returncode != 0:
+                    raise RuntimeError(
+                        fallback.stderr.strip() or f"could not reset {branch_ref}"
+                    )
+
+            if tag_name and target_oid:
+                try:
+                    current_tag_oid = run_cmd(
+                        ["git", "rev-parse", f"refs/tags/{tag_name}"], cwd=ctx.repo_dir,
+                    ).strip()
+                except Exception:
+                    current_tag_oid = ""
+                if current_tag_oid == target_oid:
+                    fallback = subprocess.run(
+                        ["git", "update-ref", "-d", f"refs/tags/{tag_name}", target_oid],
+                        cwd=ctx.repo_dir, text=True, capture_output=True, check=False,
+                    )
+                    if fallback.returncode != 0:
+                        raise RuntimeError(
+                            fallback.stderr.strip() or f"could not delete tag {tag_name}"
+                        )
+
+        final_orphan = run_cmd(
+            ["git", "rev-parse", "--verify", ref_name], cwd=ctx.repo_dir,
+        ).strip()
+        if final_orphan != sha:
+            raise RuntimeError("private orphan ref does not resolve to the unauthorized commit")
         final_head = run_cmd(["git", "rev-parse", "HEAD"], cwd=ctx.repo_dir).strip()
+        reachable = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", sha, branch_ref],
+            cwd=ctx.repo_dir, text=True, capture_output=True, check=False,
+        ).returncode == 0
+        if reachable:
+            raise RuntimeError("the unauthorized commit remains reachable from the active branch")
+        if tag_name:
+            try:
+                final_tag_target = run_cmd(
+                    ["git", "rev-parse", f"refs/tags/{tag_name}^{{commit}}"], cwd=ctx.repo_dir,
+                ).strip()
+            except Exception:
+                final_tag_target = ""
+            if final_tag_target == sha:
+                raise RuntimeError(f"tag {tag_name} still reaches the unauthorized commit")
         branch_note = (
             f"the active branch was reset to {parent[:12]}"
             if final_head == parent
             else f"a concurrent branch update to {final_head[:12]} was preserved"
         )
-        return f"The commit remains at private local ref {ref_name}; {branch_note}{tag_note}."
+        return (
+            f"The commit remains at private local ref {ref_name}; {branch_note}{tag_note}. "
+            "The index and worktree were left untouched for lossless recovery."
+        )
     except Exception as exc:
         return (
             "⚠️ EVOLUTION_ORPHAN_CONTAINMENT_FAILED: normal publication remains blocked, "
@@ -1672,7 +1756,8 @@ def _record_evolution_commit_receipt(
 
 def _evolution_publication_stopped_result(
     ctx: ToolContext, commit_message: str, commit_sha: str, test_warning: str,
-    created_tag: str = "",
+    created_tag: str = "", started_at: float = 0.0,
+    fingerprints: Optional[tuple[Dict[str, Any], Dict[str, Any]]] = None,
 ) -> str:
     """Format a local-only result when the SHA receipt loses authority."""
     if str(ctx.current_task_type or "") != "evolution":
@@ -1684,11 +1769,26 @@ def _evolution_publication_stopped_result(
     containment = _preserve_evolution_orphan(
         ctx, commit_sha, created_tag=created_tag,
     )
-    return (
+    pre_fingerprint, post_fingerprint = fingerprints or ({}, {})
+    message = (
         "⚠️ EVOLUTION_PUBLICATION_STOPPED: campaign authority changed after "
         f"the local SHA receipt ({authority.get('reason') or 'unknown'}). Nothing "
         f"was pushed and restart remains blocked. {containment}{test_warning}"
     )
+    _record_commit_attempt(
+        ctx, commit_message, "failed",
+        block_reason="evolution_authority", block_details=message,
+        duration_sec=time.time() - started_at if started_at else 0.0,
+        phase="publication_authority", fingerprint_status="matched",
+        pre_review_fingerprint=pre_fingerprint.get("fingerprint", ""),
+        post_review_fingerprint=post_fingerprint.get("fingerprint", ""),
+        triad_models=getattr(ctx, "_last_triad_models", []),
+        scope_model=getattr(ctx, "_last_scope_model", ""),
+        triad_raw_results=getattr(ctx, "_last_triad_raw_results", []),
+        scope_raw_result=getattr(ctx, "_last_scope_raw_result", {}),
+        degraded_reasons=list(getattr(ctx, "_review_degraded_reasons", []) or []),
+    )
+    return message
 
 
 def _publish_reviewed_commit(
@@ -1814,9 +1914,7 @@ def _repo_commit_push(ctx: ToolContext, commit_message: str,
             return _fail(preparation_error)
         evolution_claim: Dict[str, str] = {}
         if str(ctx.current_task_type or "") == "evolution":
-            evolution_claim, authority_error = _check_evolution_commit_stage(
-                ctx, commit_message, _commit_start, phase="pre_review_authority",
-            )
+            evolution_claim, authority_error = _check_evolution_commit_stage(ctx, commit_message, _commit_start, phase="pre_review_authority")
             if authority_error:
                 return authority_error
         outcome = _run_reviewed_stage_cycle(
@@ -1848,9 +1946,7 @@ def _repo_commit_push(ctx: ToolContext, commit_message: str,
         post_fingerprint = outcome.get("post_fingerprint", {}) or {}
 
         if evolution_claim:
-            _, authority_error = _check_evolution_commit_stage(
-                ctx, commit_message, _commit_start, phase="pre_commit_authority",
-            )
+            _, authority_error = _check_evolution_commit_stage(ctx, commit_message, _commit_start, phase="pre_commit_authority")
             if authority_error:
                 return authority_error
 
@@ -1895,6 +1991,8 @@ def _repo_commit_push(ctx: ToolContext, commit_message: str,
                 "was NOT tagged or pushed; inspect the repository and re-run review on a "
                 f"new exact tree. Detail: {binding_detail}"
             )
+            if evolution_claim:
+                binding_msg += " " + _preserve_evolution_orphan(ctx, commit_sha)
             _record_commit_attempt(
                 ctx,
                 commit_message,
@@ -1921,10 +2019,7 @@ def _repo_commit_push(ctx: ToolContext, commit_message: str,
         created_tag = ""
         if not _managed_tx:
             if evolution_claim:
-                _, authority_error = _check_evolution_commit_stage(
-                    ctx, commit_message, _commit_start,
-                    phase="pre_tag_authority", commit_sha=commit_sha,
-                )
+                _, authority_error = _check_evolution_commit_stage(ctx, commit_message, _commit_start, phase="pre_tag_authority", commit_sha=commit_sha)
                 if authority_error:
                     containment = _preserve_evolution_orphan(ctx, commit_sha)
                     return f"{authority_error}\n\n{containment}"
@@ -1948,6 +2043,10 @@ def _repo_commit_push(ctx: ToolContext, commit_message: str,
                 "release-tag verification failed. Nothing was pushed; immutable tags are "
                 f"never retargeted. Detail: {binding_detail}"
             )
+            if evolution_claim:
+                binding_msg += " " + _preserve_evolution_orphan(
+                    ctx, commit_sha, created_tag=created_tag,
+                )
             _record_commit_attempt(
                 ctx,
                 commit_message,
@@ -1974,6 +2073,15 @@ def _repo_commit_push(ctx: ToolContext, commit_message: str,
             if receipt_error:
                 return receipt_error
         _post_commit_result(ctx, commit_message, skip_tests, test_warning_ref)
+        push_status = ""
+        if not _managed_tx and evolution_claim:
+            publication_error = _evolution_publication_stopped_result(
+                ctx, commit_message, commit_sha, test_warning_ref[0],
+                created_tag=created_tag, started_at=_commit_start, fingerprints=(pre_fingerprint, post_fingerprint),
+            )
+            if publication_error:
+                return publication_error
+            push_status = _auto_push(ctx.repo_dir)
         ctx.last_reviewed_commit_sha = commit_sha
         if attribution_binding is not None:
             # The task's own commit moved HEAD: open the next attributed-staging
@@ -2000,17 +2108,6 @@ def _repo_commit_push(ctx: ToolContext, commit_message: str,
                                scope_raw_result=getattr(ctx, "_last_scope_raw_result", {}),
                                degraded_reasons=list(getattr(ctx, "_review_degraded_reasons", []) or []))
         ctx._scope_review_history = {}  # Clear on success — next commit starts fresh
-        if not _managed_tx:
-            publication_error = _evolution_publication_stopped_result(
-                ctx, commit_message, commit_sha, test_warning_ref[0],
-                created_tag=created_tag,
-            )
-            if publication_error:
-                return publication_error
-            push_status = _auto_push(ctx.repo_dir)
-            return _publish_reviewed_commit(
-                ctx, commit_message, commit_sha, tag_info, test_warning_ref[0], paths, push_status,
-            )
     finally:
         _release_git_lock(lock)
     if _managed_tx:
@@ -2028,7 +2125,11 @@ def _repo_commit_push(ctx: ToolContext, commit_message: str,
                                    duration_sec=time.time() - _commit_start)
             return _msg_pc
         return _format_commit_result(ctx, commit_message, "", test_warning_ref[0]) + "\n\n" + _msg_pc
-    raise RuntimeError("unreachable non-managed commit path")
+    if not evolution_claim:
+        push_status = _auto_push(ctx.repo_dir)
+    return _publish_reviewed_commit(
+        ctx, commit_message, commit_sha, tag_info, test_warning_ref[0], paths, push_status,
+    )
 
 
 def _limit_git_output(text: str, max_chars: int = 0) -> str:

--- a/server.py
+++ b/server.py
@@ -5,6 +5,7 @@ import base64
 import json
 import logging
 import socket
+import subprocess
 
 import os
 import pathlib
@@ -12,7 +13,7 @@ import sys
 import threading
 import time
 import uuid
-from ouroboros.utils import utc_now_iso
+from ouroboros.utils import read_json_dict, utc_now_iso
 from typing import Any, Dict, Optional
 
 from starlette.applications import Starlette
@@ -1269,11 +1270,18 @@ def _process_bridge_updates(bridge, offset: int, ctx: Any) -> int:
             if turn_on and len(parts) > 2:
                 objective = text.split(None, 2)[2].strip()
             if turn_on:
-                from supervisor.evolution_lifecycle import evolution_block_reason
+                from supervisor.evolution_lifecycle import evolution_block_reason, start_evolution_campaign
 
                 block = evolution_block_reason()
                 if block:
                     ctx.send_with_budget(chat_id, block)
+                    continue
+                try:
+                    if not start_evolution_campaign(objective, source="owner_chat"):
+                        raise RuntimeError("campaign write was refused")
+                except Exception:
+                    log.warning("Failed to start evolution campaign", exc_info=True)
+                    ctx.send_with_budget(chat_id, "⚠️ Evolution stayed OFF: campaign state could not be created.")
                     continue
             st2 = ctx.load_state()
             st2["evolution_mode_enabled"] = bool(turn_on)
@@ -1309,11 +1317,9 @@ def _process_bridge_updates(bridge, offset: int, ctx: Any) -> int:
                         f"🛑 Cancelled running evolution task(s): {', '.join(cancelled)}",
                     )
             try:
-                from supervisor.evolution_lifecycle import complete_evolution_campaign, start_evolution_campaign
+                from supervisor.evolution_lifecycle import complete_evolution_campaign
 
-                if turn_on:
-                    start_evolution_campaign(objective, source="owner_chat")
-                else:
+                if not turn_on:
                     # Terminal close (not a resumable pause): /evolve start mints a FRESH
                     # campaign rather than resurrecting this one.
                     complete_evolution_campaign("disabled via owner chat", status="stopped")
@@ -1822,6 +1828,7 @@ def _handle_restart_in_supervisor(evt: Dict[str, Any], ctx: Any) -> None:
         _pending_restart.update({
             "reason": str(evt.get("reason") or "agent_restart_request"),
             "deadline": time.time() + min(max_wait, 1800),
+            "evolution_restart": bool(evt.get("evolution_restart")),
         })
         if st.get("owner_chat_id"):
             ctx.send_with_budget(
@@ -1830,7 +1837,10 @@ def _handle_restart_in_supervisor(evt: Dict[str, Any], ctx: Any) -> None:
                 f"{', '.join(sorted(live))} to finish.",
             )
         return
-    _perform_supervisor_restart(ctx)
+    _perform_supervisor_restart(
+        ctx, restart_reason=str(evt.get("reason") or "agent_restart_request"),
+        evolution_restart=bool(evt.get("evolution_restart")),
+    )
 
 
 def _check_pending_restart_drain(ctx: Any) -> bool:
@@ -1842,8 +1852,12 @@ def _check_pending_restart_drain(ctx: Any) -> bool:
     live = _live_running_task_ids(ctx)
     if live and time.time() < float(_pending_restart.get("deadline") or 0.0):
         return True  # keep draining — events still flow each tick
+    pending = dict(_pending_restart)
     _pending_restart.clear()
-    _perform_supervisor_restart(ctx)
+    _perform_supervisor_restart(
+        ctx, restart_reason=str(pending.get("reason") or "agent_restart_request"),
+        evolution_restart=bool(pending.get("evolution_restart")),
+    )
     # Still "quiescing" this tick: _perform_supervisor_restart sets up the exit
     # (or fail-closed pauses) and returns to the loop — the process exits on the
     # next `while not _restart_requested` check. Returning True keeps the caller
@@ -1851,9 +1865,74 @@ def _check_pending_restart_drain(ctx: Any) -> bool:
     return True
 
 
-def _perform_supervisor_restart(ctx: Any) -> None:
+def _perform_supervisor_restart(
+    ctx: Any, *, restart_reason: str = "agent_restart_request",
+    evolution_restart: bool = False,
+) -> None:
     """Graceful shutdown + exit(42) (the post-drain tail; never sleeps)."""
     st = ctx.load_state()
+    marker = read_json_dict(
+        pathlib.Path(ctx.DRIVE_ROOT) / "state" / "pending_restart_verify.json"
+    ) or {}
+    claim = (
+        marker.get("evolution_claim")
+        if evolution_restart and marker.get("reason") == restart_reason
+        else {}
+    )
+    claim = claim if isinstance(claim, dict) else {}
+    if evolution_restart and not claim:
+        if st.get("owner_chat_id"):
+            ctx.send_with_budget(
+                int(st["owner_chat_id"]),
+                "🧬 Restart cancelled: the exact evolution restart receipt is missing.",
+            )
+        return
+    if claim:
+        from supervisor.evolution_lifecycle import check_evolution_authority
+
+        authority = check_evolution_authority(
+            str(claim.get("campaign_id") or ""),
+            str(claim.get("transaction_id") or ""),
+            str(claim.get("task_id") or ""),
+            commit_sha=str(claim.get("commit_sha") or ""),
+        )
+        if not authority.get("ok"):
+            if st.get("owner_chat_id"):
+                ctx.send_with_budget(
+                    int(st["owner_chat_id"]),
+                    "🧬 Restart cancelled: evolution authority changed "
+                    f"({authority.get('reason') or 'unknown'}).",
+                )
+            return
+        expected_sha = str(claim.get("commit_sha") or "")
+        try:
+            head_proc = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=str(ctx.REPO_DIR),
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            status_proc = subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=str(ctx.REPO_DIR),
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            head = head_proc.stdout.strip() if head_proc.returncode == 0 else ""
+            clean = status_proc.returncode == 0 and not status_proc.stdout.strip()
+        except Exception:
+            head = ""
+            clean = False
+        if not expected_sha or head != expected_sha or not clean:
+            if st.get("owner_chat_id"):
+                ctx.send_with_budget(
+                    int(st["owner_chat_id"]),
+                    "🧬 Restart cancelled: the live checkout no longer matches "
+                    "the exact reviewed evolution commit.",
+                )
+            return
     ok, msg = ctx.safe_restart(
         reason="agent_restart_request", unsynced_policy="rescue_and_block",
     )

--- a/supervisor/events.py
+++ b/supervisor/events.py
@@ -1502,10 +1502,51 @@ def _handle_deep_self_review_request(evt: Dict[str, Any], ctx: Any) -> None:
 
 def _handle_promote_to_stable(evt: Dict[str, Any], ctx: Any) -> None:
     import subprocess as sp
+    target = ctx.BRANCH_DEV
+    evolution_claim = evt.get("evolution_claim")
+    if isinstance(evolution_claim, dict):
+        commit_sha = str(evolution_claim.get("commit_sha") or "").strip()
+        if not commit_sha:
+            authority = {"ok": False, "reason": "commit_receipt_missing"}
+        else:
+            from supervisor.evolution_lifecycle import check_evolution_authority
+
+            authority = check_evolution_authority(
+                campaign_id=str(evolution_claim.get("campaign_id") or ""),
+                transaction_id=str(evolution_claim.get("transaction_id") or ""),
+                task_id=str(evolution_claim.get("task_id") or ""),
+                commit_sha=commit_sha,
+            )
+        if not authority.get("ok"):
+            st = ctx.load_state()
+            if st.get("owner_chat_id"):
+                ctx.send_with_budget(
+                    int(st["owner_chat_id"]),
+                    "❌ Evolution promotion refused: the exact reviewed campaign claim "
+                    f"is no longer valid ({authority.get('reason') or 'unknown'}).",
+                )
+            return
+        try:
+            dev_sha = sp.run(
+                ["git", "rev-parse", ctx.BRANCH_DEV],
+                cwd=str(ctx.REPO_DIR), capture_output=True, text=True, check=True,
+            ).stdout.strip()
+        except Exception:
+            dev_sha = ""
+        if dev_sha != commit_sha:
+            st = ctx.load_state()
+            if st.get("owner_chat_id"):
+                ctx.send_with_budget(
+                    int(st["owner_chat_id"]),
+                    "❌ Evolution promotion refused: the development branch no longer "
+                    "matches the reviewed commit receipt.",
+                )
+            return
+        target = commit_sha
     # Local branch promotion always works without a remote.
     try:
         sp.run(
-            ["git", "branch", "-f", ctx.BRANCH_STABLE, ctx.BRANCH_DEV],
+            ["git", "branch", "-f", ctx.BRANCH_STABLE, target],
             cwd=str(ctx.REPO_DIR), check=True,
         )
         new_sha = sp.run(
@@ -1524,7 +1565,7 @@ def _handle_promote_to_stable(evt: Dict[str, Any], ctx: Any) -> None:
         sp.run(["git", "remote", "get-url", "origin"], cwd=str(ctx.REPO_DIR),
                capture_output=True, check=True)
         sp.run(
-            ["git", "push", "origin", f"{ctx.BRANCH_DEV}:{ctx.BRANCH_STABLE}"],
+            ["git", "push", "origin", f"{target}:{ctx.BRANCH_STABLE}"],
             cwd=str(ctx.REPO_DIR), check=True,
         )
         remote_status = " (pushed to origin)"

--- a/supervisor/events.py
+++ b/supervisor/events.py
@@ -1097,7 +1097,7 @@ def _handle_evolution_task_done(
             if isinstance(metadata.get("evolution_transaction"), dict)
             else {}
         )
-        recorded_transaction = update_evolution_campaign_after_task(
+        lifecycle_result = update_evolution_campaign_after_task(
             str(task_id or ""),
             cost_usd=cost,
             cost_accounting_status=str(
@@ -1107,32 +1107,40 @@ def _handle_evolution_task_done(
             rounds=rounds,
             transaction=transaction,
         )
-        replayed_terminal = bool(
-            isinstance(recorded_transaction, dict)
-            and recorded_transaction.get("_replay")
-        )
+        if not isinstance(lifecycle_result, dict):
+            log.warning("Evolution terminal rejected: invalid lifecycle result for %s", task_id)
+            return
+        if not lifecycle_result.get("accepted") or not lifecycle_result.get("persisted"):
+            log.warning(
+                "Evolution terminal rejected for %s: %s",
+                task_id, lifecycle_result.get("reason") or "not_persisted",
+            )
+            return
+        if lifecycle_result.get("replay"):
+            return
+        recorded_transaction = lifecycle_result.get("transaction")
+        recorded_transaction = recorded_transaction if isinstance(recorded_transaction, dict) else {}
         try:
             from ouroboros.evolution_checkpoints import append_evolution_checkpoint
 
-            if not replayed_terminal:
-                append_evolution_checkpoint(
-                    ctx.DRIVE_ROOT,
-                    ctx.REPO_DIR,
-                    task_id=str(task_id or ""),
-                    campaign=_read_evolution_campaign(),
-                    outcome_axes=outcome_axes,
-                    cost_usd=cost,
-                    cost_accounting_status=str(
-                        task_done_event.get("cost_accounting_status") or "available"
-                    ),
-                    rounds=rounds,
-                    transaction=recorded_transaction or transaction,
-                )
+            append_evolution_checkpoint(
+                ctx.DRIVE_ROOT,
+                ctx.REPO_DIR,
+                task_id=str(task_id or ""),
+                campaign=_read_evolution_campaign(),
+                outcome_axes=outcome_axes,
+                cost_usd=cost,
+                cost_accounting_status=str(
+                    task_done_event.get("cost_accounting_status") or "available"
+                ),
+                rounds=rounds,
+                transaction=recorded_transaction or transaction,
+            )
         except Exception:
             log.debug("Failed to append evolution checkpoint", exc_info=True)
     except Exception:
         log.debug("Failed to update evolution campaign state", exc_info=True)
-        replayed_terminal = False
+        return
 
     axes = normalize_outcome_axes({
         "status": task_done_event.get("status"),
@@ -1152,9 +1160,7 @@ def _handle_evolution_task_done(
         or objective_status in {"fail", "degraded"}
         or artifact_status in {"failed", "missing"}
     )
-    if replayed_terminal:
-        pass
-    elif not failed_by_axes and (rounds or 0) >= 1:
+    if not failed_by_axes and (rounds or 0) >= 1:
         from supervisor.state import update_state
 
         update_state(lambda live: live.update(evolution_consecutive_failures=0))
@@ -3126,13 +3132,25 @@ def _handle_toggle_evolution(evt: Dict[str, Any], ctx: Any) -> None:
     """Toggle evolution mode from LLM tool call."""
     enabled = bool(evt.get("enabled"))
     if enabled:
-        from supervisor.evolution_lifecycle import evolution_block_reason
+        from supervisor.evolution_lifecycle import evolution_block_reason, start_evolution_campaign
 
         block = evolution_block_reason()
         if block:
             st = ctx.load_state()
             if st.get("owner_chat_id"):
                 ctx.send_with_budget(int(st["owner_chat_id"]), block)
+            return
+        try:
+            if not start_evolution_campaign(str(evt.get("objective") or ""), source="agent_tool"):
+                raise RuntimeError("campaign write was refused")
+        except Exception:
+            log.warning("Failed to start evolution campaign from agent tool", exc_info=True)
+            st = ctx.load_state()
+            if st.get("owner_chat_id"):
+                ctx.send_with_budget(
+                    int(st["owner_chat_id"]),
+                    "🧬 Evolution stayed OFF: campaign state could not be created.",
+                )
             return
     from supervisor.state import update_state
 
@@ -3165,11 +3183,9 @@ def _handle_toggle_evolution(evt: Dict[str, Any], ctx: Any) -> None:
         ctx.sort_pending()
         ctx.persist_queue_snapshot(reason="evolve_off_via_tool")
     try:
-        from supervisor.evolution_lifecycle import complete_evolution_campaign, start_evolution_campaign
+        from supervisor.evolution_lifecycle import complete_evolution_campaign
 
-        if enabled:
-            start_evolution_campaign(str(evt.get("objective") or ""), source="agent_tool")
-        else:
+        if not enabled:
             # Terminal close (not a resumable pause), so a later /evolve start mints fresh.
             complete_evolution_campaign("disabled via agent tool", status="stopped")
     except Exception:

--- a/supervisor/evolution_lifecycle.py
+++ b/supervisor/evolution_lifecycle.py
@@ -634,26 +634,26 @@ def _clear_objective_repeat_count(campaign: Dict[str, Any], tx: Dict[str, Any]) 
         dropped.remove(fp)
 
 
-def update_evolution_transaction(task_id: str, **updates: Any) -> None:
+def update_evolution_transaction(task_id: str, **updates: Any) -> bool:
     """Best-effort update of the active/lightweight evolution transaction."""
     from supervisor import state
 
     state.assert_test_data_path(state.STATE_PATH)
     lock_fd = state.acquire_file_lock(state.STATE_LOCK_PATH)
     if lock_fd is None:
-        return
+        return False
     try:
         campaign = _read_evolution_campaign()
         tx = campaign.get("active_transaction")
         if not isinstance(tx, dict) or str(tx.get("task_id") or "") != str(task_id or ""):
-            return
+            return False
         for key, value in updates.items():
             if value is not None:
                 tx[key] = value
         tx["updated_at"] = utc_now_iso()
         campaign["active_transaction"] = tx
         campaign["updated_at"] = utc_now_iso()
-        _write_evolution_campaign(campaign, _state_lock_held=True)
+        return _write_evolution_campaign(campaign, _state_lock_held=True)
     finally:
         state.release_file_lock(state.STATE_LOCK_PATH, lock_fd)
 
@@ -807,6 +807,35 @@ def _persist_evolution_cleanup(campaign_id: str, tx: Dict[str, Any]) -> bool:
         state.release_file_lock(state.STATE_LOCK_PATH, lock_fd)
 
 
+def _resume_evolution_terminal_effects(
+    campaign_id: str, task_id: str, tx: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Finish idempotent effects that follow the durable terminal transition."""
+    from supervisor import queue
+
+    resumed = dict(tx or {})
+    if resumed.get("cleanup_status") == "pending":
+        _cleanup_worktree_after_cycle(resumed, str(task_id or ""))
+        try:
+            if not _persist_evolution_cleanup(campaign_id, resumed):
+                log.warning("Failed to persist evolution cleanup evidence for %s", task_id)
+        except Exception:
+            log.warning("Failed to persist evolution cleanup evidence for %s", task_id, exc_info=True)
+    if (
+        resumed.get("cycle_outcome") == "waiting_for_restart"
+        and resumed.get("restart_required")
+        and not resumed.get("restart_verified")
+    ):
+        try:
+            request_evolution_restart(queue.DRIVE_ROOT, resumed, log=log)
+        except Exception:
+            log.warning("Failed to resume evolution restart request for %s", task_id, exc_info=True)
+    # Abandon/absorb reports are staged in the same campaign write as the
+    # transition. Delivery clears only the exact report after a successful send.
+    deliver_pending_owner_report()
+    return resumed
+
+
 def update_evolution_campaign_after_task(
     task_id: str,
     *,
@@ -817,116 +846,136 @@ def update_evolution_campaign_after_task(
     transaction: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Record an evolution cycle outcome in the active campaign file."""
-    from supervisor import queue
+    from supervisor import state
 
-    campaign = _read_evolution_campaign()
-    if campaign.get("status") not in {"active", "paused"}:
+    state.assert_test_data_path(state.STATE_PATH)
+    lock_fd = state.acquire_file_lock(state.STATE_LOCK_PATH)
+    if lock_fd is None:
         return {
-            "accepted": False, "persisted": False, "replay": False,
-            "reason": "campaign_not_active", "transaction": {},
+            "accepted": True, "persisted": False, "replay": False,
+            "reason": "state_lock_unavailable", "transaction": {},
         }
-    metadata_tx = transaction if isinstance(transaction, dict) else {}
-    active_tx = campaign.get("active_transaction") if isinstance(campaign.get("active_transaction"), dict) else {}
-    expected_active_tx = dict(active_tx)
-    campaign_id = str(campaign.get("id") or "")
-
-    def _matches(candidate: Dict[str, Any]) -> bool:
-        return bool(
-            campaign_id
-            and str(candidate.get("campaign_id") or "") == campaign_id
-            and str(candidate.get("transaction_id") or "")
-            and str(candidate.get("task_id") or "") == str(task_id or "")
-        )
-
-    metadata_tx_id = str(metadata_tx.get("transaction_id") or "") if _matches(metadata_tx) else ""
-    if metadata_tx_id:
-        for existing in list(campaign.get("history") or []):
-            if not isinstance(existing, dict) or str(existing.get("task_id") or "") != str(task_id or ""):
-                continue
-            existing_tx = existing.get("transaction")
-            if (
-                isinstance(existing_tx, dict)
-                and str(existing_tx.get("campaign_id") or "") == campaign_id
-                and str(existing_tx.get("transaction_id") or "") == metadata_tx_id
-            ):
-                return {
-                    "accepted": True, "persisted": True, "replay": True,
-                    "reason": "duplicate_terminal", "transaction": dict(existing_tx),
-                }
-
-    if active_tx or metadata_tx:
-        if (
-            not _matches(active_tx)
-            or not _matches(metadata_tx)
-            or str(active_tx.get("transaction_id") or "")
-            != str(metadata_tx.get("transaction_id") or "")
-        ):
+    replay_found = False
+    replay_tx: Dict[str, Any] = {}
+    campaign_id = ""
+    tx: Dict[str, Any] = {}
+    try:
+        # The complete read/check/mutate/write is protected by the same state lock
+        # used by pause, owner stop, boot reconciliation, and transaction updates.
+        campaign = _read_evolution_campaign()
+        if campaign.get("status") not in {"active", "paused"}:
             return {
                 "accepted": False, "persisted": False, "replay": False,
-                "reason": "transaction_mismatch", "transaction": {},
+                "reason": "campaign_not_active", "transaction": {},
             }
-        tx = {**metadata_tx, **active_tx}
-    else:
-        tx = {}
-    axes = normalize_outcome_axes({"outcome_axes": outcome_axes or {}})
-    tx_id = str(tx.get("transaction_id") or "") if tx else ""
-    if not tx_id:
-        for existing in list(campaign.get("history") or []):
-            if isinstance(existing, dict) and str(existing.get("task_id") or "") == str(task_id or ""):
+        metadata_tx = transaction if isinstance(transaction, dict) else {}
+        active_tx = (
+            campaign.get("active_transaction")
+            if isinstance(campaign.get("active_transaction"), dict) else {}
+        )
+        campaign_id = str(campaign.get("id") or "")
+
+        def _matches(candidate: Dict[str, Any]) -> bool:
+            return bool(
+                campaign_id
+                and str(candidate.get("campaign_id") or "") == campaign_id
+                and str(candidate.get("transaction_id") or "")
+                and str(candidate.get("task_id") or "") == str(task_id or "")
+            )
+
+        metadata_tx_id = (
+            str(metadata_tx.get("transaction_id") or "") if _matches(metadata_tx) else ""
+        )
+        if metadata_tx_id:
+            for existing in list(campaign.get("history") or []):
+                if (
+                    not isinstance(existing, dict)
+                    or str(existing.get("task_id") or "") != str(task_id or "")
+                ):
+                    continue
+                existing_tx = existing.get("transaction")
+                if (
+                    isinstance(existing_tx, dict)
+                    and str(existing_tx.get("campaign_id") or "") == campaign_id
+                    and str(existing_tx.get("transaction_id") or "") == metadata_tx_id
+                ):
+                    replay_found = True
+                    replay_tx = dict(existing_tx)
+                    break
+
+        if not replay_found and not active_tx and not metadata_tx:
+            # Preserve idempotency for old history-only records, but never let a
+            # new metadata-less terminal mutate whichever campaign happens to be active.
+            for existing in list(campaign.get("history") or []):
+                if (
+                    isinstance(existing, dict)
+                    and str(existing.get("task_id") or "") == str(task_id or "")
+                ):
+                    replay_found = True
+                    replay_tx = dict(existing.get("transaction") or {})
+                    break
+            if not replay_found:
                 return {
-                    "accepted": True, "persisted": True, "replay": True,
-                    "reason": "duplicate_terminal",
-                    "transaction": dict(existing.get("transaction") or {}),
+                    "accepted": False, "persisted": False, "replay": False,
+                    "reason": "transaction_missing", "transaction": {},
                 }
-    if tx:
-        tx["outcome_axes"] = axes
-        tx["updated_at"] = utc_now_iso()
-    history = list(campaign.get("history") or [])
-    cost_available = cost_accounting_status == "available" and cost_usd is not None
-    row = {
-        "task_id": str(task_id or ""),
-        "ts": utc_now_iso(),
-        "cost_usd": float(cost_usd) if cost_available else None,
-        "cost_accounting_status": "available" if cost_available else "unavailable",
-        "outcome_axes": axes,
-        "rounds": int(rounds or 0),
-    }
-    if tx:
-        row["transaction"] = tx
-    history.append(row)
-    campaign["history"] = history[-50:]
-    cleanup_required = False
-    restart_requested = False
-    if tx:
-        has_commit = bool(str(tx.get("commit_sha") or "").strip())
-        restart_verified = bool(tx.get("restart_verified"))
-        has_rescue = bool(str(tx.get("rescue_ref") or "").strip())
-        if str((campaign.get("active_transaction") or {}).get("task_id") or "") == str(task_id or ""):
+
+        if not replay_found:
+            if (
+                not _matches(active_tx)
+                or not _matches(metadata_tx)
+                or str(active_tx.get("transaction_id") or "")
+                != str(metadata_tx.get("transaction_id") or "")
+            ):
+                return {
+                    "accepted": False, "persisted": False, "replay": False,
+                    "reason": "transaction_mismatch", "transaction": {},
+                }
+            tx = {**metadata_tx, **active_tx}
+            axes = normalize_outcome_axes({"outcome_axes": outcome_axes or {}})
+            tx["outcome_axes"] = axes
+            tx["updated_at"] = utc_now_iso()
+            history = list(campaign.get("history") or [])
+            cost_available = cost_accounting_status == "available" and cost_usd is not None
+            row = {
+                "task_id": str(task_id or ""),
+                "ts": utc_now_iso(),
+                "cost_usd": float(cost_usd) if cost_available else None,
+                "cost_accounting_status": "available" if cost_available else "unavailable",
+                "outcome_axes": axes,
+                "rounds": int(rounds or 0),
+                "transaction": tx,
+            }
+            history.append(row)
+            campaign["history"] = history[-50:]
+            has_commit = bool(str(tx.get("commit_sha") or "").strip())
+            restart_verified = bool(tx.get("restart_verified"))
+            has_rescue = bool(str(tx.get("rescue_ref") or "").strip())
             if has_commit and restart_verified:
                 tx["cycle_outcome"] = "absorbed"
-                campaign["absorbed_cycles_done"] = int(campaign.get("absorbed_cycles_done") or 0) + 1
+                campaign["absorbed_cycles_done"] = int(
+                    campaign.get("absorbed_cycles_done") or 0
+                ) + 1
                 append_unique_transaction(campaign, tx)
                 campaign.pop("active_transaction", None)
-                _clear_objective_repeat_count(campaign, tx)  # BUG3: genuine progress clears this fp
+                _clear_objective_repeat_count(campaign, tx)
             elif has_rescue:
                 tx["cycle_outcome"] = "abandoned"
                 tx["abandoned_reason"] = "rescue_ref_present"
                 tx["cleanup_status"] = "pending"
-                cleanup_required = True
                 append_unique_transaction(campaign, tx)
                 campaign.pop("active_transaction", None)
-                campaign.pop("post_task_backlog_id", None)  # BUG3 Layer B: detach (was missing on abandoned)
-                _bump_objective_repeat_count(campaign, tx)  # BUG3: non-absorbing cycle counts
+                campaign.pop("post_task_backlog_id", None)
+                _bump_objective_repeat_count(campaign, tx)
             elif not has_commit:
                 tx["cycle_outcome"] = "no_op"
                 tx["restart_required"] = False
                 tx["recovery_hint"] = ""
                 tx["cleanup_status"] = "pending"
-                cleanup_required = True
                 append_unique_transaction(campaign, tx)
                 campaign.pop("active_transaction", None)
                 campaign.pop("post_task_backlog_id", None)
-                _bump_objective_repeat_count(campaign, tx)  # BUG3: non-absorbing cycle counts
+                _bump_objective_repeat_count(campaign, tx)
             else:
                 tx["cycle_outcome"] = "waiting_for_restart"
                 tx["recovery_hint"] = tx.get("recovery_hint") or (
@@ -937,55 +986,51 @@ def update_evolution_campaign_after_task(
                 if not tx.get("restart_decision"):
                     tx["restart_decision"] = "supervisor_auto_requested"
                 campaign["active_transaction"] = tx
-                restart_requested = True
-    campaign["last_task_id"] = str(task_id or "")
-    campaign["cycles_done"] = int(campaign.get("cycles_done") or 0) + 1
-    execution_status = str((axes.get("execution") or {}).get("status") or "unknown")
-    objective_status = str((axes.get("objective") or {}).get("status") or "not_evaluated")
-    cost_note = f"${float(cost_usd):.4f}" if cost_available else "unavailable"
-    campaign["progress_notes"] = (
-        f"Last cycle {task_id}: execution={execution_status}, objective={objective_status}, "
-        f"rounds={int(rounds or 0)}, cost={cost_note}."
-    )
-    if cost_available:
-        campaign["budget_spent_usd"] = round(
-            float(campaign.get("budget_spent_usd") or 0.0) + float(cost_usd), 6,
-        )
-    else:
-        campaign["cost_accounting_status"] = "unavailable"
-    campaign["updated_at"] = utc_now_iso()
-    try:
-        persisted = _write_evolution_campaign(
-            campaign,
-            expected_campaign_id=campaign_id,
-            expected_active_transaction=expected_active_tx,
-        )
-    except Exception:
-        log.warning("Failed to persist evolution terminal for %s", task_id, exc_info=True)
+            if tx.get("cycle_outcome") in {"absorbed", "abandoned"}:
+                campaign["pending_owner_report"] = dict(tx)
+            campaign["last_task_id"] = str(task_id or "")
+            campaign["cycles_done"] = int(campaign.get("cycles_done") or 0) + 1
+            execution_status = str((axes.get("execution") or {}).get("status") or "unknown")
+            objective_status = str((axes.get("objective") or {}).get("status") or "not_evaluated")
+            cost_note = f"${float(cost_usd):.4f}" if cost_available else "unavailable"
+            campaign["progress_notes"] = (
+                f"Last cycle {task_id}: execution={execution_status}, objective={objective_status}, "
+                f"rounds={int(rounds or 0)}, cost={cost_note}."
+            )
+            if cost_available:
+                campaign["budget_spent_usd"] = round(
+                    float(campaign.get("budget_spent_usd") or 0.0) + float(cost_usd), 6,
+                )
+            else:
+                campaign["cost_accounting_status"] = "unavailable"
+            campaign["updated_at"] = utc_now_iso()
+            try:
+                persisted = _write_evolution_campaign(
+                    campaign,
+                    expected_campaign_id=campaign_id,
+                    _state_lock_held=True,
+                )
+            except Exception:
+                log.warning("Failed to persist evolution terminal for %s", task_id, exc_info=True)
+                return {
+                    "accepted": True, "persisted": False, "replay": False,
+                    "reason": "campaign_write_failed", "transaction": {},
+                }
+            if not persisted:
+                return {
+                    "accepted": True, "persisted": False, "replay": False,
+                    "reason": "campaign_write_refused", "transaction": {},
+                }
+    finally:
+        state.release_file_lock(state.STATE_LOCK_PATH, lock_fd)
+
+    if replay_found:
+        replay_tx = _resume_evolution_terminal_effects(campaign_id, str(task_id or ""), replay_tx)
         return {
-            "accepted": True, "persisted": False, "replay": False,
-            "reason": "campaign_write_failed", "transaction": {},
+            "accepted": True, "persisted": True, "replay": True,
+            "reason": "duplicate_terminal", "transaction": replay_tx,
         }
-    if not persisted:
-        return {
-            "accepted": True, "persisted": False, "replay": False,
-            "reason": "campaign_write_refused", "transaction": {},
-        }
-    if cleanup_required:
-        _cleanup_worktree_after_cycle(tx, str(task_id or ""))
-        try:
-            if not _persist_evolution_cleanup(campaign_id, tx):
-                log.warning("Failed to persist evolution cleanup evidence for %s", task_id)
-        except Exception:
-            log.warning("Failed to persist evolution cleanup evidence for %s", task_id, exc_info=True)
-    if restart_requested:
-        request_evolution_restart(queue.DRIVE_ROOT, tx, log=log)
-    if tx:
-        # Tell the owner only after the campaign transition is durable.
-        try:
-            notify_owner_cycle_outcome(campaign, tx)
-        except Exception:
-            log.debug("Failed to send evolution cycle owner report", exc_info=True)
+    tx = _resume_evolution_terminal_effects(campaign_id, str(task_id or ""), tx)
     return {
         "accepted": True, "persisted": True, "replay": False,
         "reason": "", "transaction": tx,
@@ -1170,13 +1215,21 @@ def request_evolution_restart(drive_root: pathlib.Path, tx: Dict[str, Any], log:
             )
         return
     try:
+        marker_path = pathlib.Path(drive_root) / "state" / "pending_restart_verify.json"
+        existing = read_json_dict(marker_path) or {}
+        existing_claim = existing.get("evolution_claim")
+        restart_reason = (
+            str(existing.get("reason") or "").strip()
+            if isinstance(existing_claim, dict) and existing_claim == claim
+            else ""
+        ) or "supervisor_auto_evolution_restart"
         atomic_write_json(
-            pathlib.Path(drive_root) / "state" / "pending_restart_verify.json",
+            marker_path,
             {
                 "ts": utc_now_iso(),
                 "expected_sha": commit_sha,
                 "expected_branch": str(tx.get("base_branch") or ""),
-                "reason": "supervisor_auto_evolution_restart",
+                "reason": restart_reason,
                 "evolution_claim": claim,
             },
             trailing_newline=True,
@@ -1185,7 +1238,7 @@ def request_evolution_restart(drive_root: pathlib.Path, tx: Dict[str, Any], log:
 
         workers.get_event_q().put({
             "type": "restart_request",
-            "reason": "supervisor_auto_evolution_restart",
+            "reason": restart_reason,
             "evolution_restart": True,
             "ts": utc_now_iso(),
         })

--- a/supervisor/evolution_lifecycle.py
+++ b/supervisor/evolution_lifecycle.py
@@ -22,6 +22,17 @@ from ouroboros.utils import atomic_write_json, read_json_dict, utc_now_iso
 log = logging.getLogger(__name__)
 
 EVOLUTION_CAMPAIGN_FILE = pathlib.Path("state") / "evolution_campaign.json"
+EVOLUTION_CAMPAIGN_CAS_TIMEOUT_SEC = 0.05
+
+
+def current_evolution_boot_generation() -> str:
+    """Return the existing custody generation used by boot reconciliation."""
+    try:
+        from ouroboros.process_custody import current_custody_session_id
+
+        return str(current_custody_session_id() or "")
+    except Exception:
+        return ""
 
 
 def _evolution_campaign_path() -> pathlib.Path:
@@ -35,10 +46,92 @@ def _read_evolution_campaign() -> Dict[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
-def _write_evolution_campaign(data: Dict[str, Any]) -> None:
+def disable_evolution_projection() -> None:
+    """Clear the scheduler projection without changing campaign history."""
+    from supervisor import state
+
+    state.update_state(lambda live: live.update({
+        "evolution_mode_enabled": False,
+        "post_task_autostop": False,
+    }))
+
+
+def disable_evolution_authority(
+    action: str, *, campaign_id: str = "", task_id: str = "",
+) -> None:
+    """Clear an invalid scheduler projection and record the typed refusal."""
+    from supervisor import queue, state
+
+    disable_evolution_projection()
+    event = {
+        "ts": utc_now_iso(),
+        "type": "evolution_authority_missing",
+        "action": str(action or ""),
+        "campaign_id": str(campaign_id or ""),
+    }
+    if task_id:
+        event["task_id"] = str(task_id)
+    state.append_jsonl(pathlib.Path(queue.DRIVE_ROOT) / "logs" / "events.jsonl", event)
+
+
+def deliver_pending_owner_report(notify: Any = None) -> None:
+    """Deliver and clear a worker-staged owner report from the server process."""
+    try:
+        campaign = _read_evolution_campaign()
+        report = campaign.get("pending_owner_report")
+        if not isinstance(report, dict):
+            return
+        (notify or notify_owner_cycle_outcome)(campaign, report)
+        clear_pending_owner_report(report)
+    except Exception:
+        log.debug("failed to deliver pending owner report", exc_info=True)
+
+
+def _write_evolution_campaign(
+    data: Dict[str, Any], *, expected_campaign_id: Optional[str] = None,
+    expected_active_transaction: Optional[Dict[str, Any]] = None,
+    _state_lock_held: bool = False, _lock_timeout_sec: float = 4.0,
+) -> bool:
     path = _evolution_campaign_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write_json(path, data, trailing_newline=True)
+    from supervisor import state
+
+    state.assert_test_data_path(path)
+    lock_fd = None
+    if not _state_lock_held:
+        lock_fd = state.acquire_file_lock(
+            state.STATE_LOCK_PATH, timeout_sec=float(_lock_timeout_sec),
+        )
+        if lock_fd is None:
+            return False
+    try:
+        current = read_json_dict(path) or {}
+        current_id = str(current.get("id") or "")
+        data_id = str(data.get("id") or "")
+        expected_id = data_id if expected_campaign_id is None else str(expected_campaign_id or "")
+        if current_id and current_id != expected_id:
+            log.warning(
+                "Refusing stale evolution campaign write: current=%s expected=%s",
+                current_id, expected_id,
+            )
+            return False
+        if (
+            current_id == data_id
+            and current.get("status") not in {"active", "paused"}
+            and data.get("status") in {"active", "paused"}
+        ):
+            log.warning("Refusing stale resurrection of terminal evolution campaign %s", data_id)
+            return False
+        if expected_active_transaction is not None:
+            current_tx = current.get("active_transaction", {})
+            if current_tx != expected_active_transaction:
+                log.warning("Refusing stale evolution transaction write for campaign %s", data_id)
+                return False
+        path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_json(path, data, trailing_newline=True)
+        return True
+    finally:
+        if lock_fd is not None:
+            state.release_file_lock(state.STATE_LOCK_PATH, lock_fd)
 
 
 def evolution_block_reason() -> str:
@@ -63,35 +156,53 @@ def evolution_block_reason() -> str:
 
 def start_evolution_campaign(objective: str = "", *, source: str = "owner") -> Dict[str, Any]:
     """Start or resume the active evolution campaign."""
-    campaign = _read_evolution_campaign()
-    now = utc_now_iso()
-    objective = str(objective or "").strip()
-    if campaign.get("status") not in {"active", "paused"}:
-        campaign = {
-            "schema_version": 1,
-            "id": uuid.uuid4().hex[:8],
-            "status": "active",
-            "objective": objective or "Autonomously improve Ouroboros by acting on the highest-value backlog or process-memory signal.",
-            "source": source,
-            "started_at": now,
-            "updated_at": now,
-            "cycles_done": 0,
-            "absorbed_cycles_done": 0,
-            "objective_repeat_counts": {},  # BUG3: fp -> non-absorbing-cycle count
-            "dropped_objective_fps": [],  # BUG3 Layer B: attempted-and-dropped objective fps
-            "budget_spent_usd": 0.0,
-            "last_task_id": "",
-            "progress_notes": "",
-            "completed_at": "",
-            "completion_reason": "",
-        }
-    else:
-        if objective:
-            campaign["objective"] = objective
-        campaign["status"] = "active"
-        campaign["updated_at"] = now
-    _write_evolution_campaign(campaign)
-    return campaign
+    from supervisor import state
+
+    state.assert_test_data_path(state.STATE_PATH)
+    lock_fd = state.acquire_file_lock(state.STATE_LOCK_PATH)
+    if lock_fd is None:
+        return {}
+    try:
+        campaign = _read_evolution_campaign()
+        prior_campaign_id = str(campaign.get("id") or "")
+        now = utc_now_iso()
+        objective = str(objective or "").strip()
+        if campaign.get("status") not in {"active", "paused"}:
+            campaign = {
+                "schema_version": 1,
+                "id": uuid.uuid4().hex[:8],
+                "status": "active",
+                "objective": objective or "Autonomously improve Ouroboros by acting on the highest-value backlog or process-memory signal.",
+                "source": str(source or ""),
+                "started_at": now,
+                "updated_at": now,
+                "cycles_done": 0,
+                "absorbed_cycles_done": 0,
+                "objective_repeat_counts": {},  # BUG3: fp -> non-absorbing-cycle count
+                "dropped_objective_fps": [],  # BUG3 Layer B: attempted-and-dropped objective fps
+                "budget_spent_usd": 0.0,
+                "last_task_id": "",
+                "progress_notes": "",
+                "completed_at": "",
+                "completion_reason": "",
+            }
+        else:
+            if objective:
+                campaign["objective"] = objective
+            if not str(campaign.get("source") or "").strip() and source:
+                campaign["source"] = str(source)
+            campaign["status"] = "active"
+            campaign["updated_at"] = now
+        generation = current_evolution_boot_generation()
+        if generation:
+            campaign["last_boot_reconcile_gen"] = generation
+        return campaign if _write_evolution_campaign(
+            campaign,
+            expected_campaign_id=prior_campaign_id,
+            _state_lock_held=True,
+        ) else {}
+    finally:
+        state.release_file_lock(state.STATE_LOCK_PATH, lock_fd)
 
 
 def pause_evolution_campaign(reason: str = "") -> Dict[str, Any]:
@@ -103,13 +214,23 @@ def pause_evolution_campaign(reason: str = "") -> Dict[str, Any]:
     restart-blocked) — NOT by an owner stop. For an owner stop use
     ``complete_evolution_campaign`` (terminal).
     """
-    campaign = _read_evolution_campaign()
-    if campaign:
-        campaign["status"] = "paused"
-        campaign["updated_at"] = utc_now_iso()
-        campaign["pause_reason"] = str(reason or "")
-        _write_evolution_campaign(campaign)
-    return campaign
+    from supervisor import state
+
+    state.assert_test_data_path(state.STATE_PATH)
+    lock_fd = state.acquire_file_lock(state.STATE_LOCK_PATH)
+    if lock_fd is None:
+        return {}
+    try:
+        campaign = _read_evolution_campaign()
+        if campaign:
+            campaign["status"] = "paused"
+            campaign["updated_at"] = utc_now_iso()
+            campaign["pause_reason"] = str(reason or "")
+            if not _write_evolution_campaign(campaign, _state_lock_held=True):
+                return {}
+        return campaign
+    finally:
+        state.release_file_lock(state.STATE_LOCK_PATH, lock_fd)
 
 
 def complete_evolution_campaign(
@@ -129,40 +250,54 @@ def complete_evolution_campaign(
     (BIBLE) forbids delaying panic, so panic must NOT run git stash/reset work before its
     hard exit — the panic flag + boot reconcile own that recovery instead."""
     try:
-        campaign = _read_evolution_campaign()
-        if not campaign:
-            return campaign or {}
-        now = utc_now_iso()
-        tx = campaign.get("active_transaction")
-        if isinstance(tx, dict):
-            tx = {**tx, "cycle_outcome": tx.get("cycle_outcome") or "owner_stopped"}
-            # Owner stop mid-cycle: this terminal 'stopped' status makes
-            # update_evolution_campaign_after_task early-return when the cancelled task's
-            # (async) task_done later fires, so the normal per-cycle worktree cleanup would
-            # be SKIPPED — leaking the abandoned, unreviewed evolution edits into the live
-            # repo. Run that same deterministic cleanup here before popping the tx. It is
-            # self-guarded (skips with a recorded reason while a task still holds the shared
-            # worktree — hence owner-stop sites cancel the running cycle BEFORE this close —
-            # kill-switch-able, never raises). SKIPPED under panic (cleanup_worktree=False):
-            # the Emergency Stop Invariant forbids any git work before the panic hard-exit.
-            if cleanup_worktree:
-                try:
-                    _cleanup_worktree_after_cycle(tx, str(tx.get("task_id") or ""))
-                except Exception:
-                    pass
+        from supervisor import state
+
+        snapshot = _read_evolution_campaign()
+        snapshot_tx = snapshot.get("active_transaction")
+        cleanup_updates: Dict[str, Any] = {}
+        if cleanup_worktree and isinstance(snapshot_tx, dict):
             try:
-                append_unique_transaction(campaign, tx)
+                _cleanup_worktree_after_cycle(snapshot_tx, str(snapshot_tx.get("task_id") or ""))
+                cleanup_updates = {
+                    key: value for key, value in snapshot_tx.items()
+                    if key.startswith("cleanup_") or key == "recovery_hint"
+                }
             except Exception:
                 pass
-            campaign.pop("active_transaction", None)
-        campaign.pop("post_task_backlog_id", None)
-        campaign.pop("pause_reason", None)
-        campaign["status"] = str(status or "stopped")
-        campaign["updated_at"] = now
-        campaign["completed_at"] = now
-        campaign["completion_reason"] = str(reason or "")
-        _write_evolution_campaign(campaign)
-        return campaign
+        state.assert_test_data_path(state.STATE_PATH)
+        lock_fd = state.acquire_file_lock(
+            state.STATE_LOCK_PATH, timeout_sec=0.001 if not cleanup_worktree else 4.0,
+        )
+        if lock_fd is None:
+            return {}
+        try:
+            campaign = _read_evolution_campaign()
+            if not campaign:
+                return campaign or {}
+            now = utc_now_iso()
+            tx = campaign.get("active_transaction")
+            if isinstance(tx, dict):
+                if (
+                    cleanup_updates
+                    and isinstance(snapshot_tx, dict)
+                    and str(tx.get("transaction_id") or "")
+                    == str(snapshot_tx.get("transaction_id") or "")
+                ):
+                    tx.update(cleanup_updates)
+                tx = {**tx, "cycle_outcome": tx.get("cycle_outcome") or "owner_stopped"}
+                append_unique_transaction(campaign, tx)
+                campaign.pop("active_transaction", None)
+            campaign.pop("post_task_backlog_id", None)
+            campaign.pop("pause_reason", None)
+            campaign["status"] = str(status or "stopped")
+            campaign["updated_at"] = now
+            campaign["completed_at"] = now
+            campaign["completion_reason"] = str(reason or "")
+            return campaign if _write_evolution_campaign(
+                campaign, _state_lock_held=True,
+            ) else {}
+        finally:
+            state.release_file_lock(state.STATE_LOCK_PATH, lock_fd)
     except Exception:
         log.debug("complete_evolution_campaign failed", exc_info=True)
         return {}
@@ -181,7 +316,7 @@ def begin_evolution_transaction(task_id: str, *, cycle: int, campaign: Dict[str,
         base_head = ""
         base_branch = ""
     transaction = {
-        "schema_version": 1,
+        "schema_version": 2,
         "transaction_id": uuid.uuid4().hex[:12],
         "campaign_id": str((campaign or {}).get("id") or ""),
         "task_id": str(task_id or ""),
@@ -207,12 +342,255 @@ def begin_evolution_transaction(task_id: str, *, cycle: int, campaign: Dict[str,
         "rescue_path": "",
         "recovery_hint": "",
     }
-    current = _read_evolution_campaign()
-    if current.get("id") == campaign.get("id"):
+    from supervisor import state
+
+    state.assert_test_data_path(state.STATE_PATH)
+    lock_fd = state.acquire_file_lock(state.STATE_LOCK_PATH)
+    if lock_fd is None:
+        return {}
+    try:
+        current = _read_evolution_campaign()
+        live_state = state.json_load_file(state.STATE_PATH) or {}
+        existing_tx = current.get("active_transaction")
+        existing_tx = existing_tx if isinstance(existing_tx, dict) else {}
+        if (
+            bool(live_state.get("evolution_owner_stopped"))
+            or not bool(live_state.get("evolution_mode_enabled"))
+            or current.get("status") != "active"
+            or str(current.get("id") or "") != str(campaign.get("id") or "")
+            or bool(str(existing_tx.get("commit_sha") or "").strip())
+        ):
+            return {}
+        if existing_tx:
+            existing_tx.update({
+                "cycle_outcome": "abandoned",
+                "abandoned_reason": "dispatch_not_persisted",
+                "updated_at": utc_now_iso(),
+            })
+            append_unique_transaction(current, existing_tx)
         current["active_transaction"] = transaction
         current["updated_at"] = utc_now_iso()
-        _write_evolution_campaign(current)
-    return transaction
+        if not _write_evolution_campaign(current, _state_lock_held=True):
+            return {}
+        stored = _read_evolution_campaign()
+        stored_tx = stored.get("active_transaction")
+        if not isinstance(stored_tx, dict) or any(
+            str(stored_tx.get(key) or "") != str(transaction.get(key) or "")
+            for key in ("campaign_id", "transaction_id", "task_id")
+        ):
+            return {}
+        return transaction
+    finally:
+        state.release_file_lock(state.STATE_LOCK_PATH, lock_fd)
+
+
+def evolution_commit_receipt_error(
+    tx: Dict[str, Any], *, campaign_id: str, transaction_id: str,
+    task_id: str, commit_sha: str,
+) -> str:
+    if str(tx.get("commit_sha") or "") != commit_sha:
+        return "commit_receipt_mismatch"
+    receipt = tx.get("commit_receipt")
+    if not isinstance(receipt, dict) or not bool(receipt.get("ok")):
+        return "commit_receipt_missing"
+    expected = {
+        "campaign_id": campaign_id,
+        "transaction_id": transaction_id,
+        "task_id": task_id,
+        "commit_sha": commit_sha,
+    }
+    if any(str(receipt.get(key) or "") != value for key, value in expected.items()):
+        return "commit_receipt_mismatch"
+    return ""
+
+
+def _evolution_claim_error(
+    campaign: Dict[str, Any], live_state: Dict[str, Any], *,
+    campaign_id: str, transaction_id: str, task_id: str, commit_sha: str = "",
+    require_uncommitted: bool = False,
+) -> str:
+    if not campaign_id or not transaction_id or not task_id:
+        return "claim_identity_missing"
+    if bool(live_state.get("evolution_owner_stopped")):
+        return "owner_stopped"
+    if not bool(live_state.get("evolution_mode_enabled")) and not commit_sha:
+        return "evolution_disabled"
+    if campaign.get("status") != "active":
+        return "campaign_not_active"
+    if str(campaign.get("id") or "") != campaign_id:
+        return "campaign_mismatch"
+    tx = campaign.get("active_transaction")
+    if not isinstance(tx, dict):
+        return "transaction_missing"
+    if str(tx.get("transaction_id") or "") != transaction_id:
+        return "transaction_mismatch"
+    if str(tx.get("task_id") or "") != task_id:
+        return "task_mismatch"
+    if require_uncommitted and str(tx.get("commit_sha") or "").strip():
+        return "transaction_already_committed"
+    if commit_sha:
+        return evolution_commit_receipt_error(
+            tx,
+            campaign_id=campaign_id,
+            transaction_id=transaction_id,
+            task_id=task_id,
+            commit_sha=commit_sha,
+        )
+    return ""
+
+
+def check_evolution_authority(
+    campaign_id: str, transaction_id: str, task_id: str, *, commit_sha: str = "",
+    require_uncommitted: bool = False,
+) -> Dict[str, Any]:
+    """Check the exact campaign claim under the existing state lock."""
+    from supervisor import state
+
+    state.assert_test_data_path(state.STATE_PATH)
+    lock_fd = state.acquire_file_lock(state.STATE_LOCK_PATH)
+    if lock_fd is None:
+        return {"ok": False, "reason": "state_lock_unavailable"}
+    try:
+        campaign = _read_evolution_campaign()
+        live_state = state.json_load_file(state.STATE_PATH) or {}
+        reason = _evolution_claim_error(
+            campaign, live_state,
+            campaign_id=str(campaign_id or ""),
+            transaction_id=str(transaction_id or ""),
+            task_id=str(task_id or ""),
+            commit_sha=str(commit_sha or ""),
+            require_uncommitted=bool(require_uncommitted),
+        )
+        return {
+            "ok": not reason,
+            "reason": reason,
+            "campaign_id": str(campaign_id or ""),
+            "transaction_id": str(transaction_id or ""),
+            "task_id": str(task_id or ""),
+            "commit_sha": str(commit_sha or ""),
+        }
+    finally:
+        state.release_file_lock(state.STATE_LOCK_PATH, lock_fd)
+
+
+def record_evolution_commit(
+    campaign_id: str, transaction_id: str, task_id: str, commit_sha: str,
+) -> Dict[str, Any]:
+    """CAS the exact reviewed local commit into its still-authorized transaction."""
+    from supervisor import state
+
+    commit_sha = str(commit_sha or "").strip()
+    if not commit_sha:
+        return {"ok": False, "reason": "commit_sha_missing"}
+    state.assert_test_data_path(state.STATE_PATH)
+    lock_fd = state.acquire_file_lock(state.STATE_LOCK_PATH)
+    if lock_fd is None:
+        return {"ok": False, "reason": "state_lock_unavailable", "commit_sha": commit_sha}
+    try:
+        live_state = state.json_load_file(state.STATE_PATH) or {}
+        from ouroboros.utils import update_json_locked
+
+        receipt: Dict[str, Any] = {}
+        refused = {"reason": "campaign_write_refused"}
+
+        def _mutate(campaign: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+            reason = _evolution_claim_error(
+                campaign, live_state,
+                campaign_id=str(campaign_id or ""),
+                transaction_id=str(transaction_id or ""),
+                task_id=str(task_id or ""),
+            )
+            tx = campaign.get("active_transaction")
+            prior_sha = str((tx or {}).get("commit_sha") or "") if isinstance(tx, dict) else ""
+            if not reason and prior_sha and prior_sha != commit_sha:
+                reason = "commit_receipt_conflict"
+            if reason:
+                refused["reason"] = reason
+                return None
+            now = utc_now_iso()
+            receipt.update({
+                "ok": True,
+                "reason": "recorded",
+                "campaign_id": str(campaign_id),
+                "transaction_id": str(transaction_id),
+                "task_id": str(task_id),
+                "commit_sha": commit_sha,
+                "recorded_at": now,
+            })
+            tx.update({
+                "preflight_status": "passed",
+                "advisory_status": "fresh_or_bypassed",
+                "triad_scope_status": "passed",
+                "commit_sha": commit_sha,
+                "commit_receipt": dict(receipt),
+                "restart_required": True,
+                "restart_verified": False,
+                "updated_at": now,
+            })
+            campaign["active_transaction"] = tx
+            campaign["updated_at"] = now
+            return campaign
+
+        update_json_locked(
+            _evolution_campaign_path(), _mutate,
+            timeout_sec=EVOLUTION_CAMPAIGN_CAS_TIMEOUT_SEC,
+            strict_existing_dict=True,
+        )
+        if not receipt:
+            return {"ok": False, "reason": refused["reason"], "commit_sha": commit_sha}
+        return receipt
+    except Exception as exc:
+        log.warning("Failed to record exact evolution commit receipt", exc_info=True)
+        return {"ok": False, "reason": f"campaign_write_failed:{type(exc).__name__}", "commit_sha": commit_sha}
+    finally:
+        state.release_file_lock(state.STATE_LOCK_PATH, lock_fd)
+
+
+def link_evolution_rescue(drive_root: pathlib.Path, rescue_info: Dict[str, Any]) -> Dict[str, Any]:
+    """Attach rescue pointers without racing an exact commit receipt."""
+    from supervisor import state
+
+    root = pathlib.Path(drive_root)
+    path = root / EVOLUTION_CAMPAIGN_FILE
+    lock_path = root / "locks" / "state.lock"
+    state.assert_test_data_path(path)
+    lock_fd = state.acquire_file_lock(lock_path)
+    if lock_fd is None:
+        return {}
+    try:
+        from ouroboros.utils import update_json_locked
+
+        linked: Dict[str, Any] = {}
+
+        def _mutate(campaign: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+            if campaign.get("status") not in {"active", "paused"}:
+                return None
+            tx = campaign.get("active_transaction")
+            if not isinstance(tx, dict):
+                return None
+            tx["rescue_ref"] = str(rescue_info.get("rescue_ref") or "")
+            tx["dirty_snapshot_ref"] = str(rescue_info.get("rescue_ref") or "")
+            tx["rescue_path"] = str(rescue_info.get("path") or "")
+            tx["restart_decision"] = "rescue_snapshot_created"
+            tx["recovery_hint"] = (
+                f"Recover with {tx['rescue_ref']} or inspect {tx['rescue_path']}"
+                if tx.get("rescue_ref") or tx.get("rescue_path")
+                else "Rescue attempted; inspect supervisor logs."
+            )
+            tx["updated_at"] = utc_now_iso()
+            campaign["active_transaction"] = tx
+            campaign["updated_at"] = utc_now_iso()
+            linked.update(tx)
+            return campaign
+
+        update_json_locked(
+            path, _mutate,
+            timeout_sec=EVOLUTION_CAMPAIGN_CAS_TIMEOUT_SEC,
+            strict_existing_dict=True,
+        )
+        return linked
+    finally:
+        state.release_file_lock(lock_path, lock_fd)
 
 
 def _bump_objective_repeat_count(campaign: Dict[str, Any], tx: Dict[str, Any]) -> None:
@@ -258,17 +636,26 @@ def _clear_objective_repeat_count(campaign: Dict[str, Any], tx: Dict[str, Any]) 
 
 def update_evolution_transaction(task_id: str, **updates: Any) -> None:
     """Best-effort update of the active/lightweight evolution transaction."""
-    campaign = _read_evolution_campaign()
-    tx = campaign.get("active_transaction")
-    if not isinstance(tx, dict) or str(tx.get("task_id") or "") != str(task_id or ""):
+    from supervisor import state
+
+    state.assert_test_data_path(state.STATE_PATH)
+    lock_fd = state.acquire_file_lock(state.STATE_LOCK_PATH)
+    if lock_fd is None:
         return
-    for key, value in updates.items():
-        if value is not None:
-            tx[key] = value
-    tx["updated_at"] = utc_now_iso()
-    campaign["active_transaction"] = tx
-    campaign["updated_at"] = utc_now_iso()
-    _write_evolution_campaign(campaign)
+    try:
+        campaign = _read_evolution_campaign()
+        tx = campaign.get("active_transaction")
+        if not isinstance(tx, dict) or str(tx.get("task_id") or "") != str(task_id or ""):
+            return
+        for key, value in updates.items():
+            if value is not None:
+                tx[key] = value
+        tx["updated_at"] = utc_now_iso()
+        campaign["active_transaction"] = tx
+        campaign["updated_at"] = utc_now_iso()
+        _write_evolution_campaign(campaign, _state_lock_held=True)
+    finally:
+        state.release_file_lock(state.STATE_LOCK_PATH, lock_fd)
 
 
 def _cleanup_worktree_after_cycle(tx: Dict[str, Any], task_id: str) -> None:
@@ -380,6 +767,46 @@ def _cleanup_worktree_after_cycle(tx: Dict[str, Any], task_id: str) -> None:
         log.debug("Evolution cycle worktree cleanup failed", exc_info=True)
 
 
+def _persist_evolution_cleanup(campaign_id: str, tx: Dict[str, Any]) -> bool:
+    """Patch cleanup evidence into the exact terminal transaction under the state lock."""
+    from supervisor import state
+
+    lock_fd = state.acquire_file_lock(state.STATE_LOCK_PATH)
+    if lock_fd is None:
+        return False
+    try:
+        campaign = _read_evolution_campaign()
+        if str(campaign.get("id") or "") != str(campaign_id or ""):
+            return False
+        tx_id = str(tx.get("transaction_id") or "")
+        cleanup = {
+            key: tx[key]
+            for key in (
+                "cleanup_status", "cleanup_stash", "cleanup_preserved_ref",
+                "recovery_hint",
+            )
+            if key in tx
+        }
+        updated = False
+        for item in list(campaign.get("transaction_history") or []):
+            if isinstance(item, dict) and str(item.get("transaction_id") or "") == tx_id:
+                item.update(cleanup)
+                updated = True
+        for row in list(campaign.get("history") or []):
+            item = row.get("transaction") if isinstance(row, dict) else None
+            if isinstance(item, dict) and str(item.get("transaction_id") or "") == tx_id:
+                item.update(cleanup)
+                updated = True
+        if not updated:
+            return False
+        campaign["updated_at"] = utc_now_iso()
+        return _write_evolution_campaign(
+            campaign, expected_campaign_id=campaign_id, _state_lock_held=True,
+        )
+    finally:
+        state.release_file_lock(state.STATE_LOCK_PATH, lock_fd)
+
+
 def update_evolution_campaign_after_task(
     task_id: str,
     *,
@@ -394,23 +821,63 @@ def update_evolution_campaign_after_task(
 
     campaign = _read_evolution_campaign()
     if campaign.get("status") not in {"active", "paused"}:
-        return {}
+        return {
+            "accepted": False, "persisted": False, "replay": False,
+            "reason": "campaign_not_active", "transaction": {},
+        }
     metadata_tx = transaction if isinstance(transaction, dict) else {}
     active_tx = campaign.get("active_transaction") if isinstance(campaign.get("active_transaction"), dict) else {}
-    if str(active_tx.get("task_id") or "") == str(task_id or ""):
+    expected_active_tx = dict(active_tx)
+    campaign_id = str(campaign.get("id") or "")
+
+    def _matches(candidate: Dict[str, Any]) -> bool:
+        return bool(
+            campaign_id
+            and str(candidate.get("campaign_id") or "") == campaign_id
+            and str(candidate.get("transaction_id") or "")
+            and str(candidate.get("task_id") or "") == str(task_id or "")
+        )
+
+    metadata_tx_id = str(metadata_tx.get("transaction_id") or "") if _matches(metadata_tx) else ""
+    if metadata_tx_id:
+        for existing in list(campaign.get("history") or []):
+            if not isinstance(existing, dict) or str(existing.get("task_id") or "") != str(task_id or ""):
+                continue
+            existing_tx = existing.get("transaction")
+            if (
+                isinstance(existing_tx, dict)
+                and str(existing_tx.get("campaign_id") or "") == campaign_id
+                and str(existing_tx.get("transaction_id") or "") == metadata_tx_id
+            ):
+                return {
+                    "accepted": True, "persisted": True, "replay": True,
+                    "reason": "duplicate_terminal", "transaction": dict(existing_tx),
+                }
+
+    if active_tx or metadata_tx:
+        if (
+            not _matches(active_tx)
+            or not _matches(metadata_tx)
+            or str(active_tx.get("transaction_id") or "")
+            != str(metadata_tx.get("transaction_id") or "")
+        ):
+            return {
+                "accepted": False, "persisted": False, "replay": False,
+                "reason": "transaction_mismatch", "transaction": {},
+            }
         tx = {**metadata_tx, **active_tx}
-    elif str(metadata_tx.get("task_id") or "") == str(task_id or ""):
-        tx = dict(metadata_tx)
     else:
         tx = {}
     axes = normalize_outcome_axes({"outcome_axes": outcome_axes or {}})
     tx_id = str(tx.get("transaction_id") or "") if tx else ""
-    for existing in list(campaign.get("history") or []):
-        if not isinstance(existing, dict) or str(existing.get("task_id") or "") != str(task_id or ""):
-            continue
-        existing_tx = existing.get("transaction") if isinstance(existing.get("transaction"), dict) else {}
-        if not tx_id or str(existing_tx.get("transaction_id") or "") == tx_id:
-            return {**dict(campaign.get("active_transaction") or existing_tx or tx), "_replay": True}
+    if not tx_id:
+        for existing in list(campaign.get("history") or []):
+            if isinstance(existing, dict) and str(existing.get("task_id") or "") == str(task_id or ""):
+                return {
+                    "accepted": True, "persisted": True, "replay": True,
+                    "reason": "duplicate_terminal",
+                    "transaction": dict(existing.get("transaction") or {}),
+                }
     if tx:
         tx["outcome_axes"] = axes
         tx["updated_at"] = utc_now_iso()
@@ -428,6 +895,8 @@ def update_evolution_campaign_after_task(
         row["transaction"] = tx
     history.append(row)
     campaign["history"] = history[-50:]
+    cleanup_required = False
+    restart_requested = False
     if tx:
         has_commit = bool(str(tx.get("commit_sha") or "").strip())
         restart_verified = bool(tx.get("restart_verified"))
@@ -442,7 +911,8 @@ def update_evolution_campaign_after_task(
             elif has_rescue:
                 tx["cycle_outcome"] = "abandoned"
                 tx["abandoned_reason"] = "rescue_ref_present"
-                _cleanup_worktree_after_cycle(tx, str(task_id or ""))
+                tx["cleanup_status"] = "pending"
+                cleanup_required = True
                 append_unique_transaction(campaign, tx)
                 campaign.pop("active_transaction", None)
                 campaign.pop("post_task_backlog_id", None)  # BUG3 Layer B: detach (was missing on abandoned)
@@ -451,7 +921,8 @@ def update_evolution_campaign_after_task(
                 tx["cycle_outcome"] = "no_op"
                 tx["restart_required"] = False
                 tx["recovery_hint"] = ""
-                _cleanup_worktree_after_cycle(tx, str(task_id or ""))
+                tx["cleanup_status"] = "pending"
+                cleanup_required = True
                 append_unique_transaction(campaign, tx)
                 campaign.pop("active_transaction", None)
                 campaign.pop("post_task_backlog_id", None)
@@ -466,14 +937,7 @@ def update_evolution_campaign_after_task(
                 if not tx.get("restart_decision"):
                     tx["restart_decision"] = "supervisor_auto_requested"
                 campaign["active_transaction"] = tx
-                request_evolution_restart(queue.DRIVE_ROOT, tx, log=log)
-        # WS-13.5 (e5=ux_absorb_report): tell the owner in chat what a completed
-        # self-evolution cycle did. Absorbed -> short what/why; abandoned ->
-        # honest warning; no-op / waiting -> quiet (event only). No web edits.
-        try:
-            notify_owner_cycle_outcome(campaign, tx)
-        except Exception:
-            log.debug("Failed to send evolution cycle owner report", exc_info=True)
+                restart_requested = True
     campaign["last_task_id"] = str(task_id or "")
     campaign["cycles_done"] = int(campaign.get("cycles_done") or 0) + 1
     execution_status = str((axes.get("execution") or {}).get("status") or "unknown")
@@ -490,8 +954,42 @@ def update_evolution_campaign_after_task(
     else:
         campaign["cost_accounting_status"] = "unavailable"
     campaign["updated_at"] = utc_now_iso()
-    _write_evolution_campaign(campaign)
-    return tx
+    try:
+        persisted = _write_evolution_campaign(
+            campaign,
+            expected_campaign_id=campaign_id,
+            expected_active_transaction=expected_active_tx,
+        )
+    except Exception:
+        log.warning("Failed to persist evolution terminal for %s", task_id, exc_info=True)
+        return {
+            "accepted": True, "persisted": False, "replay": False,
+            "reason": "campaign_write_failed", "transaction": {},
+        }
+    if not persisted:
+        return {
+            "accepted": True, "persisted": False, "replay": False,
+            "reason": "campaign_write_refused", "transaction": {},
+        }
+    if cleanup_required:
+        _cleanup_worktree_after_cycle(tx, str(task_id or ""))
+        try:
+            if not _persist_evolution_cleanup(campaign_id, tx):
+                log.warning("Failed to persist evolution cleanup evidence for %s", task_id)
+        except Exception:
+            log.warning("Failed to persist evolution cleanup evidence for %s", task_id, exc_info=True)
+    if restart_requested:
+        request_evolution_restart(queue.DRIVE_ROOT, tx, log=log)
+    if tx:
+        # Tell the owner only after the campaign transition is durable.
+        try:
+            notify_owner_cycle_outcome(campaign, tx)
+        except Exception:
+            log.debug("Failed to send evolution cycle owner report", exc_info=True)
+    return {
+        "accepted": True, "persisted": True, "replay": False,
+        "reason": "", "transaction": tx,
+    }
 
 
 def build_evolution_task_text(cycle: int) -> str:
@@ -614,6 +1112,33 @@ def notify_owner_cycle_outcome(campaign: Dict[str, Any], tx: Dict[str, Any]) -> 
     send_with_budget(owner_chat_id, msg)
 
 
+def clear_pending_owner_report(expected: Dict[str, Any]) -> bool:
+    """Clear only the report that was sent, without overwriting newer campaign state."""
+    from ouroboros.utils import update_json_locked
+    from supervisor import state
+
+    path = _evolution_campaign_path()
+    state.assert_test_data_path(path)
+    lock_fd = state.acquire_file_lock(state.STATE_LOCK_PATH)
+    if lock_fd is None:
+        return False
+    cleared = {"ok": False}
+
+    def _mutate(campaign: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        if campaign.get("pending_owner_report") != expected:
+            return None
+        campaign.pop("pending_owner_report", None)
+        campaign["updated_at"] = utc_now_iso()
+        cleared["ok"] = True
+        return campaign
+
+    try:
+        update_json_locked(path, _mutate, strict_existing_dict=True)
+        return bool(cleared["ok"])
+    finally:
+        state.release_file_lock(state.STATE_LOCK_PATH, lock_fd)
+
+
 def append_unique_transaction(campaign: Dict[str, Any], tx: Dict[str, Any]) -> None:
     tx_history = list(campaign.get("transaction_history") or [])
     tx_id = str(tx.get("transaction_id") or "")
@@ -630,6 +1155,20 @@ def request_evolution_restart(drive_root: pathlib.Path, tx: Dict[str, Any], log:
     commit_sha = str(tx.get("commit_sha") or "").strip()
     if not commit_sha:
         return
+    claim = {
+        "campaign_id": str(tx.get("campaign_id") or ""),
+        "transaction_id": str(tx.get("transaction_id") or ""),
+        "task_id": str(tx.get("task_id") or ""),
+        "commit_sha": commit_sha,
+    }
+    authority = check_evolution_authority(**claim)
+    if not authority.get("ok"):
+        if log is not None:
+            log.warning(
+                "Automatic evolution restart cancelled: exact authority changed (%s)",
+                authority.get("reason") or "unknown",
+            )
+        return
     try:
         atomic_write_json(
             pathlib.Path(drive_root) / "state" / "pending_restart_verify.json",
@@ -638,6 +1177,7 @@ def request_evolution_restart(drive_root: pathlib.Path, tx: Dict[str, Any], log:
                 "expected_sha": commit_sha,
                 "expected_branch": str(tx.get("base_branch") or ""),
                 "reason": "supervisor_auto_evolution_restart",
+                "evolution_claim": claim,
             },
             trailing_newline=True,
         )
@@ -646,6 +1186,7 @@ def request_evolution_restart(drive_root: pathlib.Path, tx: Dict[str, Any], log:
         workers.get_event_q().put({
             "type": "restart_request",
             "reason": "supervisor_auto_evolution_restart",
+            "evolution_restart": True,
             "ts": utc_now_iso(),
         })
     except Exception:

--- a/supervisor/git_ops.py
+++ b/supervisor/git_ops.py
@@ -15,7 +15,7 @@ import uuid
 from typing import Any, Dict, List, Optional, Tuple
 
 from supervisor.state import (
-    load_state, save_state, append_jsonl, atomic_write_text,
+    append_jsonl, atomic_write_text, load_state, save_state,
 )
 from ouroboros.utils import utc_now_iso
 
@@ -565,38 +565,21 @@ def _create_rescue_snapshot(branch: str, reason: str,
 def _link_rescue_to_evolution_transaction(rescue_info: Dict[str, Any], reason: str) -> None:
     """Attach rescue recovery pointers to the active evolution transaction."""
     try:
-        path = pathlib.Path(DRIVE_ROOT) / "state" / "evolution_campaign.json"
-        if not path.is_file():
+        from supervisor.evolution_lifecycle import link_evolution_rescue
+
+        linked = link_evolution_rescue(pathlib.Path(DRIVE_ROOT), rescue_info)
+        if not linked:
             return
-        raw = json.loads(path.read_text(encoding="utf-8"))
-        if not isinstance(raw, dict) or raw.get("status") not in {"active", "paused"}:
-            return
-        tx = raw.get("active_transaction")
-        if not isinstance(tx, dict):
-            return
-        tx["rescue_ref"] = str(rescue_info.get("rescue_ref") or "")
-        tx["dirty_snapshot_ref"] = str(rescue_info.get("rescue_ref") or "")
-        tx["rescue_path"] = str(rescue_info.get("path") or "")
-        tx["restart_decision"] = "rescue_snapshot_created"
-        tx["recovery_hint"] = (
-            f"Recover with {tx['rescue_ref']} or inspect {tx['rescue_path']}"
-            if tx.get("rescue_ref") or tx.get("rescue_path")
-            else "Rescue attempted; inspect supervisor logs."
-        )
-        tx["updated_at"] = utc_now_iso()
-        raw["active_transaction"] = tx
-        raw["updated_at"] = utc_now_iso()
-        atomic_write_text(path, json.dumps(raw, ensure_ascii=False, indent=2) + "\n")
         append_jsonl(
             pathlib.Path(DRIVE_ROOT) / "logs" / "supervisor.jsonl",
             {
                 "ts": utc_now_iso(),
                 "type": "evolution_transaction_rescue_linked",
                 "reason": reason,
-                "transaction_id": tx.get("transaction_id"),
-                "task_id": tx.get("task_id"),
-                "rescue_ref": tx.get("rescue_ref"),
-                "rescue_path": tx.get("rescue_path"),
+                "transaction_id": linked.get("transaction_id"),
+                "task_id": linked.get("task_id"),
+                "rescue_ref": linked.get("rescue_ref"),
+                "rescue_path": linked.get("rescue_path"),
             },
         )
     except Exception:

--- a/supervisor/queue.py
+++ b/supervisor/queue.py
@@ -1295,6 +1295,11 @@ def _enforce_task_timeouts_locked(
         # no longer race a concurrently-assigned retry; for a subagent the retry reuses the
         # same id/drive). Decisions that need live RUNNING state (orchestrator -> no blind
         # retry; the retry id) are frozen HERE under the lock and passed in the job.
+        if task_type == "evolution":
+            from supervisor.evolution_lifecycle import update_evolution_transaction
+            if not update_evolution_transaction(task_id, dispatch_status="reaping"):
+                log.warning("Evolution timeout teardown deferred: reaping state was not durable for %s", task_id)
+                continue
         RUNNING.pop(task_id, None)
         proc_handle = None
         if worker_id in workers.WORKERS:
@@ -1325,7 +1330,8 @@ def _enforce_task_timeouts_locked(
             will_retry = False
         retry_task_id = ""
         if will_retry:
-            retry_task_id = task_id if str(task.get("delegation_role") or "") == "subagent" else uuid.uuid4().hex[:8]
+            same_id = task_type == "evolution" or str(task.get("delegation_role") or "") == "subagent"
+            retry_task_id = task_id if same_id else uuid.uuid4().hex[:8]
 
         _ensure_reaper_started()
         _reap_queue.put({
@@ -1491,21 +1497,19 @@ def enqueue_evolution_task_if_needed() -> None:
         return
     campaign = _read_evolution_campaign()
     from supervisor.state import update_state
-
-    if campaign.get("status") != "active" or not all(
-        str(campaign.get(key) or "").strip() for key in ("id", "source")
-    ):
-        disable_evolution_authority(
-            "bare_flag_disabled", campaign_id=str(campaign.get("id") or ""),
-        )
+    has_authority = all(str(campaign.get(key) or "").strip() for key in ("id", "source"))
+    if campaign.get("status") != "active" or not has_authority:
+        disable_evolution_authority("bare_flag_disabled", campaign_id=str(campaign.get("id") or ""))
         send_with_budget(
             int(owner_chat_id),
-            "🧬 Evolution stayed off: the enable flag had no active campaign authority. "
-            "Use /evolve start to begin a fresh campaign.",
+            "🧬 Evolution stayed off: the enable flag had no active campaign authority. Use /evolve start to begin a fresh campaign.",
         )
         return
     active_tx = campaign.get("active_transaction") if isinstance(campaign.get("active_transaction"), dict) else {}
-    if active_tx and str(active_tx.get("commit_sha") or "").strip():
+    if active_tx and (
+        str(active_tx.get("commit_sha") or "").strip()
+        or str(active_tx.get("dispatch_status") or "") == "reaping"
+    ):
         return
 
     # Defensive net: light mode must never run evolution even if the flag was
@@ -1571,15 +1575,10 @@ def enqueue_evolution_task_if_needed() -> None:
     tid = uuid.uuid4().hex[:8]
     transaction = begin_evolution_transaction(tid, cycle=cycle, campaign=campaign)
     if not transaction:
-        disable_evolution_authority(
-            "transaction_attach_failed",
-            campaign_id=str(campaign.get("id") or ""),
-            task_id=tid,
-        )
+        disable_evolution_authority("transaction_attach_failed", campaign_id=str(campaign.get("id") or ""), task_id=tid)
         send_with_budget(
             int(owner_chat_id),
-            "🧬 Evolution stayed off: the campaign changed before its next task "
-            "could be attached. Start it again when ready.",
+            "🧬 Evolution stayed off: the campaign changed before its next task could be attached. Start it again when ready.",
         )
         return
     from ouroboros.contracts.task_contract import attach_task_contract

--- a/supervisor/queue.py
+++ b/supervisor/queue.py
@@ -21,6 +21,7 @@ from supervisor.state import (
 )
 from supervisor.message_bus import send_with_budget
 from ouroboros.config import (
+    DATA_DIR,
     FINALIZATION_GRACE_DEFAULT_SEC,
     get_finalization_grace_sec,
     get_per_call_timeout_ceiling_sec,
@@ -33,13 +34,15 @@ from ouroboros.outcomes import normalize_outcome_axes, terminal_outcome_axes
 from ouroboros.utils import atomic_write_json, read_json_dict, utc_now_iso
 from supervisor.evolution_lifecycle import (
     _read_evolution_campaign,
-    _write_evolution_campaign,
     begin_evolution_transaction,
     build_evolution_task_text,
+    disable_evolution_authority,
+    disable_evolution_projection,
+    deliver_pending_owner_report,
     evolution_block_reason,
     notify_owner_cycle_outcome,
     pause_evolution_campaign,
-    start_evolution_campaign,
+    start_evolution_campaign,  # noqa: F401 -- historical queue API re-export
 )
 from supervisor.task_lifecycle import (  # noqa: F401 -- public queue API re-exports
     BUDGET_ROOT_FENCES, apply_budget_root_admission_fence, cancel_task_by_id,
@@ -50,7 +53,7 @@ from supervisor.task_lifecycle import (  # noqa: F401 -- public queue API re-exp
 log = logging.getLogger(__name__)
 
 
-DRIVE_ROOT: pathlib.Path = pathlib.Path.home() / "Ouroboros" / "data"
+DRIVE_ROOT: pathlib.Path = pathlib.Path(DATA_DIR)
 SOFT_TIMEOUT_SEC: int = 600
 HARD_TIMEOUT_SEC: int = 1800
 HEARTBEAT_STALE_SEC: int = 120
@@ -1472,23 +1475,7 @@ def get_evolution_status_snapshot() -> Dict[str, Any]:
 
 
 def _deliver_pending_owner_report() -> None:
-    """Deliver a WS-13.5 owner report staged by a worker-side absorb/abandon.
-
-    verify_restart runs in the worker (no live message bus), so it stages
-    ``pending_owner_report`` on the campaign; we deliver it here in the SERVER
-    process (where the bus is initialized) and clear it. Runs every supervisor
-    tick. Best-effort; never raises into the tick.
-    """
-    try:
-        campaign = _read_evolution_campaign()
-        report = campaign.get("pending_owner_report")
-        if not isinstance(report, dict):
-            return
-        notify_owner_cycle_outcome(campaign, report)  # reuses the message builder
-        campaign.pop("pending_owner_report", None)
-        _write_evolution_campaign(campaign)
-    except Exception:
-        log.debug("failed to deliver pending owner report", exc_info=True)
+    deliver_pending_owner_report(notify_owner_cycle_outcome)
 
 
 def enqueue_evolution_task_if_needed() -> None:
@@ -1503,33 +1490,38 @@ def enqueue_evolution_task_if_needed() -> None:
     if not owner_chat_id:
         return
     campaign = _read_evolution_campaign()
-    active_tx = campaign.get("active_transaction") if isinstance(campaign.get("active_transaction"), dict) else {}
-    if (
-        active_tx
-        and str(active_tx.get("commit_sha") or "").strip()
-        and (bool(active_tx.get("restart_required")) or not bool(active_tx.get("restart_verified")))
+    from supervisor.state import update_state
+
+    if campaign.get("status") != "active" or not all(
+        str(campaign.get(key) or "").strip() for key in ("id", "source")
     ):
+        disable_evolution_authority(
+            "bare_flag_disabled", campaign_id=str(campaign.get("id") or ""),
+        )
+        send_with_budget(
+            int(owner_chat_id),
+            "🧬 Evolution stayed off: the enable flag had no active campaign authority. "
+            "Use /evolve start to begin a fresh campaign.",
+        )
+        return
+    active_tx = campaign.get("active_transaction") if isinstance(campaign.get("active_transaction"), dict) else {}
+    if active_tx and str(active_tx.get("commit_sha") or "").strip():
         return
 
     # Defensive net: light mode must never run evolution even if the flag was
     # left enabled (e.g. carried across a restart into light mode). Disable and
     # pause once; entry points already refuse new starts up front.
-    from supervisor.state import update_state
-
-    def _disable_evolution(live: Dict[str, Any]) -> None:
-        live["evolution_mode_enabled"] = False
-
     block = evolution_block_reason()
     if block:
         pause_evolution_campaign("blocked in light runtime mode")
-        update_state(_disable_evolution)
+        disable_evolution_projection()
         send_with_budget(int(owner_chat_id), block)
         return
 
     consecutive_failures = int(st.get("evolution_consecutive_failures") or 0)
     if consecutive_failures >= 3:
         pause_evolution_campaign("paused after consecutive failures")
-        update_state(_disable_evolution)
+        disable_evolution_projection()
         send_with_budget(
             int(owner_chat_id),
             f"🧬⚠️ Evolution paused: {consecutive_failures} consecutive failures. "
@@ -1551,7 +1543,7 @@ def enqueue_evolution_task_if_needed() -> None:
     _objective_repeats = int(_objective_repeat_counts.get(_active_objective_fp, 0)) if _active_objective_fp else 0
     if _objective_repeats >= OBJECTIVE_REPEAT_CAP:
         pause_evolution_campaign("paused: objective re-proposed without ever absorbing")
-        update_state(_disable_evolution)
+        disable_evolution_projection()
         send_with_budget(
             int(owner_chat_id),
             f"🧬⚠️ Evolution paused: the current objective ran {_objective_repeats} reviewed "
@@ -1572,13 +1564,24 @@ def enqueue_evolution_task_if_needed() -> None:
         return
     if remaining < EVOLUTION_BUDGET_RESERVE:
         pause_evolution_campaign("budget reserve reached")
-        update_state(_disable_evolution)
+        disable_evolution_projection()
         send_with_budget(int(owner_chat_id), f"💸 Evolution stopped: ${remaining:.2f} remaining (reserve ${EVOLUTION_BUDGET_RESERVE:.0f} for conversations).")
         return
     cycle = int(st.get("evolution_cycle") or 0) + 1
-    campaign = start_evolution_campaign(source="idle_evolution")
     tid = uuid.uuid4().hex[:8]
     transaction = begin_evolution_transaction(tid, cycle=cycle, campaign=campaign)
+    if not transaction:
+        disable_evolution_authority(
+            "transaction_attach_failed",
+            campaign_id=str(campaign.get("id") or ""),
+            task_id=tid,
+        )
+        send_with_budget(
+            int(owner_chat_id),
+            "🧬 Evolution stayed off: the campaign changed before its next task "
+            "could be attached. Start it again when ready.",
+        )
+        return
     from ouroboros.contracts.task_contract import attach_task_contract
 
     task = {
@@ -1595,5 +1598,3 @@ def enqueue_evolution_task_if_needed() -> None:
         live["last_evolution_task_at"] = utc_now_iso()
 
     update_state(_record_cycle)
-    # The generic "Evolution task <id> started." lifecycle message (workers.py)
-    # already announces the cycle start, so no extra enqueue bubble here.

--- a/supervisor/state.py
+++ b/supervisor/state.py
@@ -10,13 +10,14 @@ import time
 import uuid
 from typing import Any, Dict, List, Optional
 
+from ouroboros.config import DATA_DIR
 from ouroboros.platform_layer import acquire_exclusive_file_lock, release_exclusive_file_lock
 from ouroboros.utils import append_jsonl, utc_now_iso
 
 log = logging.getLogger(__name__)
 
 
-DRIVE_ROOT: pathlib.Path = pathlib.Path.home() / "Ouroboros" / "data"
+DRIVE_ROOT: pathlib.Path = pathlib.Path(DATA_DIR)
 STATE_PATH: pathlib.Path = DRIVE_ROOT / "state" / "state.json"
 STATE_LAST_GOOD_PATH: pathlib.Path = DRIVE_ROOT / "state" / "state.last_good.json"
 STATE_LOCK_PATH: pathlib.Path = DRIVE_ROOT / "locks" / "state.lock"
@@ -27,6 +28,25 @@ QUEUE_SNAPSHOT_PATH: pathlib.Path = DRIVE_ROOT / "state" / "queue_snapshot.json"
 # has it, so reset_per_task_budget can refuse on it regardless of how the path resolves —
 # closing the budget-reset guard for custom-data-root installs (BIBLE P8).
 ISOLATED_BENCHMARK_SENTINEL = ".ouroboros_isolated_benchmark"
+
+
+def assert_test_data_path(path: pathlib.Path) -> None:
+    """Fail closed when pytest resolves a writer into the live data tree."""
+    if os.environ.get("OUROBOROS_PYTEST_ACTIVE") != "1":
+        return
+    if os.environ.get("OUROBOROS_ALLOW_LIVE_DATA_TESTS") == "1":
+        return
+    roots = {pathlib.Path.home() / "Ouroboros" / "data"}
+    configured = str(os.environ.get("OUROBOROS_TEST_LIVE_DATA_ROOT") or "").strip()
+    if configured:
+        roots.add(pathlib.Path(configured))
+    target = pathlib.Path(path).resolve(strict=False)
+    for root in roots:
+        try:
+            target.relative_to(root.resolve(strict=False))
+        except ValueError:
+            continue
+        raise RuntimeError(f"PYTEST_LIVE_DATA_WRITE_BLOCKED: {target}")
 
 
 def init(drive_root: pathlib.Path, total_budget_limit: float = 0.0) -> None:
@@ -40,6 +60,7 @@ def init(drive_root: pathlib.Path, total_budget_limit: float = 0.0) -> None:
 
 
 def atomic_write_text(path: pathlib.Path, content: str) -> None:
+    assert_test_data_path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(f".{path.name}.tmp.{uuid.uuid4().hex}")
     fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
@@ -165,6 +186,7 @@ def _warn_state_unlocked(op: str, lock_fd: Optional[int]) -> None:
 
 
 def load_state() -> Dict[str, Any]:
+    assert_test_data_path(STATE_PATH)
     lock_fd = acquire_file_lock(STATE_LOCK_PATH)
     _warn_state_unlocked("load", lock_fd)
     try:
@@ -174,6 +196,7 @@ def load_state() -> Dict[str, Any]:
 
 
 def save_state(st: Dict[str, Any]) -> None:
+    assert_test_data_path(STATE_PATH)
     lock_fd = acquire_file_lock(STATE_LOCK_PATH)
     _warn_state_unlocked("save", lock_fd)
     try:
@@ -199,6 +222,7 @@ def update_state(mutator) -> Dict[str, Any]:
     ``mutator`` must NOT call ``load_state``/``save_state``/``update_state`` itself:
     STATE_LOCK is not re-entrant within a process, so re-entering would block.
     """
+    assert_test_data_path(STATE_PATH)
     lock_fd = acquire_file_lock(STATE_LOCK_PATH)
     _warn_state_unlocked("update", lock_fd)
     try:
@@ -212,6 +236,7 @@ def update_state(mutator) -> Dict[str, Any]:
 
 def init_state() -> Dict[str, Any]:
     """Initialize session snapshots for budget drift detection."""
+    assert_test_data_path(STATE_PATH)
     lock_fd = acquire_file_lock(STATE_LOCK_PATH)
     try:
         st = _load_state_unlocked()

--- a/supervisor/task_reaper.py
+++ b/supervisor/task_reaper.py
@@ -355,6 +355,7 @@ def reap_timed_out_task(job: Dict[str, Any]) -> None:
                     "type": "task_done", "task_id": task_id, "task_type": task_type,
                     "chat_id": done_chat_id, "status": self_status,
                     "reason_code": str((_existing or {}).get("reason_code") or ""),
+                    "metadata": task.get("metadata") if isinstance(task.get("metadata"), dict) else {},
             })
         except Exception:
             log.debug("Reaper: failed to emit task_done for self-finalized %s", task_id, exc_info=True)

--- a/supervisor/task_reaper.py
+++ b/supervisor/task_reaper.py
@@ -259,6 +259,9 @@ def reap_timed_out_task(job: Dict[str, Any]) -> None:
     proc = job.get("proc")
     task_id = str(job.get("task_id") or "")
     task = job.get("task") if isinstance(job.get("task"), dict) else {}
+    task_metadata = task.get("metadata") if isinstance(task.get("metadata"), dict) else {}
+    evolution_tx = task_metadata.get("evolution_transaction")
+    terminal_metadata = {"evolution_transaction": dict(evolution_tx)} if isinstance(evolution_tx, dict) else {}
     task_type = str(job.get("task_type") or "")
     terminal_reason = str(job.get("terminal_reason") or "idle_timeout")
     attempt = int(job.get("attempt") or 1)
@@ -355,7 +358,7 @@ def reap_timed_out_task(job: Dict[str, Any]) -> None:
                     "type": "task_done", "task_id": task_id, "task_type": task_type,
                     "chat_id": done_chat_id, "status": self_status,
                     "reason_code": str((_existing or {}).get("reason_code") or ""),
-                    "metadata": task.get("metadata") if isinstance(task.get("metadata"), dict) else {},
+                    "metadata": terminal_metadata,
             })
         except Exception:
             log.debug("Reaper: failed to emit task_done for self-finalized %s", task_id, exc_info=True)
@@ -508,7 +511,7 @@ def reap_timed_out_task(job: Dict[str, Any]) -> None:
                         "chat_id": done_chat_id, "status": "failed", "reason_code": terminal_reason,
                         "outcome_axes": terminal_outcome_axes(lifecycle="failed", execution=EXECUTION_INFRA_FAILED, reason_code=terminal_reason, review_trigger="supervisor_terminal"),
                         **recon_fields,
-                        "metadata": task.get("metadata") if isinstance(task.get("metadata"), dict) else {},
+                        "metadata": terminal_metadata,
                 })
             except Exception:
                 log.debug("Reaper: failed to emit task_done for %s", task_id, exc_info=True)

--- a/supervisor/workers.py
+++ b/supervisor/workers.py
@@ -17,12 +17,13 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from supervisor.state import load_state, append_jsonl, reconstruct_task_cost
 from supervisor.message_bus import coerce_chat_identity, send_with_budget
+from ouroboros.config import DATA_DIR, REPO_DIR as CONFIG_REPO_DIR
 from ouroboros.outcomes import EXECUTION_FAILED, EXECUTION_INFRA_FAILED, terminal_outcome_axes
 from ouroboros.utils import utc_now_iso
 
 
-REPO_DIR: pathlib.Path = pathlib.Path.home() / "Ouroboros" / "repo"
-DRIVE_ROOT: pathlib.Path = pathlib.Path.home() / "Ouroboros" / "data"
+REPO_DIR: pathlib.Path = pathlib.Path(CONFIG_REPO_DIR)
+DRIVE_ROOT: pathlib.Path = pathlib.Path(DATA_DIR)
 MAX_WORKERS: int = 10
 SOFT_TIMEOUT_SEC: int = 600
 HARD_TIMEOUT_SEC: int = 1800
@@ -1302,6 +1303,9 @@ def _emit_task_done_terminal(
     status = status or "failed"
     # Caller reason_code wins; budget_exhausted -> EXECUTION_FAILED below, not infra-failure.
     reason_code = reason_code or ("worker_terminal_failure" if status == "failed" else status)
+    task_metadata = (task or {}).get("metadata")
+    task_metadata = task_metadata if isinstance(task_metadata, dict) else {}
+    evolution_tx = task_metadata.get("evolution_transaction")
     try:
         cost_fields: Dict[str, Any] = {
             "cost_accounting_status": cost_accounting_status,
@@ -1332,6 +1336,8 @@ def _emit_task_done_terminal(
                 review_trigger="worker_terminal",
             ),
             "reason_code": reason_code,
+            **({"metadata": {"evolution_transaction": dict(evolution_tx)}}
+               if isinstance(evolution_tx, dict) else {}),
             **cost_fields,
         })
         return True
@@ -1812,6 +1818,62 @@ def _drop_cancelled_pending() -> None:
         )
 
 
+def _evolution_assignment_error(task: Dict[str, Any]) -> str:
+    """Return the exact authority error for an evolution task about to run."""
+    if str(task.get("type") or "") != "evolution":
+        return ""
+    metadata = task.get("metadata") if isinstance(task.get("metadata"), dict) else {}
+    tx = metadata.get("evolution_transaction")
+    tx = tx if isinstance(tx, dict) else {}
+    task_id = str(task.get("id") or "")
+    if str(tx.get("task_id") or "") != task_id:
+        return "task_mismatch"
+    from supervisor.evolution_lifecycle import check_evolution_authority
+
+    try:
+        authority = check_evolution_authority(
+            campaign_id=str(tx.get("campaign_id") or ""),
+            transaction_id=str(tx.get("transaction_id") or ""),
+            task_id=task_id,
+            require_uncommitted=True,
+        )
+    except Exception:
+        log.warning("Evolution assignment authority check failed", exc_info=True)
+        return "authority_check_failed"
+    return "" if authority.get("ok") else str(authority.get("reason") or "unknown")
+
+
+def _cancel_unauthorized_evolution(task: Dict[str, Any], reason: str) -> bool:
+    """Terminally cancel a stale restored/retried evolution task."""
+    task_id = str(task.get("id") or "")
+    from ouroboros.task_results import STATUS_CANCELLED, write_task_result
+
+    try:
+        write_task_result(
+            DRIVE_ROOT,
+            task_id,
+            STATUS_CANCELLED,
+            reason_code="evolution_authority_missing",
+            authority_reason=str(reason or "unknown"),
+            metadata=task.get("metadata") if isinstance(task.get("metadata"), dict) else {},
+            result=f"Evolution authority is no longer active ({reason or 'unknown'}).",
+        )
+    except Exception:
+        log.debug("Failed to cancel unauthorized evolution task %s", task_id, exc_info=True)
+        return False
+    _emit_task_done_terminal(
+        task, task_id, "cancelled", reason_code="evolution_authority_missing",
+    )
+    append_jsonl(
+        DRIVE_ROOT / "logs" / "events.jsonl",
+        {
+            "ts": utc_now_iso(), "type": "evolution_assignment_rejected",
+            "task_id": task_id, "reason": str(reason or "unknown"),
+        },
+    )
+    return True
+
+
 def assign_tasks() -> None:
     from supervisor import queue
     from supervisor.state import budget_remaining, EVOLUTION_BUDGET_RESERVE
@@ -2007,6 +2069,13 @@ def assign_tasks() -> None:
                         queue.persist_queue_snapshot(reason="evolution_dropped_budget")
                     continue
                 task = PENDING.pop(chosen_idx)
+                evolution_error = _evolution_assignment_error(task)
+                if evolution_error:
+                    if _cancel_unauthorized_evolution(task, evolution_error):
+                        queue.persist_queue_snapshot(reason="evolution_authority_rejected")
+                    else:
+                        PENDING.insert(chosen_idx, task)
+                    continue
                 if str(task.get("delegation_role") or "") == "subagent" and str(task.get("drive_root") or ""):
                     try:
                         from ouroboros.task_results import STATUS_RUNNING, write_task_result
@@ -2268,19 +2337,10 @@ def _ensure_workers_healthy_locked(queue: Any) -> tuple[List[int], bool]:
                             )
                         except Exception:
                             log.debug("Failed to send failure message for %s", w.busy_task_id, exc_info=True)
-                        try:
-                            get_event_q().put({
-                                "type": "task_done",
-                                "task_id": str(w.busy_task_id),
-                                "task_type": task_type,
-                                "chat_id": chat_id,
-                                "status": "failed",
-                                "reason_code": reason_code,
-                                "outcome_axes": terminal_outcome_axes(lifecycle="failed", execution=EXECUTION_INFRA_FAILED, reason_code=reason_code, review_trigger="worker_terminal"),
-                                **r_cost_fields,
-                            })
-                        except Exception:
-                            log.debug("Failed to emit terminal event for %s", w.busy_task_id, exc_info=True)
+                        _emit_task_done_terminal(
+                            task, str(w.busy_task_id), "failed",
+                            reason_code=reason_code, **r_cost_fields,
+                        )
                     elif task_type == "evolution" and not bool(load_state().get("evolution_mode_enabled")):
                         # Evolution was stopped: do not resurrect a dead evolution
                         # worker into another cycle (mirrors the hard-timeout gate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,11 @@
 # Cross-module helpers that are not pytest fixtures (e.g. SDK mock, extension
 # runtime cleanup) live in ``tests/_shared.py`` instead.
 import asyncio
+import functools
 import os
 import pathlib
 import shutil
+import subprocess
 import sys
 import tempfile
 
@@ -15,8 +17,10 @@ import pytest
 
 _PYTEST_DATA_DIR = None
 if os.environ.get("OUROBOROS_ALLOW_LIVE_DATA_TESTS") != "1":
-    _LIVE_DATA_ROOT = os.environ.get(
-        "OUROBOROS_DATA_DIR", str(pathlib.Path.home() / "Ouroboros" / "data")
+    _LIVE_DATA_ROOT = (
+        os.environ.get("OUROBOROS_TEST_LIVE_DATA_ROOT")
+        or os.environ.get("OUROBOROS_DATA_DIR")
+        or str(pathlib.Path.home() / "Ouroboros" / "data")
     )
     _PYTEST_DATA_DIR = pathlib.Path(tempfile.mkdtemp(prefix="ouroboros-pytest-data-"))
     os.environ["OUROBOROS_PYTEST_ACTIVE"] = "1"
@@ -30,6 +34,54 @@ if os.environ.get("OUROBOROS_ALLOW_LIVE_DATA_TESTS") != "1":
     # programbench/swe_bench_pro pollution). A file-local autouse fixture only
     # covered one module; pinning it here covers every test.
     os.environ["OUROBOROS_BENCH_RUNS_ROOT"] = str(_PYTEST_DATA_DIR / "bench_runs")
+
+
+_ORIGINAL_POPEN_INIT = subprocess.Popen.__init__
+_PYTEST_CHILD_DATA_DIR = os.environ.get("OUROBOROS_DATA_DIR", "")
+_PYTEST_CHILD_LIVE_ROOT = os.environ.get("OUROBOROS_TEST_LIVE_DATA_ROOT", "")
+_PYTEST_CHILD_BENCH_ROOT = os.environ.get("OUROBOROS_BENCH_RUNS_ROOT", "")
+_PYTEST_POPEN_PATCHED = False
+
+
+def _isolated_child_env(value) -> dict:
+    child_env = dict(value)
+    if not child_env.get("OUROBOROS_DATA_DIR"):
+        child_env["OUROBOROS_DATA_DIR"] = _PYTEST_CHILD_DATA_DIR
+    if not child_env.get("OUROBOROS_SETTINGS_PATH"):
+        child_env["OUROBOROS_SETTINGS_PATH"] = str(
+            pathlib.Path(child_env["OUROBOROS_DATA_DIR"]) / "settings.json"
+        )
+    if _PYTEST_CHILD_BENCH_ROOT and not child_env.get("OUROBOROS_BENCH_RUNS_ROOT"):
+        child_env["OUROBOROS_BENCH_RUNS_ROOT"] = _PYTEST_CHILD_BENCH_ROOT
+    child_env["OUROBOROS_PYTEST_ACTIVE"] = "1"
+    child_env["OUROBOROS_TEST_LIVE_DATA_ROOT"] = _PYTEST_CHILD_LIVE_ROOT
+    return child_env
+
+
+def _install_pytest_child_isolation() -> None:
+    """Keep the disposable data root when a test scrubs a child env."""
+    global _PYTEST_POPEN_PATCHED
+    if _PYTEST_DATA_DIR is None or _PYTEST_POPEN_PATCHED:
+        return
+
+    @functools.wraps(_ORIGINAL_POPEN_INIT)
+    def isolated_init(self, *args, **kwargs):
+        positional = list(args)
+        if len(positional) > 10 and positional[10] is not None:
+            positional[10] = _isolated_child_env(positional[10])
+        elif kwargs.get("env") is not None:
+            kwargs["env"] = _isolated_child_env(kwargs["env"])
+        return _ORIGINAL_POPEN_INIT(self, *positional, **kwargs)
+
+    subprocess.Popen.__init__ = isolated_init
+    _PYTEST_POPEN_PATCHED = True
+
+
+def _restore_pytest_child_isolation() -> None:
+    global _PYTEST_POPEN_PATCHED
+    if _PYTEST_POPEN_PATCHED:
+        subprocess.Popen.__init__ = _ORIGINAL_POPEN_INIT
+        _PYTEST_POPEN_PATCHED = False
 
 
 def _bind_pytest_runtime_roots() -> None:
@@ -112,6 +164,7 @@ def pytest_collection_modifyitems(config, items):  # noqa: ARG001
 
 def pytest_sessionstart(session):  # noqa: ARG001
     _bind_pytest_runtime_roots()
+    _install_pytest_child_isolation()
     repo_root = pathlib.Path(__file__).resolve().parents[1]
     session.config._ouroboros_initial_mock_pollution = _mock_pollution_files(repo_root)
 
@@ -150,6 +203,12 @@ def pytest_sessionfinish(session, exitstatus):  # noqa: ARG001
     # Per-process temp data dir (unique mkdtemp per controller/worker) — clean on EVERY process.
     if _PYTEST_DATA_DIR is not None:
         shutil.rmtree(_PYTEST_DATA_DIR, ignore_errors=True)
+
+
+def pytest_unconfigure(config):  # noqa: ARG001
+    # Keep child isolation active through every session-finish hook; some tests
+    # exercise that hook directly before the real pytest session has ended.
+    _restore_pytest_child_isolation()
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,12 @@ import pytest
 
 _PYTEST_DATA_DIR = None
 if os.environ.get("OUROBOROS_ALLOW_LIVE_DATA_TESTS") != "1":
+    _LIVE_DATA_ROOT = os.environ.get(
+        "OUROBOROS_DATA_DIR", str(pathlib.Path.home() / "Ouroboros" / "data")
+    )
     _PYTEST_DATA_DIR = pathlib.Path(tempfile.mkdtemp(prefix="ouroboros-pytest-data-"))
+    os.environ["OUROBOROS_PYTEST_ACTIVE"] = "1"
+    os.environ["OUROBOROS_TEST_LIVE_DATA_ROOT"] = _LIVE_DATA_ROOT
     os.environ["OUROBOROS_DATA_DIR"] = str(_PYTEST_DATA_DIR)
     os.environ["OUROBOROS_SETTINGS_PATH"] = str(_PYTEST_DATA_DIR / "settings.json")
     # Conftest-WIDE bench-runs isolation. devtools benchmark tests invoke
@@ -25,6 +30,21 @@ if os.environ.get("OUROBOROS_ALLOW_LIVE_DATA_TESTS") != "1":
     # programbench/swe_bench_pro pollution). A file-local autouse fixture only
     # covered one module; pinning it here covers every test.
     os.environ["OUROBOROS_BENCH_RUNS_ROOT"] = str(_PYTEST_DATA_DIR / "bench_runs")
+
+
+def _bind_pytest_runtime_roots() -> None:
+    """Rebind modules that may have been imported before conftest set the env."""
+    if _PYTEST_DATA_DIR is None:
+        return
+    root = _PYTEST_DATA_DIR.resolve(strict=False)
+    import ouroboros.config as config
+    from supervisor import queue, state, workers
+
+    config.DATA_DIR = root
+    config.SETTINGS_PATH = root / "settings.json"
+    state.init(root, state.TOTAL_BUDGET_LIMIT)
+    queue.init(root, queue.SOFT_TIMEOUT_SEC, queue.HARD_TIMEOUT_SEC)
+    workers.DRIVE_ROOT = root
 
 
 def _mock_pollution_files(root: pathlib.Path) -> set[pathlib.Path]:
@@ -91,6 +111,7 @@ def pytest_collection_modifyitems(config, items):  # noqa: ARG001
 
 
 def pytest_sessionstart(session):  # noqa: ARG001
+    _bind_pytest_runtime_roots()
     repo_root = pathlib.Path(__file__).resolve().parents[1]
     session.config._ouroboros_initial_mock_pollution = _mock_pollution_files(repo_root)
 
@@ -148,6 +169,12 @@ def pytest_runtest_call(item):  # noqa: ARG001
     yield  # test body runs here
     test_loop.close()
     asyncio.set_event_loop(None)
+
+
+@pytest.fixture(autouse=True)
+def _rebind_runtime_roots_between_tests():
+    _bind_pytest_runtime_roots()
+    yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_agent_task_pipeline.py
+++ b/tests/test_agent_task_pipeline.py
@@ -193,6 +193,28 @@ def test_emit_task_results_queues_restart_after_final_events(tmp_path, monkeypat
     assert memory_calls == ["post_task"]
 
     pending_events.clear()
+    evolution_ctx = SimpleNamespace(
+        pending_restart_reason="apply reviewed evolution",
+        pending_restart_is_evolution=True,
+    )
+    pipeline.emit_task_results(
+        env=env,
+        memory=object(),
+        llm=object(),
+        pending_events=pending_events,
+        task={"id": "evo-1", "type": "evolution", "chat_id": 1, "text": "improve"},
+        text="All done",
+        usage={"rounds": 2, "cost": 0.2},
+        llm_trace={"tool_calls": [], "reasoning_notes": []},
+        start_time=0.0,
+        drive_logs=drive_logs,
+        ctx=evolution_ctx,
+    )
+    assert [evt["type"] for evt in pending_events] == ["send_message", "task_metrics", "task_done"]
+    assert evolution_ctx.pending_restart_reason is None
+    assert evolution_ctx.pending_restart_is_evolution is False
+
+    pending_events.clear()
     memory_calls.clear()
     pipeline.emit_task_results(
         env=env,

--- a/tests/test_commit_gate.py
+++ b/tests/test_commit_gate.py
@@ -436,14 +436,15 @@ def test_auto_push_is_best_effort():
     assert "non-fatal" in source.lower() or "non_fatal" in source.lower()
 
 
-def test_final_evolution_authority_recheck_and_auto_push_hold_git_lock():
-    """The final exact-authority check and push must precede lock release."""
+def test_only_evolution_authority_recheck_and_auto_push_hold_git_lock():
+    """Evolution push stays inside the lock; ordinary push returns outside it."""
     git_mod = _get_git_module()
     source = inspect.getsource(git_mod._repo_commit_push)
-    lock_release_pos = source.rfind("_release_git_lock")
-    authority_pos = source.rfind("_evolution_publication_stopped_result")
-    push_pos = source.rfind("_auto_push")
-    assert authority_pos < push_pos < lock_release_pos
+    authority_pos = source.find("_evolution_publication_stopped_result")
+    evolution_push_pos = source.find("_auto_push", authority_pos)
+    lock_release_pos = source.find("_release_git_lock", evolution_push_pos)
+    ordinary_push_pos = source.find("_auto_push", lock_release_pos)
+    assert authority_pos < evolution_push_pos < lock_release_pos < ordinary_push_pos
 
 
 # --- Credential configuration (legacy token-in-URL migration retired) ---

--- a/tests/test_commit_gate.py
+++ b/tests/test_commit_gate.py
@@ -436,13 +436,14 @@ def test_auto_push_is_best_effort():
     assert "non-fatal" in source.lower() or "non_fatal" in source.lower()
 
 
-def test_auto_push_outside_git_lock():
-    """Auto-push call must happen AFTER _release_git_lock, not inside the try/finally."""
+def test_final_evolution_authority_recheck_and_auto_push_hold_git_lock():
+    """The final exact-authority check and push must precede lock release."""
     git_mod = _get_git_module()
     source = inspect.getsource(git_mod._repo_commit_push)
     lock_release_pos = source.rfind("_release_git_lock")
+    authority_pos = source.rfind("_evolution_publication_stopped_result")
     push_pos = source.rfind("_auto_push")
-    assert lock_release_pos < push_pos, "_repo_commit_push: _auto_push must come after _release_git_lock"
+    assert authority_pos < push_pos < lock_release_pos
 
 
 # --- Credential configuration (legacy token-in-URL migration retired) ---

--- a/tests/test_conftest_xdist_guard.py
+++ b/tests/test_conftest_xdist_guard.py
@@ -41,6 +41,7 @@ def test_pollution_sweep_runs_on_controller(monkeypatch):
 
     assert session.exitstatus == 1, "controller must run the sweep and fail the run on pollution"
     assert not _FAKE_LEAK.exists(), "sweep must not have created anything on disk"
+    assert conftest._PYTEST_POPEN_PATCHED is True
 
 
 def test_pollution_sweep_is_skipped_on_worker(monkeypatch):
@@ -53,3 +54,4 @@ def test_pollution_sweep_is_skipped_on_worker(monkeypatch):
     # A worker must NOT run the sweep nor mutate exitstatus — the controller owns the repo-root
     # authority, so workers cannot race the rmtree or each independently fail the run.
     assert session.exitstatus == 0
+    assert conftest._PYTEST_POPEN_PATCHED is True

--- a/tests/test_evolution_redesign.py
+++ b/tests/test_evolution_redesign.py
@@ -83,6 +83,7 @@ def test_evolution_enqueue_attaches_lightweight_transaction(tmp_path, monkeypatc
     queue.init(tmp_path, 600, 1800)
     pending = []
     queue.init_queue_refs(pending, {}, {"value": 0})
+    queue.start_evolution_campaign("Improve", source="test")
     st = supervisor_state.load_state()
     st["evolution_mode_enabled"] = True
     st["owner_chat_id"] = 1
@@ -101,15 +102,22 @@ def test_evolution_enqueue_attaches_lightweight_transaction(tmp_path, monkeypatc
 
 def test_evolution_task_completion_preserves_live_transaction_updates(tmp_path):
     from supervisor import queue
+    from supervisor import state as supervisor_state
 
+    supervisor_state.init(tmp_path)
     queue.init(tmp_path, 600, 1800)
     campaign = queue.start_evolution_campaign("Improve", source="test")
+    st = supervisor_state.load_state()
+    st["evolution_mode_enabled"] = True
+    supervisor_state.save_state(st)
     stale = queue.begin_evolution_transaction("task1", cycle=1, campaign=campaign)
+    assert lifecycle.record_evolution_commit(
+        campaign["id"], stale["transaction_id"], "task1", "abc123",
+    )["ok"] is True
     lifecycle.update_evolution_transaction(
         "task1",
         preflight_status="passed",
         triad_scope_status="passed",
-        commit_sha="abc123",
         push_status="skipped_or_failed",
     )
 
@@ -122,7 +130,9 @@ def test_evolution_task_completion_preserves_live_transaction_updates(tmp_path):
     )
     campaign = queue.get_evolution_status_snapshot()["campaign"]
 
-    assert recorded["commit_sha"] == "abc123"
+    assert recorded["accepted"] is True
+    assert recorded["persisted"] is True
+    assert recorded["transaction"]["commit_sha"] == "abc123"
     assert campaign["history"][0]["transaction"]["commit_sha"] == "abc123"
     assert campaign.get("transaction_history", []) == []
     assert campaign["active_transaction"]["commit_sha"] == "abc123"
@@ -138,10 +148,12 @@ def test_evolution_task_completion_preserves_live_transaction_updates(tmp_path):
         transaction=stale,
     )
     campaign = queue.get_evolution_status_snapshot()["campaign"]
-    assert replay_recorded["commit_sha"] == "abc123"
+    assert replay_recorded["replay"] is True
+    assert replay_recorded["transaction"]["commit_sha"] == "abc123"
     assert len(campaign["history"]) == 1
     assert campaign["cycles_done"] == 1
 
+    lifecycle.complete_evolution_campaign("previous scenario complete", cleanup_worktree=False)
     campaign = queue.start_evolution_campaign("Improve", source="test")
     no_durability = queue.begin_evolution_transaction("task2", cycle=2, campaign=campaign)
     lifecycle.update_evolution_campaign_after_task(
@@ -168,6 +180,9 @@ def test_terminal_evolution_event_without_running_metadata_updates_transaction(t
     supervisor_state.init(tmp_path)
     queue.init(tmp_path, 600, 1800)
     campaign = queue.start_evolution_campaign("Improve", source="test")
+    st = supervisor_state.load_state()
+    st["evolution_mode_enabled"] = True
+    supervisor_state.save_state(st)
     tx = queue.begin_evolution_transaction("task-cancel", cycle=1, campaign=campaign)
     write_task_result(tmp_path, "task-cancel", STATUS_CANCELLED, cost_usd=1.0, total_rounds=1)
 
@@ -215,6 +230,9 @@ def test_degraded_evolution_axes_count_as_failure(tmp_path):
     supervisor_state.init(tmp_path)
     queue.init(tmp_path, 600, 1800)
     campaign = queue.start_evolution_campaign("Improve", source="test")
+    st = supervisor_state.load_state()
+    st["evolution_mode_enabled"] = True
+    supervisor_state.save_state(st)
     tx = queue.begin_evolution_transaction("task-degraded", cycle=1, campaign=campaign)
     write_task_result(
         tmp_path,
@@ -684,6 +702,7 @@ def test_no_op_cycle_resets_dirty_worktree_to_base_with_recovery_refs(tmp_path, 
     import subprocess
 
     from supervisor import git_ops, queue
+    from supervisor import state as supervisor_state
 
     repo = tmp_path / "repo"
     _git = _make_git_repo(repo)
@@ -700,6 +719,9 @@ def test_no_op_cycle_resets_dirty_worktree_to_base_with_recovery_refs(tmp_path, 
     queue.RUNNING.clear()
 
     campaign = queue.start_evolution_campaign("Improve", source="test")
+    st = supervisor_state.load_state()
+    st["evolution_mode_enabled"] = True
+    supervisor_state.save_state(st)
     tx = queue.begin_evolution_transaction("task-noop", cycle=1, campaign=campaign)
     assert tx["base_head"]  # begin records the CURRENT head (after leftover commit)
     # Rewrite base to the true cycle base for the scenario.
@@ -708,12 +730,14 @@ def test_no_op_cycle_resets_dirty_worktree_to_base_with_recovery_refs(tmp_path, 
     recorded = lifecycle.update_evolution_campaign_after_task(
         "task-noop", cost_usd=0.1,
         outcome_axes={"execution": {"status": "ok"}}, rounds=2,
+        transaction=tx,
     )
 
-    assert recorded["cycle_outcome"] == "no_op"
-    assert recorded["cleanup_status"] == "reset_to_base"
-    assert recorded["cleanup_stash"].startswith("evolution-cycle-cleanup-")
-    assert recorded["cleanup_preserved_ref"].startswith("evolution-leftover-")
+    recorded_tx = recorded["transaction"]
+    assert recorded_tx["cycle_outcome"] == "no_op"
+    assert recorded_tx["cleanup_status"] == "reset_to_base"
+    assert recorded_tx["cleanup_stash"].startswith("evolution-cycle-cleanup-")
+    assert recorded_tx["cleanup_preserved_ref"].startswith("evolution-leftover-")
     # Worktree is back at base and clean.
     head_now = subprocess.run(["git", "rev-parse", "HEAD"], cwd=str(repo), capture_output=True, text=True).stdout.strip()
     status_now = subprocess.run(["git", "status", "--porcelain"], cwd=str(repo), capture_output=True, text=True).stdout.strip()
@@ -759,6 +783,8 @@ def test_no_op_cleanup_skips_when_other_tasks_running_or_already_clean(tmp_path)
 def test_evolution_restart_uses_local_commit_not_origin_and_blocks_dirty_tree(tmp_path):
     from ouroboros.tools.control import _request_restart
     from ouroboros.tools.registry import ToolContext
+    from supervisor import evolution_lifecycle, queue
+    from supervisor import state as supervisor_state
 
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -777,19 +803,38 @@ def test_evolution_restart_uses_local_commit_not_origin_and_blocks_dirty_tree(tm
     head = __import__("subprocess").run(
         ["git", "rev-parse", "HEAD"], cwd=str(repo), check=True, capture_output=True, text=True
     ).stdout.strip()
-    ctx = ToolContext(repo_dir=repo, drive_root=tmp_path, current_task_type="evolution")
+    supervisor_state.init(tmp_path)
+    queue.init(tmp_path, 600, 1800)
+    campaign = evolution_lifecycle.start_evolution_campaign("Improve", source="test")
+    st = supervisor_state.load_state()
+    st["evolution_mode_enabled"] = True
+    supervisor_state.save_state(st)
+    tx = evolution_lifecycle.begin_evolution_transaction("evo", cycle=1, campaign=campaign)
+    assert evolution_lifecycle.record_evolution_commit(
+        campaign["id"], tx["transaction_id"], "evo", head,
+    )["ok"] is True
+    ctx = ToolContext(
+        repo_dir=repo,
+        drive_root=tmp_path,
+        current_task_type="evolution",
+        task_id="evo",
+        task_metadata={"evolution_transaction": tx},
+    )
     ctx.last_reviewed_commit_sha = head
 
-    result = _request_restart(ctx, "after local commit")
+    result = _request_restart(ctx, "   ")
 
     assert "Restart requested" in result
+    marker = json.loads((tmp_path / "state" / "pending_restart_verify.json").read_text())
+    assert marker["reason"] == "agent_requested_restart"
+    assert ctx.pending_restart_is_evolution is True
     (repo / "file.txt").write_text("dirty\n", encoding="utf-8")
     ctx = ToolContext(repo_dir=repo, drive_root=tmp_path, current_task_type="evolution")
 
     result = _request_restart(ctx, "dirty")
 
     assert "RESTART_BLOCKED" in result
-    assert "local reviewed commit" in result
+    assert "exact local commit receipt" in result
 
 
 def test_toggle_evolution_tool_accepts_objective(tmp_path, monkeypatch):
@@ -891,6 +936,7 @@ def test_enqueue_evolution_omits_duplicate_cycle_message(tmp_path, monkeypatch):
     queue.init(tmp_path, 600, 1800)
     pending = []
     queue.init_queue_refs(pending, {}, {"value": 0})
+    queue.start_evolution_campaign("Improve", source="test")
     st = supervisor_state.load_state()
     st["evolution_mode_enabled"] = True
     st["owner_chat_id"] = 1

--- a/tests/test_evolution_redesign.py
+++ b/tests/test_evolution_redesign.py
@@ -36,15 +36,21 @@ def test_evolution_campaign_text_includes_objective(tmp_path, monkeypatch):
 
 
 def test_evolution_campaign_pause_resume_preserves_history(tmp_path):
-    from supervisor import queue
+    from supervisor import queue, state
 
+    state.init(tmp_path)
     queue.init(tmp_path, 600, 1800)
     first = queue.start_evolution_campaign("Improve scheduler observability", source="test")
+    live = state.load_state()
+    live["evolution_mode_enabled"] = True
+    state.save_state(live)
+    transaction = lifecycle.begin_evolution_transaction("task1", cycle=1, campaign=first)
     lifecycle.update_evolution_campaign_after_task(
         "task1",
         cost_usd=0.5,
         outcome_axes={"execution": {"status": "ok"}, "objective": {"status": "not_evaluated"}},
         rounds=3,
+        transaction=transaction,
     )
     queue.pause_evolution_campaign("pause")
     resumed = queue.start_evolution_campaign("", source="test")

--- a/tests/test_evolution_state_integrity_v3.py
+++ b/tests/test_evolution_state_integrity_v3.py
@@ -1,0 +1,1647 @@
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+
+def _active_transaction(tmp_path: pathlib.Path, task_id: str = "evo-task"):
+    from supervisor import evolution_lifecycle, queue, state
+
+    state.init(tmp_path)
+    queue.init(tmp_path, 600, 1800)
+    queue.init_queue_refs([], {}, {"value": 0})
+    campaign = evolution_lifecycle.start_evolution_campaign("Improve", source="test")
+    live = state.load_state()
+    live.update({
+        "owner_chat_id": 1,
+        "evolution_mode_enabled": True,
+        "evolution_owner_stopped": False,
+    })
+    state.save_state(live)
+    tx = evolution_lifecycle.begin_evolution_transaction(task_id, cycle=1, campaign=campaign)
+    return campaign, tx
+
+
+class _CaptureQueue:
+    def __init__(self):
+        self.items = []
+
+    def put(self, item):
+        self.items.append(item)
+
+
+def _assignment_case(tmp_path, monkeypatch, task_id="assign-evo"):
+    from supervisor import evolution_lifecycle, queue, state, workers
+
+    state.init(tmp_path)
+    monkeypatch.setattr(state, "TOTAL_BUDGET_LIMIT", 0.0)
+    pending, running = [], {}
+    monkeypatch.setattr(workers, "PENDING", pending)
+    monkeypatch.setattr(workers, "RUNNING", running)
+    workers.init(tmp_path, tmp_path, 1, 600, 1800, 0.0)
+    campaign = evolution_lifecycle.start_evolution_campaign("Improve", source="test")
+    state.update_state(lambda live: live.update(
+        evolution_mode_enabled=True,
+        evolution_owner_stopped=False,
+    ))
+    tx = evolution_lifecycle.begin_evolution_transaction(task_id, cycle=1, campaign=campaign)
+    task = {
+        "id": task_id,
+        "type": "evolution",
+        "text": "Improve",
+        "metadata": {"evolution_transaction": dict(tx)},
+    }
+    pending.append(task)
+    inbox, events = _CaptureQueue(), _CaptureQueue()
+    worker = SimpleNamespace(wid=1, busy_task_id=None, reaping=False, in_q=inbox)
+    monkeypatch.setattr(workers, "WORKERS", {1: worker})
+    monkeypatch.setattr(workers, "get_event_q", lambda: events)
+    monkeypatch.setattr(queue, "persist_queue_snapshot", lambda reason="": None)
+    monkeypatch.setattr(evolution_lifecycle, "evolution_block_reason", lambda: "")
+    return workers, task, tx, worker, inbox, events
+
+
+def test_pytest_process_globals_use_the_disposable_root():
+    from supervisor import queue, state, workers
+
+    expected = pathlib.Path(os.environ["OUROBOROS_DATA_DIR"]).resolve(strict=False)
+    assert state.DRIVE_ROOT.resolve(strict=False) == expected
+    assert queue.DRIVE_ROOT.resolve(strict=False) == expected
+    assert workers.DRIVE_ROOT.resolve(strict=False) == expected
+    assert expected != (pathlib.Path.home() / "Ouroboros" / "data").resolve(strict=False)
+
+
+def test_pytest_fuse_blocks_state_and_campaign_writes_to_live_data(monkeypatch):
+    from supervisor import evolution_lifecycle, queue, state
+
+    live = pathlib.Path(os.environ["OUROBOROS_TEST_LIVE_DATA_ROOT"])
+    monkeypatch.setattr(state, "STATE_PATH", live / "state" / "state.json")
+    monkeypatch.setattr(state, "STATE_LOCK_PATH", live / "locks" / "state.lock")
+    with pytest.raises(RuntimeError, match="PYTEST_LIVE_DATA_WRITE_BLOCKED"):
+        state.save_state({"evolution_mode_enabled": True})
+
+    monkeypatch.setattr(queue, "DRIVE_ROOT", live)
+    with pytest.raises(RuntimeError, match="PYTEST_LIVE_DATA_WRITE_BLOCKED"):
+        evolution_lifecycle._write_evolution_campaign({"id": "blocked", "status": "active"})
+
+
+@pytest.mark.serial
+def test_pytest_bootstrap_rebinds_preimported_modules_away_from_fake_home(tmp_path):
+    repo = pathlib.Path(__file__).resolve().parents[1]
+    fake_home = tmp_path / "home"
+    sentinel_path = fake_home / "Ouroboros" / "data" / "state" / "state.json"
+    sentinel_path.parent.mkdir(parents=True)
+    sentinel = b'{"sentinel":"live"}\n'
+    sentinel_path.write_bytes(sentinel)
+    env = dict(os.environ)
+    for key in (
+        "OUROBOROS_DATA_DIR",
+        "OUROBOROS_SETTINGS_PATH",
+        "OUROBOROS_PYTEST_ACTIVE",
+        "OUROBOROS_TEST_LIVE_DATA_ROOT",
+    ):
+        env.pop(key, None)
+    env["HOME"] = str(fake_home)
+    env["PYTHONPATH"] = os.pathsep.join((str(repo), str(repo / "tests")))
+    code = """
+import importlib.util, json, pathlib
+from supervisor import queue, state, workers
+spec = importlib.util.spec_from_file_location('isolated_conftest', pathlib.Path('tests/conftest.py'))
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+module._bind_pytest_runtime_roots()
+state.update_state(lambda live: live.update({'probe': 'isolated'}))
+print(json.dumps({'root': str(state.DRIVE_ROOT), 'state': state.load_state()}))
+"""
+
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert sentinel_path.read_bytes() == sentinel
+    assert pathlib.Path(payload["root"]) != sentinel_path.parents[1]
+    assert payload["state"]["probe"] == "isolated"
+
+
+def test_scheduler_disables_a_bare_flag_without_campaign(tmp_path, monkeypatch):
+    from supervisor import queue, state
+
+    state.init(tmp_path)
+    queue.init(tmp_path, 600, 1800)
+    pending = []
+    queue.init_queue_refs(pending, {}, {"value": 0})
+    live = state.load_state()
+    live.update({
+        "owner_chat_id": 1,
+        "evolution_mode_enabled": True,
+        "post_task_autostop": True,
+    })
+    state.save_state(live)
+    sent = []
+    monkeypatch.setattr(queue, "send_with_budget", lambda *args, **kwargs: sent.append(args[1]))
+
+    queue.enqueue_evolution_task_if_needed()
+
+    assert pending == []
+    assert state.load_state()["evolution_mode_enabled"] is False
+    assert state.load_state()["post_task_autostop"] is False
+    assert "active campaign authority" in sent[0]
+    event = json.loads((tmp_path / "logs" / "events.jsonl").read_text().splitlines()[-1])
+    assert event["type"] == "evolution_authority_missing"
+
+
+def test_scheduler_refuses_active_campaign_without_source(tmp_path, monkeypatch):
+    from supervisor import evolution_lifecycle, queue, state
+
+    state.init(tmp_path)
+    queue.init(tmp_path, 600, 1800)
+    queue.init_queue_refs([], {}, {"value": 0})
+    campaign = evolution_lifecycle.start_evolution_campaign("Improve", source="test")
+    campaign.pop("source")
+    assert evolution_lifecycle._write_evolution_campaign(campaign) is True
+    live = state.load_state()
+    live.update({"owner_chat_id": 1, "evolution_mode_enabled": True})
+    state.save_state(live)
+    monkeypatch.setattr(queue, "send_with_budget", lambda *a, **k: None)
+
+    queue.enqueue_evolution_task_if_needed()
+
+    assert state.load_state()["evolution_mode_enabled"] is False
+
+
+def test_owner_resume_repairs_missing_legacy_campaign_source(tmp_path):
+    from supervisor import evolution_lifecycle, queue, state
+
+    state.init(tmp_path)
+    queue.init(tmp_path, 600, 1800)
+    campaign = evolution_lifecycle.start_evolution_campaign("Improve", source="test")
+    campaign["status"] = "paused"
+    campaign.pop("source")
+    assert evolution_lifecycle._write_evolution_campaign(campaign) is True
+
+    resumed = evolution_lifecycle.start_evolution_campaign("", source="owner_chat")
+
+    assert resumed["status"] == "active"
+    assert resumed["source"] == "owner_chat"
+
+
+def test_scheduler_does_not_enqueue_when_transaction_attach_fails(tmp_path, monkeypatch):
+    from supervisor import evolution_lifecycle, queue, state
+
+    state.init(tmp_path)
+    queue.init(tmp_path, 600, 1800)
+    pending = []
+    queue.init_queue_refs(pending, {}, {"value": 0})
+    evolution_lifecycle.start_evolution_campaign("Improve", source="test")
+    live = state.load_state()
+    live.update({"owner_chat_id": 1, "evolution_mode_enabled": True})
+    state.save_state(live)
+    monkeypatch.setattr(queue, "begin_evolution_transaction", lambda *a, **k: {})
+    monkeypatch.setattr(queue, "send_with_budget", lambda *a, **k: None)
+
+    queue.enqueue_evolution_task_if_needed()
+
+    assert pending == []
+    assert state.load_state()["evolution_mode_enabled"] is False
+
+
+def test_transaction_attach_rechecks_owner_stop_under_state_lock(tmp_path):
+    from supervisor import evolution_lifecycle, queue, state
+
+    state.init(tmp_path)
+    queue.init(tmp_path, 600, 1800)
+    campaign = evolution_lifecycle.start_evolution_campaign("Improve", source="test")
+    live = state.load_state()
+    live.update({"evolution_mode_enabled": False, "evolution_owner_stopped": True})
+    state.save_state(live)
+
+    tx = evolution_lifecycle.begin_evolution_transaction(
+        "too-late", cycle=1, campaign=campaign,
+    )
+
+    assert tx == {}
+    assert "active_transaction" not in evolution_lifecycle._read_evolution_campaign()
+
+
+def test_scheduler_replaces_uncommitted_transaction_lost_before_enqueue(tmp_path, monkeypatch):
+    from supervisor import evolution_lifecycle, queue, state
+
+    state.init(tmp_path)
+    queue.init(tmp_path, 600, 1800)
+    pending = []
+    queue.init_queue_refs(pending, {}, {"value": 0})
+    campaign = evolution_lifecycle.start_evolution_campaign("Improve", source="test")
+    live = state.load_state()
+    live.update({"owner_chat_id": 1, "evolution_mode_enabled": True})
+    state.save_state(live)
+    lost = evolution_lifecycle.begin_evolution_transaction(
+        "lost-before-enqueue", cycle=1, campaign=campaign,
+    )
+    monkeypatch.setattr(queue, "send_with_budget", lambda *a, **k: None)
+
+    queue.enqueue_evolution_task_if_needed()
+
+    assert len(pending) == 1
+    replacement = pending[0]["metadata"]["evolution_transaction"]
+    assert replacement["transaction_id"] != lost["transaction_id"]
+    stored = evolution_lifecycle._read_evolution_campaign()
+    assert stored["active_transaction"]["transaction_id"] == replacement["transaction_id"]
+    assert stored["transaction_history"][-1]["abandoned_reason"] == "dispatch_not_persisted"
+
+
+def test_terminal_event_cannot_write_into_a_different_campaign(tmp_path):
+    from supervisor import evolution_lifecycle
+
+    campaign, tx = _active_transaction(tmp_path, task_id="same-task")
+    stale = {
+        **tx,
+        "campaign_id": "old-campaign",
+        "transaction_id": "old-transaction",
+    }
+
+    result = evolution_lifecycle.update_evolution_campaign_after_task(
+        "same-task",
+        cost_usd=1.0,
+        outcome_axes={"execution": {"status": "ok"}},
+        rounds=1,
+        transaction=stale,
+    )
+
+    assert result == {
+        "accepted": False,
+        "persisted": False,
+        "replay": False,
+        "reason": "transaction_mismatch",
+        "transaction": {},
+    }
+    stored = evolution_lifecycle._read_evolution_campaign()
+    assert stored["id"] == campaign["id"]
+    assert stored["active_transaction"]["transaction_id"] == tx["transaction_id"]
+    assert stored.get("history", []) == []
+
+
+def test_terminal_write_cas_preserves_concurrent_transaction_state(tmp_path, monkeypatch):
+    from supervisor import evolution_lifecycle
+
+    _campaign, tx = _active_transaction(tmp_path)
+    real_write = evolution_lifecycle._write_evolution_campaign
+    side_effects = []
+
+    def _interleave(data, **kwargs):
+        current = evolution_lifecycle._read_evolution_campaign()
+        current["active_transaction"]["concurrent_evidence"] = "kept"
+        assert real_write(current) is True
+        return real_write(data, **kwargs)
+
+    monkeypatch.setattr(evolution_lifecycle, "_write_evolution_campaign", _interleave)
+    monkeypatch.setattr(
+        evolution_lifecycle,
+        "_cleanup_worktree_after_cycle",
+        lambda *_a, **_k: side_effects.append("cleanup"),
+    )
+    monkeypatch.setattr(
+        evolution_lifecycle,
+        "notify_owner_cycle_outcome",
+        lambda *_a, **_k: side_effects.append("notify"),
+    )
+
+    result = evolution_lifecycle.update_evolution_campaign_after_task(
+        tx["task_id"],
+        cost_usd=1.0,
+        outcome_axes={"execution": {"status": "ok"}},
+        rounds=1,
+        transaction=tx,
+    )
+
+    assert result["accepted"] is True
+    assert result["persisted"] is False
+    assert result["reason"] == "campaign_write_refused"
+    stored = evolution_lifecycle._read_evolution_campaign()
+    assert stored["active_transaction"]["concurrent_evidence"] == "kept"
+    assert stored.get("history", []) == []
+    assert side_effects == []
+
+
+def test_terminal_write_exception_has_no_lifecycle_side_effects(tmp_path, monkeypatch):
+    from supervisor import evolution_lifecycle
+
+    _campaign, tx = _active_transaction(tmp_path)
+    side_effects = []
+    monkeypatch.setattr(
+        evolution_lifecycle,
+        "_write_evolution_campaign",
+        lambda *_a, **_k: (_ for _ in ()).throw(OSError("disk full")),
+    )
+    monkeypatch.setattr(
+        evolution_lifecycle,
+        "_cleanup_worktree_after_cycle",
+        lambda *_a, **_k: side_effects.append("cleanup"),
+    )
+    monkeypatch.setattr(
+        evolution_lifecycle,
+        "notify_owner_cycle_outcome",
+        lambda *_a, **_k: side_effects.append("notify"),
+    )
+
+    result = evolution_lifecycle.update_evolution_campaign_after_task(
+        tx["task_id"],
+        cost_usd=1.0,
+        outcome_axes={"execution": {"status": "ok"}},
+        rounds=1,
+        transaction=tx,
+    )
+
+    assert result["persisted"] is False
+    assert result["reason"] == "campaign_write_failed"
+    assert side_effects == []
+
+
+def test_rejected_terminal_does_not_consume_global_evolution_state(tmp_path, monkeypatch):
+    from supervisor import evolution_lifecycle, state
+    from supervisor.events import _handle_evolution_task_done
+
+    state.init(tmp_path)
+    state.update_state(lambda live: live.update(
+        evolution_mode_enabled=True,
+        post_task_autostop=True,
+        evolution_consecutive_failures=4,
+    ))
+    monkeypatch.setattr(
+        evolution_lifecycle,
+        "update_evolution_campaign_after_task",
+        lambda *_a, **_k: {
+            "accepted": True, "persisted": False, "replay": False,
+            "reason": "campaign_write_refused", "transaction": {},
+        },
+    )
+    checkpoints = []
+    monkeypatch.setattr(
+        "ouroboros.evolution_checkpoints.append_evolution_checkpoint",
+        lambda *_a, **_k: checkpoints.append(True),
+    )
+    ctx = SimpleNamespace(DRIVE_ROOT=tmp_path, REPO_DIR=tmp_path)
+    task = {"metadata": {"evolution_transaction": {"transaction_id": "stale"}}}
+
+    _handle_evolution_task_done(
+        ctx,
+        evt={},
+        task_id="stale",
+        task=task,
+        task_done_event={"status": "failed"},
+        outcome_axes={"execution": {"status": "failed"}},
+        cost=1.0,
+        rounds=1,
+    )
+
+    live = state.load_state()
+    assert live["evolution_mode_enabled"] is True
+    assert live["post_task_autostop"] is True
+    assert live["evolution_consecutive_failures"] == 4
+    assert checkpoints == []
+
+
+def test_assignment_dispatches_exact_uncommitted_evolution_claim(tmp_path, monkeypatch):
+    workers, task, _tx, worker, inbox, events = _assignment_case(tmp_path, monkeypatch)
+
+    workers.assign_tasks()
+
+    assert inbox.items == [task]
+    assert worker.busy_task_id == task["id"]
+    assert workers.RUNNING[task["id"]]["task"] == task
+    assert events.items == []
+
+
+def test_assignment_rejects_stale_or_committed_evolution_claim(tmp_path, monkeypatch):
+    from ouroboros.task_results import load_task_result
+    from supervisor import evolution_lifecycle
+
+    workers, task, tx, worker, inbox, events = _assignment_case(tmp_path, monkeypatch)
+    task["metadata"]["evolution_transaction"]["task_id"] = "other-task"
+
+    workers.assign_tasks()
+
+    assert inbox.items == []
+    assert workers.RUNNING == {}
+    assert worker.busy_task_id is None
+    stored = load_task_result(tmp_path, task["id"])
+    assert stored["status"] == "cancelled"
+    assert stored["reason_code"] == "evolution_authority_missing"
+    assert stored["authority_reason"] == "task_mismatch"
+    assert events.items[-1]["metadata"]["evolution_transaction"]["task_id"] == "other-task"
+
+    workers, task, tx, _worker, inbox, _events = _assignment_case(
+        tmp_path / "committed", monkeypatch, task_id="committed-evo",
+    )
+    campaign = evolution_lifecycle._read_evolution_campaign()
+    assert evolution_lifecycle.record_evolution_commit(
+        campaign["id"], tx["transaction_id"], tx["task_id"], "a" * 40,
+    )["ok"] is True
+
+    workers.assign_tasks()
+
+    assert inbox.items == []
+    assert load_task_result(tmp_path / "committed", task["id"])["authority_reason"] == (
+        "transaction_already_committed"
+    )
+
+
+def test_assignment_keeps_invalid_evolution_pending_when_cancel_write_fails(
+    tmp_path, monkeypatch,
+):
+    from supervisor import workers as workers_module
+
+    workers, task, _tx, worker, inbox, events = _assignment_case(tmp_path, monkeypatch)
+    task["metadata"]["evolution_transaction"]["task_id"] = "other-task"
+    monkeypatch.setattr(
+        "ouroboros.task_results.write_task_result",
+        lambda *_a, **_k: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    workers.assign_tasks()
+
+    assert workers_module.PENDING == [task]
+    assert worker.busy_task_id is None
+    assert inbox.items == []
+    assert events.items == []
+
+
+def test_evolution_orphan_ref_cannot_be_published_by_later_normal_push(
+    tmp_path, monkeypatch,
+):
+    from ouroboros.tools import git as git_tools
+    from supervisor import git_ops
+
+    repo, remote = tmp_path / "repo", tmp_path / "remote.git"
+
+    def _git(*args, cwd=repo, check=True):
+        return subprocess.run(
+            ["git", *args], cwd=cwd, check=check, capture_output=True, text=True,
+        )
+
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)], check=True, capture_output=True, text=True,
+    )
+    repo.mkdir()
+    _git("init", "-b", "ouroboros")
+    _git("config", "user.name", "Test")
+    _git("config", "user.email", "test@example.com")
+    _git("remote", "add", "origin", str(remote))
+    (repo / "file.txt").write_text("base\n", encoding="utf-8")
+    _git("add", ".")
+    _git("commit", "-m", "base")
+    base_sha = _git("rev-parse", "HEAD").stdout.strip()
+    _git("tag", "-a", "v-base", "-m", "base")
+    _git("push", "-u", "origin", "ouroboros")
+    _git("push", "origin", "--tags")
+    (repo / "file.txt").write_text("orphan\n", encoding="utf-8")
+    _git("add", ".")
+    _git("commit", "-m", "orphan")
+    orphan_sha = _git("rev-parse", "HEAD").stdout.strip()
+    _git("tag", "-a", "v-orphan", "-m", "orphan")
+
+    note = git_tools._preserve_evolution_orphan(
+        SimpleNamespace(repo_dir=repo), orphan_sha, created_tag="v-orphan",
+    )
+
+    assert "CONTAINMENT_FAILED" not in note
+    assert _git("rev-parse", "HEAD").stdout.strip() == base_sha
+    private_ref = f"refs/ouroboros/evolution-orphans/{orphan_sha}"
+    assert _git("rev-parse", private_ref).stdout.strip() == orphan_sha
+    assert _git("show-ref", "--verify", "refs/tags/v-orphan", check=False).returncode != 0
+    assert _git("rev-parse", "refs/tags/v-base^{commit}").stdout.strip() == base_sha
+
+    monkeypatch.setattr(git_ops, "REPO_DIR", repo)
+    pushed, _message = git_ops.push_to_remote("ouroboros", push_tags=True)
+
+    assert pushed is True
+    assert _git("rev-parse", "refs/heads/ouroboros", cwd=remote).stdout.strip() == base_sha
+    assert _git("show-ref", "--verify", "refs/tags/v-orphan", cwd=remote, check=False).returncode != 0
+    assert _git("show-ref", "--verify", private_ref, cwd=remote, check=False).returncode != 0
+    assert _git("cat-file", "-e", orphan_sha, cwd=remote, check=False).returncode != 0
+
+    # A separate Git writer may advance the branch after the atomic containment
+    # transaction. Worktree alignment must not move that ref back to the parent.
+    (repo / "file.txt").write_text("second orphan\n", encoding="utf-8")
+    _git("add", ".")
+    _git("commit", "-m", "second orphan")
+    second_orphan = _git("rev-parse", "HEAD").stdout.strip()
+    base_tree = _git("rev-parse", f"{base_sha}^{{tree}}").stdout.strip()
+    concurrent = subprocess.run(
+        ["git", "commit-tree", base_tree, "-p", base_sha],
+        cwd=repo,
+        input="concurrent branch update\n",
+        text=True,
+        check=True,
+        capture_output=True,
+    ).stdout.strip()
+    real_run_cmd = git_tools.run_cmd
+    interleaved = {"done": False}
+
+    def _interleave_before_worktree_sync(cmd, cwd=None):
+        if cmd[:4] == ["git", "read-tree", "--reset", "-u"] and not interleaved["done"]:
+            _git("update-ref", "refs/heads/ouroboros", concurrent, base_sha)
+            interleaved["done"] = True
+        return real_run_cmd(cmd, cwd=cwd)
+
+    monkeypatch.setattr(git_tools, "run_cmd", _interleave_before_worktree_sync)
+    note = git_tools._preserve_evolution_orphan(
+        SimpleNamespace(repo_dir=repo), second_orphan,
+    )
+
+    assert "CONTAINMENT_FAILED" not in note
+    assert "concurrent branch update" in note
+    assert _git("rev-parse", "HEAD").stdout.strip() == concurrent
+    assert _git(
+        "rev-parse", f"refs/ouroboros/evolution-orphans/{second_orphan}",
+    ).stdout.strip() == second_orphan
+
+
+def test_exact_commit_receipt_is_bound_to_campaign_transaction_and_task(tmp_path):
+    from supervisor import evolution_lifecycle
+
+    campaign, tx = _active_transaction(tmp_path)
+    claim = {
+        "campaign_id": campaign["id"],
+        "transaction_id": tx["transaction_id"],
+        "task_id": tx["task_id"],
+    }
+    assert evolution_lifecycle.check_evolution_authority(**claim)["ok"] is True
+
+    receipt = evolution_lifecycle.record_evolution_commit(**claim, commit_sha="a" * 40)
+
+    assert receipt["ok"] is True
+    assert receipt["commit_sha"] == "a" * 40
+    stored = evolution_lifecycle._read_evolution_campaign()["active_transaction"]
+    assert stored["commit_receipt"] == receipt
+    assert evolution_lifecycle.check_evolution_authority(
+        **claim, commit_sha="b" * 40,
+    )["reason"] == "commit_receipt_mismatch"
+
+    campaign_state = evolution_lifecycle._read_evolution_campaign()
+    campaign_state["active_transaction"].pop("commit_receipt")
+    assert evolution_lifecycle._write_evolution_campaign(campaign_state) is True
+    assert evolution_lifecycle.check_evolution_authority(
+        **claim, commit_sha="a" * 40,
+    )["reason"] == "commit_receipt_missing"
+
+
+def test_revoked_authority_leaves_commit_unrecorded(tmp_path):
+    from supervisor import evolution_lifecycle, state
+
+    campaign, tx = _active_transaction(tmp_path)
+    live = state.load_state()
+    live["evolution_mode_enabled"] = False
+    live["evolution_owner_stopped"] = True
+    state.save_state(live)
+
+    receipt = evolution_lifecycle.record_evolution_commit(
+        campaign["id"], tx["transaction_id"], tx["task_id"], "c" * 40,
+    )
+
+    assert receipt == {"ok": False, "reason": "owner_stopped", "commit_sha": "c" * 40}
+    assert evolution_lifecycle._read_evolution_campaign()["active_transaction"]["commit_sha"] == ""
+
+
+def test_exact_receipt_remains_authority_after_post_task_autostop(tmp_path):
+    from supervisor import evolution_lifecycle, state
+
+    campaign, tx = _active_transaction(tmp_path)
+    sha = "9" * 40
+    claim = {
+        "campaign_id": campaign["id"],
+        "transaction_id": tx["transaction_id"],
+        "task_id": tx["task_id"],
+    }
+    assert evolution_lifecycle.record_evolution_commit(**claim, commit_sha=sha)["ok"] is True
+    state.update_state(lambda live: live.update(
+        evolution_mode_enabled=False,
+        post_task_autostop=False,
+    ))
+
+    assert evolution_lifecycle.check_evolution_authority(
+        **claim, commit_sha=sha,
+    )["ok"] is True
+    assert evolution_lifecycle.check_evolution_authority(**claim)["reason"] == "evolution_disabled"
+
+
+@pytest.mark.parametrize("held_lock", ["state", "campaign"])
+def test_rescue_link_uses_shared_campaign_cas_and_preserves_commit_receipt(
+    tmp_path, monkeypatch, held_lock,
+):
+    from ouroboros.platform_layer import (
+        acquire_exclusive_file_lock,
+        release_exclusive_file_lock,
+    )
+    from ouroboros.utils import atomic_write_json
+    from supervisor import evolution_lifecycle, git_ops, state
+
+    campaign, tx = _active_transaction(tmp_path)
+    sha = "3" * 40
+    assert evolution_lifecycle.record_evolution_commit(
+        campaign["id"], tx["transaction_id"], tx["task_id"], sha,
+    )["ok"] is True
+    monkeypatch.setattr(evolution_lifecycle, "EVOLUTION_CAMPAIGN_CAS_TIMEOUT_SEC", 1.0)
+    monkeypatch.setattr(git_ops, "DRIVE_ROOT", tmp_path)
+    campaign_path = tmp_path / "state" / "evolution_campaign.json"
+    if held_lock == "state":
+        lock_path = tmp_path / "locks" / "state.lock"
+        lock_fd = state.acquire_file_lock(lock_path, timeout_sec=1.0)
+        release = state.release_file_lock
+    else:
+        lock_path = campaign_path.with_name(campaign_path.name + ".lock")
+        lock_fd = acquire_exclusive_file_lock(lock_path, timeout_sec=1.0)
+        release = release_exclusive_file_lock
+    assert lock_fd is not None
+    done = threading.Event()
+
+    def _link() -> None:
+        git_ops._link_rescue_to_evolution_transaction(
+            {"rescue_ref": "rescue/test", "path": "/tmp/rescue-test"},
+            "test",
+        )
+        done.set()
+
+    thread = threading.Thread(target=_link, daemon=True)
+    thread.start()
+    try:
+        assert done.wait(0.1) is False
+        current = evolution_lifecycle._read_evolution_campaign()
+        current["active_transaction"]["interleaved"] = held_lock
+        atomic_write_json(campaign_path, current, trailing_newline=True)
+    finally:
+        release(lock_path, lock_fd)
+    assert done.wait(2.0) is True
+    thread.join(timeout=1.0)
+
+    stored = evolution_lifecycle._read_evolution_campaign()["active_transaction"]
+    assert stored["commit_sha"] == sha
+    assert stored["commit_receipt"]["commit_sha"] == sha
+    assert stored["rescue_ref"] == "rescue/test"
+    assert stored["interleaved"] == held_lock
+
+
+def test_commit_receipt_uses_campaign_sidecar_before_rescue(tmp_path, monkeypatch):
+    from ouroboros.platform_layer import (
+        acquire_exclusive_file_lock,
+        release_exclusive_file_lock,
+    )
+    from supervisor import evolution_lifecycle
+
+    campaign, tx = _active_transaction(tmp_path)
+    monkeypatch.setattr(evolution_lifecycle, "EVOLUTION_CAMPAIGN_CAS_TIMEOUT_SEC", 1.0)
+    campaign_path = tmp_path / "state" / "evolution_campaign.json"
+    lock_path = campaign_path.with_name(campaign_path.name + ".lock")
+    lock_fd = acquire_exclusive_file_lock(lock_path, timeout_sec=1.0)
+    assert lock_fd is not None
+    done = threading.Event()
+    result = {}
+
+    def _record() -> None:
+        result.update(evolution_lifecycle.record_evolution_commit(
+            campaign["id"], tx["transaction_id"], tx["task_id"], "4" * 40,
+        ))
+        done.set()
+
+    thread = threading.Thread(target=_record, daemon=True)
+    thread.start()
+    try:
+        assert done.wait(0.1) is False
+    finally:
+        release_exclusive_file_lock(lock_path, lock_fd)
+    assert done.wait(2.0) is True
+    thread.join(timeout=1.0)
+    assert result["ok"] is True
+    assert evolution_lifecycle._read_evolution_campaign()["active_transaction"][
+        "commit_receipt"
+    ]["commit_sha"] == "4" * 40
+
+
+def test_campaign_sidecar_contention_releases_state_lock_quickly(tmp_path):
+    from ouroboros.platform_layer import (
+        acquire_exclusive_file_lock,
+        release_exclusive_file_lock,
+    )
+    from supervisor import evolution_lifecycle, state
+
+    campaign, tx = _active_transaction(tmp_path)
+    campaign_path = tmp_path / "state" / "evolution_campaign.json"
+    sidecar = campaign_path.with_name(campaign_path.name + ".lock")
+    sidecar_fd = acquire_exclusive_file_lock(sidecar, timeout_sec=1.0)
+    assert sidecar_fd is not None
+    try:
+        result = evolution_lifecycle.record_evolution_commit(
+            campaign["id"], tx["transaction_id"], tx["task_id"], "6" * 40,
+        )
+        assert result["ok"] is False
+        state_fd = state.acquire_file_lock(state.STATE_LOCK_PATH, timeout_sec=0.2)
+        assert state_fd is not None
+        state.release_file_lock(state.STATE_LOCK_PATH, state_fd)
+    finally:
+        release_exclusive_file_lock(sidecar, sidecar_fd)
+
+
+def test_sent_owner_report_clear_cannot_erase_concurrent_commit_receipt(tmp_path, monkeypatch):
+    from supervisor import evolution_lifecycle, queue
+
+    campaign, tx = _active_transaction(tmp_path)
+    report = {"cycle_outcome": "absorbed", "task_id": "previous"}
+    current = evolution_lifecycle._read_evolution_campaign()
+    current["pending_owner_report"] = report
+    assert evolution_lifecycle._write_evolution_campaign(current) is True
+
+    def _send_then_record(*args, **kwargs):
+        receipt = evolution_lifecycle.record_evolution_commit(
+            campaign["id"], tx["transaction_id"], tx["task_id"], "5" * 40,
+        )
+        assert receipt["ok"] is True
+
+    monkeypatch.setattr(queue, "notify_owner_cycle_outcome", _send_then_record)
+
+    queue._deliver_pending_owner_report()
+
+    stored = evolution_lifecycle._read_evolution_campaign()
+    assert "pending_owner_report" not in stored
+    assert stored["active_transaction"]["commit_receipt"]["commit_sha"] == "5" * 40
+
+
+def test_terminal_campaign_cannot_be_resurrected_by_a_stale_writer(tmp_path):
+    from supervisor import evolution_lifecycle
+
+    campaign, _ = _active_transaction(tmp_path)
+    stale = dict(campaign)
+    evolution_lifecycle.complete_evolution_campaign("owner stop", cleanup_worktree=False)
+    stale["status"] = "active"
+
+    assert evolution_lifecycle._write_evolution_campaign(stale) is False
+    assert evolution_lifecycle._read_evolution_campaign()["status"] == "stopped"
+
+
+def test_stale_campaign_cannot_overwrite_a_new_campaign(tmp_path):
+    from supervisor import evolution_lifecycle, queue, state
+
+    state.init(tmp_path)
+    queue.init(tmp_path, 600, 1800)
+    first = evolution_lifecycle.start_evolution_campaign("First", source="test")
+    stale = dict(first)
+    evolution_lifecycle.complete_evolution_campaign("done", cleanup_worktree=False)
+    second = evolution_lifecycle.start_evolution_campaign("Second", source="test")
+
+    stale["status"] = "active"
+    assert evolution_lifecycle._write_evolution_campaign(stale) is False
+    assert evolution_lifecycle._read_evolution_campaign()["id"] == second["id"]
+
+
+def test_panic_campaign_close_uses_nonblocking_state_lock(tmp_path, monkeypatch):
+    from supervisor import evolution_lifecycle, queue, state
+
+    state.init(tmp_path)
+    queue.init(tmp_path, 600, 1800)
+    evolution_lifecycle.start_evolution_campaign("Improve", source="test")
+    timeouts = []
+    monkeypatch.setattr(
+        state,
+        "acquire_file_lock",
+        lambda path, timeout_sec=4.0, **kw: timeouts.append(timeout_sec) or None,
+    )
+
+    evolution_lifecycle.complete_evolution_campaign(
+        "panic stop", status="stopped", cleanup_worktree=False,
+    )
+
+    assert timeouts == [0.001]
+
+
+def test_evolution_commit_refuses_review_when_claim_is_gone(tmp_path, monkeypatch):
+    from ouroboros.tools import git as git_tools
+
+    reviewed = []
+    monkeypatch.setattr(git_tools, "_task_attributed_commit_paths", lambda *a, **k: (None, None, "", None))
+    monkeypatch.setattr(git_tools, "_check_overlapping_review_attempt", lambda *a, **k: "")
+    monkeypatch.setattr(git_tools, "_record_commit_attempt", lambda *a, **k: None)
+    monkeypatch.setattr(git_tools, "_acquire_git_lock", lambda *a, **k: pathlib.Path("lock"))
+    monkeypatch.setattr(git_tools, "_release_git_lock", lambda *a, **k: None)
+    monkeypatch.setattr(git_tools, "_prepare_review_commit_worktree", lambda *a, **k: (False, ""))
+    monkeypatch.setattr(
+        git_tools, "_evolution_commit_authority",
+        lambda *a, **k: ({}, {"ok": False, "reason": "owner_stopped"}),
+    )
+    monkeypatch.setattr(
+        git_tools, "_run_reviewed_stage_cycle",
+        lambda *a, **k: reviewed.append(True) or {"status": "passed"},
+    )
+    ctx = SimpleNamespace(
+        repo_dir=tmp_path,
+        drive_root=tmp_path,
+        branch_dev="ouroboros",
+        current_task_type="evolution",
+        task_id="evo",
+        task_metadata={},
+    )
+
+    result = git_tools._repo_commit_push(ctx, "test commit")
+
+    assert "EVOLUTION_AUTHORITY_REVOKED" in result
+    assert reviewed == []
+
+
+def test_postcommit_cas_failure_returns_local_orphan_after_binding(tmp_path, monkeypatch):
+    from ouroboros.tools import git as git_tools
+    from supervisor import evolution_lifecycle
+
+    claim = {"campaign_id": "camp", "transaction_id": "tx", "task_id": "evo"}
+    tagged, contained = [], []
+    monkeypatch.setattr(git_tools, "_task_attributed_commit_paths", lambda *a, **k: (None, None, "", None))
+    monkeypatch.setattr(git_tools, "_check_overlapping_review_attempt", lambda *a, **k: "")
+    monkeypatch.setattr(git_tools, "_record_commit_attempt", lambda *a, **k: None)
+    monkeypatch.setattr(git_tools, "_acquire_git_lock", lambda *a, **k: pathlib.Path("lock"))
+    monkeypatch.setattr(git_tools, "_release_git_lock", lambda *a, **k: None)
+    monkeypatch.setattr(git_tools, "_prepare_review_commit_worktree", lambda *a, **k: (False, ""))
+    monkeypatch.setattr(git_tools, "_evolution_commit_authority", lambda *a, **k: (claim, {"ok": True}))
+    monkeypatch.setattr(git_tools, "_verify_reviewed_commit_binding", lambda *a, **k: (True, ""))
+    monkeypatch.setattr(
+        git_tools, "_run_reviewed_stage_cycle",
+        lambda *a, **k: {
+            "status": "passed",
+            "pre_fingerprint": {"fingerprint": "pre"},
+            "post_fingerprint": {"fingerprint": "post", "binding": {}},
+        },
+    )
+    monkeypatch.setattr(
+        git_tools, "run_cmd",
+        lambda cmd, cwd=None: "d" * 40 if cmd[:3] == ["git", "rev-parse", "HEAD"] else "",
+    )
+    monkeypatch.setattr(
+        evolution_lifecycle,
+        "record_evolution_commit",
+        lambda **kwargs: {"ok": False, "reason": "owner_stopped", "commit_sha": kwargs["commit_sha"]},
+    )
+    monkeypatch.setattr(
+        git_tools,
+        "_auto_tag_on_version_bump",
+        lambda *a, **k: tagged.append(True) or "",
+    )
+    monkeypatch.setattr(
+        git_tools,
+        "_preserve_evolution_orphan",
+        lambda *a, **k: contained.append((a, k)) or "contained",
+    )
+    ctx = SimpleNamespace(
+        repo_dir=tmp_path,
+        drive_root=tmp_path,
+        branch_dev="ouroboros",
+        current_task_type="evolution",
+        task_id="evo",
+        task_metadata={"evolution_transaction": claim},
+    )
+
+    result = git_tools._repo_commit_push(ctx, "test commit")
+
+    assert "EVOLUTION_COMMIT_ORPHANED" in result
+    assert "d" * 40 in result
+    assert tagged == [True]
+    assert len(contained) == 1
+
+
+def test_final_evolution_authority_check_and_push_stay_under_git_lock(tmp_path, monkeypatch):
+    from ouroboros.tools import git as git_tools
+
+    claim = {"campaign_id": "camp", "transaction_id": "tx", "task_id": "evo"}
+    order = []
+    monkeypatch.setattr(git_tools, "_task_attributed_commit_paths", lambda *a, **k: (None, None, "", None))
+    monkeypatch.setattr(git_tools, "_check_overlapping_review_attempt", lambda *a, **k: "")
+    monkeypatch.setattr(git_tools, "_record_commit_attempt", lambda *a, **k: None)
+    monkeypatch.setattr(git_tools, "_acquire_git_lock", lambda *a, **k: pathlib.Path("lock"))
+    monkeypatch.setattr(git_tools, "_release_git_lock", lambda *a, **k: order.append("release"))
+    monkeypatch.setattr(git_tools, "_prepare_review_commit_worktree", lambda *a, **k: (False, ""))
+    monkeypatch.setattr(git_tools, "_evolution_commit_authority", lambda *a, **k: (claim, {"ok": True}))
+    monkeypatch.setattr(git_tools, "_verify_reviewed_commit_binding", lambda *a, **k: (True, ""))
+    monkeypatch.setattr(
+        git_tools,
+        "_run_reviewed_stage_cycle",
+        lambda *a, **k: {
+            "status": "passed",
+            "pre_fingerprint": {"fingerprint": "pre"},
+            "post_fingerprint": {"fingerprint": "post", "binding": {}},
+        },
+    )
+    monkeypatch.setattr(
+        git_tools,
+        "run_cmd",
+        lambda cmd, cwd=None: "d" * 40 if cmd[:3] == ["git", "rev-parse", "HEAD"] else "",
+    )
+    monkeypatch.setattr(git_tools, "_auto_tag_on_version_bump", lambda *a, **k: "")
+    monkeypatch.setattr(git_tools, "_record_evolution_commit_receipt", lambda *a, **k: "")
+    monkeypatch.setattr(
+        git_tools,
+        "_evolution_publication_stopped_result",
+        lambda *a, **k: order.append("authority") or "",
+    )
+    monkeypatch.setattr(git_tools, "_auto_push", lambda *a, **k: order.append("push") or "")
+    monkeypatch.setattr(git_tools, "_publish_reviewed_commit", lambda *a, **k: "ok")
+    ctx = SimpleNamespace(
+        repo_dir=tmp_path,
+        drive_root=tmp_path,
+        branch_dev="ouroboros",
+        current_task_type="evolution",
+        task_id="evo",
+        task_metadata={"evolution_transaction": claim},
+    )
+
+    assert git_tools._repo_commit_push(ctx, "test commit", skip_tests=True) == "ok"
+    assert order == ["authority", "push", "release"]
+
+
+def test_final_tag_binding_failure_cannot_record_restart_receipt(tmp_path, monkeypatch):
+    from ouroboros.tools import git as git_tools
+
+    claim = {"campaign_id": "camp", "transaction_id": "tx", "task_id": "evo"}
+    recorded = []
+    binding_results = iter([(True, ""), (False, "tag target mismatch")])
+    monkeypatch.setattr(git_tools, "_task_attributed_commit_paths", lambda *a, **k: (None, None, "", None))
+    monkeypatch.setattr(git_tools, "_check_overlapping_review_attempt", lambda *a, **k: "")
+    monkeypatch.setattr(git_tools, "_record_commit_attempt", lambda *a, **k: None)
+    monkeypatch.setattr(git_tools, "_acquire_git_lock", lambda *a, **k: pathlib.Path("lock"))
+    monkeypatch.setattr(git_tools, "_release_git_lock", lambda *a, **k: None)
+    monkeypatch.setattr(git_tools, "_prepare_review_commit_worktree", lambda *a, **k: (False, ""))
+    monkeypatch.setattr(git_tools, "_evolution_commit_authority", lambda *a, **k: (claim, {"ok": True}))
+    monkeypatch.setattr(
+        git_tools, "_verify_reviewed_commit_binding", lambda *a, **k: next(binding_results),
+    )
+    monkeypatch.setattr(
+        git_tools, "_run_reviewed_stage_cycle",
+        lambda *a, **k: {
+            "status": "passed",
+            "pre_fingerprint": {"fingerprint": "pre"},
+            "post_fingerprint": {"fingerprint": "post", "binding": {}},
+        },
+    )
+    monkeypatch.setattr(
+        git_tools, "run_cmd",
+        lambda cmd, cwd=None: "1" * 40 if cmd[:3] == ["git", "rev-parse", "HEAD"] else "",
+    )
+    monkeypatch.setattr(git_tools, "_auto_tag_on_version_bump", lambda *a, **k: "")
+    monkeypatch.setattr(
+        git_tools,
+        "_record_evolution_commit_receipt",
+        lambda *a, **k: recorded.append(True) or "",
+    )
+    ctx = SimpleNamespace(
+        repo_dir=tmp_path,
+        drive_root=tmp_path,
+        branch_dev="ouroboros",
+        current_task_type="evolution",
+        task_id="evo",
+        task_metadata={"evolution_transaction": claim},
+    )
+
+    result = git_tools._repo_commit_push(ctx, "test commit")
+
+    assert "REVIEW_BINDING_FAILED" in result
+    assert recorded == []
+
+
+def test_evolution_publication_authority_requires_exact_head(tmp_path, monkeypatch):
+    from ouroboros.tools import git as git_tools
+
+    monkeypatch.setattr(
+        "supervisor.evolution_lifecycle.check_evolution_authority",
+        lambda **kwargs: {"ok": True, "reason": ""},
+    )
+    monkeypatch.setattr(
+        git_tools,
+        "run_cmd",
+        lambda cmd, cwd=None: "b" * 40 if cmd[:3] == ["git", "rev-parse", "HEAD"] else "",
+    )
+    ctx = SimpleNamespace(
+        repo_dir=tmp_path,
+        task_id="evo",
+        task_metadata={"evolution_transaction": {
+            "campaign_id": "camp",
+            "transaction_id": "tx",
+            "task_id": "evo",
+        }},
+    )
+
+    _, authority = git_tools._evolution_commit_authority(ctx, commit_sha="a" * 40)
+
+    assert authority["ok"] is False
+    assert authority["reason"] == "head_mismatch"
+
+
+def test_restart_requires_the_exact_active_commit_receipt(tmp_path, monkeypatch):
+    from ouroboros.tools import control
+    from supervisor import evolution_lifecycle, state
+
+    campaign, tx = _active_transaction(tmp_path)
+    sha = "e" * 40
+    claim = {
+        "campaign_id": campaign["id"],
+        "transaction_id": tx["transaction_id"],
+        "task_id": tx["task_id"],
+    }
+    assert evolution_lifecycle.record_evolution_commit(**claim, commit_sha=sha)["ok"] is True
+    monkeypatch.setattr(
+        control,
+        "run_cmd",
+        lambda cmd, cwd=None: "" if cmd[:2] == ["git", "status"] else sha,
+    )
+    ctx = SimpleNamespace(
+        current_task_type="evolution",
+        repo_dir=tmp_path,
+        task_id=tx["task_id"],
+        task_metadata={"evolution_transaction": tx},
+        last_reviewed_commit_sha=sha,
+    )
+    assert control._evolution_restart_block_reason(ctx) == ""
+
+    live = state.load_state()
+    live["evolution_owner_stopped"] = True
+    live["evolution_mode_enabled"] = False
+    state.save_state(live)
+    assert "owner_stopped" in control._evolution_restart_block_reason(ctx)
+
+
+def test_boot_restart_verifies_exact_v2_claim_only_after_new_generation(
+    tmp_path, monkeypatch,
+):
+    from ouroboros import agent_startup_checks, process_custody
+    from supervisor import evolution_lifecycle
+
+    generation = {"value": "server-a"}
+    monkeypatch.setattr(
+        process_custody, "current_custody_session_id", lambda: generation["value"],
+    )
+    campaign, tx = _active_transaction(tmp_path)
+    assert tx["schema_version"] == 2
+    sha = "8" * 40
+    claim = {
+        "campaign_id": campaign["id"],
+        "transaction_id": tx["transaction_id"],
+        "task_id": tx["task_id"],
+        "commit_sha": sha,
+    }
+    assert evolution_lifecycle.record_evolution_commit(**claim)["ok"] is True
+    marker = tmp_path / "state" / "pending_restart_verify.json"
+    marker.write_text(json.dumps({"expected_sha": sha, "evolution_claim": claim}))
+    env = SimpleNamespace(
+        drive_path=lambda name: tmp_path / name,
+        drive_root=tmp_path,
+        repo_dir=tmp_path,
+    )
+
+    agent_startup_checks.verify_restart(env, sha)
+
+    stored = evolution_lifecycle._read_evolution_campaign()
+    assert stored["active_transaction"]["transaction_id"] == tx["transaction_id"]
+    assert int(stored.get("absorbed_cycles_done") or 0) == 0
+    assert marker.is_file()
+
+    generation["value"] = "server-b"
+    agent_startup_checks.verify_restart(env, sha)
+
+    stored = evolution_lifecycle._read_evolution_campaign()
+    assert "active_transaction" not in stored
+    assert stored["transaction_history"][-1]["cycle_outcome"] == "absorbed"
+    assert stored["last_boot_reconcile_gen"] == "server-b"
+    assert not marker.exists()
+
+
+def test_boot_restart_rejects_mismatched_claim_without_loser_bypass(
+    tmp_path, monkeypatch,
+):
+    from ouroboros import agent_startup_checks, process_custody
+    from supervisor import evolution_lifecycle
+
+    campaign, tx = _active_transaction(tmp_path)
+    sha = "9" * 40
+    exact = {
+        "campaign_id": campaign["id"],
+        "transaction_id": tx["transaction_id"],
+        "task_id": tx["task_id"],
+        "commit_sha": sha,
+    }
+    assert evolution_lifecycle.record_evolution_commit(**exact)["ok"] is True
+    stale = {**exact, "transaction_id": "stale-transaction"}
+    marker = tmp_path / "state" / "pending_restart_verify.json"
+    marker.write_text(json.dumps({"expected_sha": sha, "evolution_claim": stale}))
+    monkeypatch.setattr(process_custody, "current_custody_session_id", lambda: "boot-gen")
+    env = SimpleNamespace(
+        drive_path=lambda name: tmp_path / name,
+        drive_root=tmp_path,
+        repo_dir=tmp_path,
+    )
+
+    agent_startup_checks.verify_restart(env, sha)
+    agent_startup_checks.verify_restart(env, sha)  # a rename loser must not reconcile it
+
+    stored = evolution_lifecycle._read_evolution_campaign()
+    assert stored["active_transaction"]["transaction_id"] == tx["transaction_id"]
+    assert stored["active_transaction"]["restart_authority_error"] == "restart_claim_mismatch"
+    assert int(stored.get("absorbed_cycles_done") or 0) == 0
+    event = json.loads((tmp_path / "logs" / "events.jsonl").read_text().splitlines()[-1])
+    assert event["type"] == "restart_verify"
+    assert event["error"] == "restart_claim_mismatch"
+
+
+def test_boot_markerless_v2_missing_receipt_stays_unresolved(tmp_path, monkeypatch):
+    from ouroboros import agent_startup_checks, process_custody
+    from supervisor import evolution_lifecycle
+
+    campaign, tx = _active_transaction(tmp_path)
+    stored = evolution_lifecycle._read_evolution_campaign()
+    stored["active_transaction"]["commit_sha"] = "a" * 40
+    assert evolution_lifecycle._write_evolution_campaign(stored) is True
+    monkeypatch.setattr(process_custody, "current_custody_session_id", lambda: "boot-gen")
+    monkeypatch.setattr(
+        agent_startup_checks.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    env = SimpleNamespace(
+        drive_path=lambda name: tmp_path / name,
+        drive_root=tmp_path,
+        repo_dir=tmp_path,
+    )
+
+    agent_startup_checks.verify_restart(env, "head")
+
+    current = evolution_lifecycle._read_evolution_campaign()
+    assert current["active_transaction"]["transaction_id"] == tx["transaction_id"]
+    assert current["active_transaction"]["restart_authority_error"] == "commit_receipt_missing"
+    assert int(current.get("absorbed_cycles_done") or 0) == 0
+    event = json.loads((tmp_path / "logs" / "events.jsonl").read_text().splitlines()[-1])
+    assert event["type"] == "evolution_tx_reconcile_blocked"
+    assert event["reason"] == "commit_receipt_missing"
+
+
+def test_boot_rename_loser_waits_for_claim_winner(tmp_path):
+    from ouroboros import agent_startup_checks
+    from supervisor import evolution_lifecycle
+
+    campaign, tx = _active_transaction(tmp_path)
+    sha = "b" * 40
+    claim = {
+        "campaign_id": campaign["id"],
+        "transaction_id": tx["transaction_id"],
+        "task_id": tx["task_id"],
+        "commit_sha": sha,
+    }
+    assert evolution_lifecycle.record_evolution_commit(**claim)["ok"] is True
+    claimed = tmp_path / "state" / f"pending_restart_verify.claimed.{os.getpid()}.json"
+    claimed.write_text(json.dumps({"expected_sha": sha, "evolution_claim": claim}))
+    env = SimpleNamespace(
+        drive_path=lambda name: tmp_path / name,
+        drive_root=tmp_path,
+        repo_dir=tmp_path,
+    )
+
+    agent_startup_checks.verify_restart(env, sha)
+
+    current = evolution_lifecycle._read_evolution_campaign()
+    assert current["active_transaction"]["transaction_id"] == tx["transaction_id"]
+    assert int(current.get("absorbed_cycles_done") or 0) == 0
+
+
+def test_boot_reclaims_dead_restart_claim(tmp_path, monkeypatch):
+    from ouroboros import agent_startup_checks, platform_layer, process_custody
+    from supervisor import evolution_lifecycle
+
+    generation = {"value": "server-a"}
+    monkeypatch.setattr(
+        process_custody, "current_custody_session_id", lambda: generation["value"],
+    )
+    campaign, tx = _active_transaction(tmp_path)
+    sha = "7" * 40
+    claim = {
+        "campaign_id": campaign["id"],
+        "transaction_id": tx["transaction_id"],
+        "task_id": tx["task_id"],
+        "commit_sha": sha,
+    }
+    assert evolution_lifecycle.record_evolution_commit(**claim)["ok"] is True
+    claimed = tmp_path / "state" / "pending_restart_verify.claimed.999999999.json"
+    claimed.write_text(json.dumps({"expected_sha": sha, "evolution_claim": claim}))
+    monkeypatch.setattr(platform_layer, "pid_is_alive", lambda pid: False)
+    generation["value"] = "server-b"
+    env = SimpleNamespace(
+        drive_path=lambda name: tmp_path / name,
+        drive_root=tmp_path,
+        repo_dir=tmp_path,
+    )
+
+    agent_startup_checks.verify_restart(env, sha)
+
+    current = evolution_lifecycle._read_evolution_campaign()
+    assert "active_transaction" not in current
+    assert current["transaction_history"][-1]["cycle_outcome"] == "absorbed"
+    assert list((tmp_path / "state").glob("pending_restart_verify.claimed.*.json")) == []
+
+
+def test_new_campaign_is_stamped_for_same_generation_worker_respawns(tmp_path, monkeypatch):
+    from ouroboros import agent_startup_checks, process_custody
+    from supervisor import evolution_lifecycle, queue, state
+
+    monkeypatch.setattr(process_custody, "current_custody_session_id", lambda: "same-server")
+    state.init(tmp_path)
+    queue.init(tmp_path, 600, 1800)
+    queue.init_queue_refs([], {}, {"value": 0})
+    campaign = evolution_lifecycle.start_evolution_campaign("Improve", source="test")
+    assert campaign["last_boot_reconcile_gen"] == "same-server"
+    state.update_state(lambda live: live.update(evolution_mode_enabled=True))
+    tx = evolution_lifecycle.begin_evolution_transaction("respawn", cycle=1, campaign=campaign)
+    claim = {
+        "campaign_id": campaign["id"],
+        "transaction_id": tx["transaction_id"],
+        "task_id": tx["task_id"],
+        "commit_sha": "6" * 40,
+    }
+    assert evolution_lifecycle.record_evolution_commit(**claim)["ok"] is True
+    env = SimpleNamespace(
+        drive_path=lambda name: tmp_path / name,
+        drive_root=tmp_path,
+        repo_dir=tmp_path,
+    )
+
+    agent_startup_checks.verify_restart(env, claim["commit_sha"])
+
+    current = evolution_lifecycle._read_evolution_campaign()
+    assert current["active_transaction"]["transaction_id"] == tx["transaction_id"]
+    assert int(current.get("absorbed_cycles_done") or 0) == 0
+
+
+def test_boot_reconcile_cannot_resurrect_owner_stopped_campaign(tmp_path, monkeypatch):
+    from ouroboros import agent_startup_checks, process_custody
+    from supervisor import evolution_lifecycle
+
+    generation = {"value": "before-restart"}
+    monkeypatch.setattr(
+        process_custody, "current_custody_session_id", lambda: generation["value"],
+    )
+    campaign, tx = _active_transaction(tmp_path)
+    sha = "4" * 40
+    claim = {
+        "campaign_id": campaign["id"],
+        "transaction_id": tx["transaction_id"],
+        "task_id": tx["task_id"],
+        "commit_sha": sha,
+    }
+    assert evolution_lifecycle.record_evolution_commit(**claim)["ok"] is True
+    generation["value"] = "after-restart"
+    reached = threading.Event()
+    release = threading.Event()
+
+    def delayed_merge_base(*args, **kwargs):
+        reached.set()
+        assert release.wait(timeout=2)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(agent_startup_checks.subprocess, "run", delayed_merge_base)
+    env = SimpleNamespace(
+        drive_path=lambda name: tmp_path / name,
+        drive_root=tmp_path,
+        repo_dir=tmp_path,
+    )
+    worker = threading.Thread(target=agent_startup_checks.verify_restart, args=(env, "5" * 40))
+    worker.start()
+    assert reached.wait(timeout=2)
+    evolution_lifecycle.complete_evolution_campaign("owner stop", cleanup_worktree=False)
+    release.set()
+    worker.join(timeout=2)
+
+    current = evolution_lifecycle._read_evolution_campaign()
+    assert current["status"] == "stopped"
+    assert current["completion_reason"] == "owner stop"
+    assert "active_transaction" not in current
+
+
+def test_owner_stop_preserves_prior_boot_reconciliation_evidence(tmp_path, monkeypatch):
+    from ouroboros import agent_startup_checks, process_custody
+    from supervisor import evolution_lifecycle
+
+    generation = {"value": "before-restart"}
+    monkeypatch.setattr(
+        process_custody, "current_custody_session_id", lambda: generation["value"],
+    )
+    campaign, tx = _active_transaction(tmp_path)
+    sha = "3" * 40
+    claim = {
+        "campaign_id": campaign["id"],
+        "transaction_id": tx["transaction_id"],
+        "task_id": tx["task_id"],
+        "commit_sha": sha,
+    }
+    assert evolution_lifecycle.record_evolution_commit(**claim)["ok"] is True
+    generation["value"] = "after-restart"
+    env = SimpleNamespace(
+        drive_path=lambda name: tmp_path / name,
+        drive_root=tmp_path,
+        repo_dir=tmp_path,
+    )
+    agent_startup_checks.verify_restart(env, sha)
+    evolution_lifecycle.complete_evolution_campaign("owner stop", cleanup_worktree=False)
+
+    current = evolution_lifecycle._read_evolution_campaign()
+    assert current["status"] == "stopped"
+    assert current["absorbed_cycles_done"] == 1
+    assert current["last_boot_reconcile_gen"] == "after-restart"
+    assert current["transaction_history"][-1]["cycle_outcome"] == "absorbed"
+
+
+def test_boot_restart_writers_obey_live_root_fuse(tmp_path, monkeypatch):
+    from ouroboros import agent_startup_checks
+    from supervisor import evolution_lifecycle
+
+    campaign, tx = _active_transaction(tmp_path)
+    sha = "2" * 40
+    claim = {
+        "campaign_id": campaign["id"],
+        "transaction_id": tx["transaction_id"],
+        "task_id": tx["task_id"],
+        "commit_sha": sha,
+    }
+    assert evolution_lifecycle.record_evolution_commit(**claim)["ok"] is True
+    campaign_path = tmp_path / "state" / "evolution_campaign.json"
+    before = campaign_path.read_bytes()
+    monkeypatch.setenv("OUROBOROS_PYTEST_ACTIVE", "1")
+    monkeypatch.setenv("OUROBOROS_TEST_LIVE_DATA_ROOT", str(tmp_path))
+    env = SimpleNamespace(
+        drive_path=lambda name: tmp_path / name,
+        drive_root=tmp_path,
+        repo_dir=tmp_path,
+    )
+
+    with pytest.raises(RuntimeError, match="PYTEST_LIVE_DATA_WRITE_BLOCKED"):
+        agent_startup_checks.verify_restart(env, sha)
+
+    assert campaign_path.read_bytes() == before
+    assert list((tmp_path / "state").glob("pending_restart_verify.claimed.*.json")) == []
+
+
+def test_boot_restart_write_failure_restores_claim_for_retry(tmp_path, monkeypatch):
+    from ouroboros import agent_startup_checks, process_custody
+    from supervisor import evolution_lifecycle
+
+    generation = {"value": "server-a"}
+    monkeypatch.setattr(
+        process_custody, "current_custody_session_id", lambda: generation["value"],
+    )
+    campaign, tx = _active_transaction(tmp_path)
+    sha = "c" * 40
+    claim = {
+        "campaign_id": campaign["id"],
+        "transaction_id": tx["transaction_id"],
+        "task_id": tx["task_id"],
+        "commit_sha": sha,
+    }
+    assert evolution_lifecycle.record_evolution_commit(**claim)["ok"] is True
+    pending = tmp_path / "state" / "pending_restart_verify.json"
+    pending.write_text(json.dumps({"expected_sha": sha, "evolution_claim": claim}))
+    real_write = agent_startup_checks.atomic_write_json
+    calls = {"count": 0}
+
+    def fail_once(*args, **kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise OSError("temporary write failure")
+        return real_write(*args, **kwargs)
+
+    monkeypatch.setattr(agent_startup_checks, "atomic_write_json", fail_once)
+    generation["value"] = "server-b"
+    env = SimpleNamespace(
+        drive_path=lambda name: tmp_path / name,
+        drive_root=tmp_path,
+        repo_dir=tmp_path,
+    )
+
+    agent_startup_checks.verify_restart(env, sha)
+    assert pending.is_file()
+    assert list((tmp_path / "state").glob("pending_restart_verify.claimed.*.json")) == []
+
+    agent_startup_checks.verify_restart(env, sha)
+    current = evolution_lifecycle._read_evolution_campaign()
+    assert "active_transaction" not in current
+    assert current["transaction_history"][-1]["cycle_outcome"] == "absorbed"
+
+
+def test_boot_exact_claim_never_passes_without_active_transaction(tmp_path):
+    from ouroboros import agent_startup_checks
+
+    (tmp_path / "state").mkdir(parents=True)
+    (tmp_path / "logs").mkdir(parents=True)
+    sha = "d" * 40
+    claim = {
+        "campaign_id": "campaign",
+        "transaction_id": "transaction",
+        "task_id": "task",
+        "commit_sha": sha,
+    }
+    marker = tmp_path / "state" / "pending_restart_verify.json"
+    marker.write_text(json.dumps({"expected_sha": sha, "evolution_claim": claim}))
+    campaign_path = tmp_path / "state" / "evolution_campaign.json"
+    campaign_path.write_text("{bad")
+    env = SimpleNamespace(
+        drive_path=lambda name: tmp_path / name,
+        drive_root=tmp_path,
+        repo_dir=tmp_path,
+    )
+
+    agent_startup_checks.verify_restart(env, sha)
+
+    event = json.loads((tmp_path / "logs" / "events.jsonl").read_text().splitlines()[-1])
+    assert event["type"] == "restart_verify"
+    assert event["ok"] is False
+    assert event["error"] == "transaction_missing"
+    assert marker.exists() is False
+    assert campaign_path.read_text() == "{bad"
+
+
+def test_evolution_restart_write_failure_does_not_become_generic_restart(tmp_path, monkeypatch):
+    from ouroboros.tools import control
+
+    monkeypatch.setattr(control, "_evolution_restart_block_reason", lambda ctx: "")
+    monkeypatch.setattr(
+        control, "run_cmd",
+        lambda cmd, cwd=None: "f" * 40 if cmd[-1] == "HEAD" else "ouroboros",
+    )
+    monkeypatch.setattr(
+        control, "atomic_write_json",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")),
+    )
+    ctx = SimpleNamespace(
+        current_task_type="evolution",
+        repo_dir=tmp_path,
+        drive_path=lambda name: tmp_path / name,
+        task_id="evo",
+        task_metadata={"evolution_transaction": {}},
+        pending_restart_reason=None,
+        last_push_succeeded=True,
+        last_reviewed_commit_sha="f" * 40,
+    )
+
+    result = control._request_restart(ctx, "apply reviewed evolution")
+
+    assert "RESTART_BLOCKED" in result
+    assert ctx.pending_restart_reason is None
+
+
+def test_supervisor_rechecks_evolution_claim_immediately_before_restart(tmp_path):
+    import server
+    from supervisor import evolution_lifecycle, state
+
+    campaign, tx = _active_transaction(tmp_path)
+    sha = "1" * 40
+    claim = {
+        "campaign_id": campaign["id"],
+        "transaction_id": tx["transaction_id"],
+        "task_id": tx["task_id"],
+        "commit_sha": sha,
+    }
+    assert evolution_lifecycle.record_evolution_commit(
+        campaign["id"], tx["transaction_id"], tx["task_id"], sha,
+    )["ok"] is True
+    marker = tmp_path / "state" / "pending_restart_verify.json"
+    marker.write_text(json.dumps({
+        "reason": "evolution restart",
+        "expected_sha": sha,
+        "evolution_claim": claim,
+    }))
+    live = state.load_state()
+    live.update({"evolution_mode_enabled": False, "evolution_owner_stopped": True})
+    state.save_state(live)
+    restarted = []
+    messages = []
+    ctx = SimpleNamespace(
+        DRIVE_ROOT=tmp_path,
+        load_state=state.load_state,
+        safe_restart=lambda **k: restarted.append(k) or (True, "ok"),
+        send_with_budget=lambda *a: messages.append(a),
+    )
+
+    server._perform_supervisor_restart(
+        ctx, restart_reason="evolution restart", evolution_restart=True,
+    )
+
+    assert restarted == []
+    assert "owner_stopped" in messages[0][1]
+
+
+def test_supervisor_blocks_evolution_restart_if_marker_disappears_during_drain(tmp_path):
+    import server
+
+    restarted = []
+    messages = []
+    ctx = SimpleNamespace(
+        DRIVE_ROOT=tmp_path,
+        load_state=lambda: {"owner_chat_id": 1},
+        safe_restart=lambda **k: restarted.append(k) or (True, "ok"),
+        send_with_budget=lambda *a: messages.append(a),
+    )
+
+    server._perform_supervisor_restart(
+        ctx,
+        restart_reason="agent_requested_restart",
+        evolution_restart=True,
+    )
+
+    assert restarted == []
+    assert "receipt is missing" in messages[0][1]
+
+
+def test_generic_restart_ignores_stale_evolution_marker(tmp_path, monkeypatch):
+    import server
+
+    marker = tmp_path / "state" / "pending_restart_verify.json"
+    marker.parent.mkdir(parents=True)
+    marker.write_text(json.dumps({
+        "reason": "agent_requested_restart",
+        "evolution_claim": {"campaign_id": "stale"},
+    }))
+    restarted = []
+    exited = []
+    monkeypatch.setattr(server, "_request_restart_exit", lambda: exited.append(True))
+    ctx = SimpleNamespace(
+        DRIVE_ROOT=tmp_path,
+        load_state=lambda: {},
+        safe_restart=lambda **k: restarted.append(k) or (True, "ok"),
+        kill_workers=lambda **k: None,
+        save_state=lambda state: None,
+        persist_queue_snapshot=lambda **k: None,
+    )
+
+    server._perform_supervisor_restart(
+        ctx, restart_reason="agent_requested_restart", evolution_restart=False,
+    )
+
+    assert restarted
+    assert exited == [True]
+
+
+def test_supervisor_blocks_restart_when_head_moved_after_receipt(tmp_path):
+    import server
+    from supervisor import evolution_lifecycle
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    (repo / "file.txt").write_text("current\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "current"], cwd=repo, check=True, capture_output=True)
+    campaign, tx = _active_transaction(tmp_path)
+    reviewed_sha = "2" * 40
+    claim = {
+        "campaign_id": campaign["id"],
+        "transaction_id": tx["transaction_id"],
+        "task_id": tx["task_id"],
+        "commit_sha": reviewed_sha,
+    }
+    assert evolution_lifecycle.record_evolution_commit(
+        campaign["id"], tx["transaction_id"], tx["task_id"], reviewed_sha,
+    )["ok"] is True
+    (tmp_path / "state" / "pending_restart_verify.json").write_text(json.dumps({
+        "reason": "evolution restart",
+        "expected_sha": reviewed_sha,
+        "evolution_claim": claim,
+    }))
+    restarted = []
+    messages = []
+    ctx = SimpleNamespace(
+        DRIVE_ROOT=tmp_path,
+        REPO_DIR=repo,
+        load_state=lambda: {"owner_chat_id": 1},
+        safe_restart=lambda **k: restarted.append(k) or (True, "ok"),
+        send_with_budget=lambda *a: messages.append(a),
+    )
+
+    server._perform_supervisor_restart(
+        ctx, restart_reason="evolution restart", evolution_restart=True,
+    )
+
+    assert restarted == []
+    assert "no longer matches" in messages[0][1]
+
+
+def test_benchmark_seed_creates_campaign_before_enabling(tmp_path):
+    from devtools.benchmarks.common.server_runner import seed_owner_state
+
+    seed_owner_state(tmp_path, evolution_enabled=True)
+
+    state = json.loads((tmp_path / "state" / "state.json").read_text())
+    campaign = json.loads((tmp_path / "state" / "evolution_campaign.json").read_text())
+    assert campaign["status"] == "active"
+    assert campaign["id"]
+    assert state["evolution_mode_enabled"] is True

--- a/tests/test_evolution_state_integrity_v3.py
+++ b/tests/test_evolution_state_integrity_v3.py
@@ -136,6 +136,105 @@ print(json.dumps({'root': str(state.DRIVE_ROOT), 'state': state.load_state()}))
     assert payload["state"]["probe"] == "isolated"
 
 
+@pytest.mark.serial
+def test_pytest_scrubbed_child_keeps_disposable_state_root(tmp_path):
+    repo = pathlib.Path(__file__).resolve().parents[1]
+    fake_home = tmp_path / "home"
+    fake_live = fake_home / "Ouroboros" / "data" / "state"
+    fake_live.mkdir(parents=True)
+    sentinels = {
+        fake_live / "state.json": b'{"sentinel":"state"}\n',
+        fake_live / "evolution_campaign.json": b'{"sentinel":"campaign"}\n',
+    }
+    for path, content in sentinels.items():
+        path.write_bytes(content)
+    disposable_state = pathlib.Path(os.environ["OUROBOROS_DATA_DIR"]) / "state"
+    disposable_paths = tuple(
+        disposable_state / name
+        for name in ("state.json", "state.last_good.json", "evolution_campaign.json")
+    )
+    disposable_before = {
+        path: path.read_bytes() if path.exists() else None for path in disposable_paths
+    }
+    code = """
+import json
+from supervisor import evolution_lifecycle, state
+state.update_state(lambda live: live.update({'scrubbed_child_probe': True}))
+campaign = evolution_lifecycle.start_evolution_campaign('Probe', source='test')
+print(json.dumps({
+    'campaign_id': campaign.get('id', ''),
+    'drive_root': str(state.DRIVE_ROOT),
+    'pytest_loaded': 'pytest' in __import__('sys').modules,
+}))
+"""
+
+    child_env = {"HOME": str(fake_home), "USERPROFILE": str(fake_home)}
+    if os.name == "nt" and os.environ.get("SystemRoot"):
+        child_env["SystemRoot"] = os.environ["SystemRoot"]
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=repo,
+            env=child_env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        payload = json.loads(proc.stdout.strip().splitlines()[-1])
+        assert payload["pytest_loaded"] is False
+        assert pathlib.Path(payload["drive_root"]).resolve(strict=False) == pathlib.Path(
+            os.environ["OUROBOROS_DATA_DIR"]
+        ).resolve(strict=False)
+        assert payload["campaign_id"]
+        for path, content in sentinels.items():
+            assert path.read_bytes() == content
+    finally:
+        for path, content in disposable_before.items():
+            if content is None:
+                path.unlink(missing_ok=True)
+            else:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(content)
+
+
+@pytest.mark.serial
+def test_nested_pytest_keeps_the_original_live_root_marker(tmp_path):
+    repo = pathlib.Path(__file__).resolve().parents[1]
+    inherited_disposable = tmp_path / "parent-pytest-data"
+    env = {
+        "OUROBOROS_DATA_DIR": str(inherited_disposable),
+        "OUROBOROS_SETTINGS_PATH": str(inherited_disposable / "settings.json"),
+    }
+    code = """
+import importlib.util, json, os, pathlib
+spec = importlib.util.spec_from_file_location('nested_conftest', pathlib.Path('tests/conftest.py'))
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+print(json.dumps({
+    'live_root': os.environ['OUROBOROS_TEST_LIVE_DATA_ROOT'],
+    'data_root': os.environ['OUROBOROS_DATA_DIR'],
+}))
+"""
+
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert pathlib.Path(payload["live_root"]).resolve(strict=False) == pathlib.Path(
+        os.environ["OUROBOROS_TEST_LIVE_DATA_ROOT"]
+    ).resolve(strict=False)
+    assert pathlib.Path(payload["data_root"]).resolve(strict=False) != inherited_disposable.resolve(
+        strict=False
+    )
+
+
 def test_scheduler_disables_a_bare_flag_without_campaign(tmp_path, monkeypatch):
     from supervisor import queue, state
 
@@ -262,6 +361,75 @@ def test_scheduler_replaces_uncommitted_transaction_lost_before_enqueue(tmp_path
     assert stored["transaction_history"][-1]["abandoned_reason"] == "dispatch_not_persisted"
 
 
+def test_scheduler_does_not_replace_transaction_while_worker_is_reaping(tmp_path, monkeypatch):
+    from supervisor import evolution_lifecycle, queue
+
+    _campaign, tx = _active_transaction(tmp_path, task_id="reaping-evolution")
+    pending = []
+    queue.init_queue_refs(pending, {}, {"value": 0})
+    assert evolution_lifecycle.update_evolution_transaction(
+        tx["task_id"], dispatch_status="reaping",
+    )
+    monkeypatch.setattr(queue, "send_with_budget", lambda *args, **kwargs: None)
+
+    queue.enqueue_evolution_task_if_needed()
+
+    assert pending == []
+    stored = evolution_lifecycle._read_evolution_campaign()["active_transaction"]
+    assert stored["transaction_id"] == tx["transaction_id"]
+    assert stored["dispatch_status"] == "reaping"
+
+
+def test_timeout_marks_evolution_reaping_before_scheduler_can_replace_it(tmp_path, monkeypatch):
+    from supervisor import evolution_lifecycle, queue
+
+    _campaign, tx = _active_transaction(tmp_path, task_id="timeout-evolution")
+    pending = []
+    running = {
+        tx["task_id"]: {
+            "task": {
+                "id": tx["task_id"],
+                "type": "evolution",
+                "chat_id": 1,
+                "metadata": {"evolution_transaction": dict(tx)},
+            },
+            "started_at": 1.0,
+            "last_heartbeat_at": 1.0,
+            "worker_id": 7,
+            "attempt": 1,
+        }
+    }
+    queue.init_queue_refs(pending, running, {"value": 0})
+    worker = SimpleNamespace(busy_task_id=tx["task_id"], proc=None, reaping=False)
+    workers_view = SimpleNamespace(WORKERS={7: worker})
+    reaper_jobs = _CaptureQueue()
+    monkeypatch.setattr(queue, "FINALIZATION_GRACE_SEC", 0)
+    monkeypatch.setattr(queue, "get_task_idle_timeout_sec", lambda: 1)
+    monkeypatch.setattr(queue, "get_per_call_timeout_ceiling_sec", lambda: 1)
+    monkeypatch.setattr(queue, "get_task_abs_ceiling_sec", lambda: 10)
+    monkeypatch.setattr(queue, "_ensure_reaper_started", lambda: None)
+    monkeypatch.setattr(queue, "_reap_queue", reaper_jobs)
+    monkeypatch.setattr(queue, "persist_queue_snapshot", lambda reason="": True)
+    monkeypatch.setattr(queue, "send_with_budget", lambda *args, **kwargs: None)
+
+    queue._enforce_task_timeouts_locked(
+        workers_view, now=1000.0, owner_chat_id=1,
+        st={"evolution_mode_enabled": True},
+    )
+
+    assert running == {}
+    assert worker.reaping is True
+    assert len(reaper_jobs.items) == 1
+    stored = evolution_lifecycle._read_evolution_campaign()["active_transaction"]
+    assert stored["dispatch_status"] == "reaping"
+
+    queue.enqueue_evolution_task_if_needed()
+    assert pending == []
+    assert evolution_lifecycle._read_evolution_campaign()["active_transaction"][
+        "transaction_id"
+    ] == tx["transaction_id"]
+
+
 def test_terminal_event_cannot_write_into_a_different_campaign(tmp_path):
     from supervisor import evolution_lifecycle
 
@@ -293,32 +461,111 @@ def test_terminal_event_cannot_write_into_a_different_campaign(tmp_path):
     assert stored.get("history", []) == []
 
 
-def test_terminal_write_cas_preserves_concurrent_transaction_state(tmp_path, monkeypatch):
+def test_metadata_less_terminal_cannot_mutate_active_campaign(tmp_path):
+    from supervisor import evolution_lifecycle, queue, state
+
+    state.init(tmp_path)
+    queue.init(tmp_path, 600, 1800)
+    campaign = evolution_lifecycle.start_evolution_campaign("Improve", source="test")
+
+    result = evolution_lifecycle.update_evolution_campaign_after_task(
+        "stale-task",
+        cost_usd=1.25,
+        outcome_axes={"execution": {"status": "failed"}},
+        rounds=1,
+    )
+
+    assert result == {
+        "accepted": False,
+        "persisted": False,
+        "replay": False,
+        "reason": "transaction_missing",
+        "transaction": {},
+    }
+    stored = evolution_lifecycle._read_evolution_campaign()
+    assert stored["id"] == campaign["id"]
+    assert stored["cycles_done"] == 0
+    assert stored["budget_spent_usd"] == 0.0
+    assert stored.get("history", []) == []
+
+
+def test_duplicate_terminal_resumes_pending_cleanup_and_owner_report(tmp_path, monkeypatch):
     from supervisor import evolution_lifecycle
 
     _campaign, tx = _active_transaction(tmp_path)
-    real_write = evolution_lifecycle._write_evolution_campaign
-    side_effects = []
-
-    def _interleave(data, **kwargs):
-        current = evolution_lifecycle._read_evolution_campaign()
-        current["active_transaction"]["concurrent_evidence"] = "kept"
-        assert real_write(current) is True
-        return real_write(data, **kwargs)
-
-    monkeypatch.setattr(evolution_lifecycle, "_write_evolution_campaign", _interleave)
+    assert evolution_lifecycle.update_evolution_transaction(
+        tx["task_id"], rescue_ref="refs/ouroboros/rescue/test",
+    )
+    real_resume = evolution_lifecycle._resume_evolution_terminal_effects
     monkeypatch.setattr(
         evolution_lifecycle,
-        "_cleanup_worktree_after_cycle",
-        lambda *_a, **_k: side_effects.append("cleanup"),
+        "_resume_evolution_terminal_effects",
+        lambda _campaign_id, _task_id, value: dict(value),
     )
+
+    first = evolution_lifecycle.update_evolution_campaign_after_task(
+        tx["task_id"],
+        cost_usd=1.0,
+        outcome_axes={"execution": {"status": "failed"}},
+        rounds=1,
+        transaction=tx,
+    )
+
+    assert first["persisted"] is True
+    stored = evolution_lifecycle._read_evolution_campaign()
+    assert stored["history"][0]["transaction"]["cleanup_status"] == "pending"
+    assert stored["pending_owner_report"]["cycle_outcome"] == "abandoned"
+
+    cleanup_calls = []
+    reports = []
+
+    def _cleanup(value, *_args, **_kwargs):
+        cleanup_calls.append(value["transaction_id"])
+        value["cleanup_status"] = "already_clean"
+
+    monkeypatch.setattr(evolution_lifecycle, "_resume_evolution_terminal_effects", real_resume)
+    monkeypatch.setattr(evolution_lifecycle, "_cleanup_worktree_after_cycle", _cleanup)
     monkeypatch.setattr(
         evolution_lifecycle,
         "notify_owner_cycle_outcome",
-        lambda *_a, **_k: side_effects.append("notify"),
+        lambda campaign, value: reports.append((campaign["id"], value["cycle_outcome"])),
     )
 
-    result = evolution_lifecycle.update_evolution_campaign_after_task(
+    replay = evolution_lifecycle.update_evolution_campaign_after_task(
+        tx["task_id"],
+        cost_usd=1.0,
+        outcome_axes={"execution": {"status": "failed"}},
+        rounds=1,
+        transaction=tx,
+    )
+
+    assert replay["replay"] is True
+    assert cleanup_calls == [tx["transaction_id"]]
+    assert reports == [(_campaign["id"], "abandoned")]
+    stored = evolution_lifecycle._read_evolution_campaign()
+    assert stored["history"][0]["transaction"]["cleanup_status"] == "already_clean"
+    assert "pending_owner_report" not in stored
+
+
+def test_duplicate_terminal_resumes_missing_restart_request(tmp_path, monkeypatch):
+    from supervisor import evolution_lifecycle
+
+    _campaign, tx = _active_transaction(tmp_path)
+    receipt = evolution_lifecycle.record_evolution_commit(
+        campaign_id=tx["campaign_id"],
+        transaction_id=tx["transaction_id"],
+        task_id=tx["task_id"],
+        commit_sha="a" * 40,
+    )
+    assert receipt["ok"] is True
+    real_resume = evolution_lifecycle._resume_evolution_terminal_effects
+    monkeypatch.setattr(
+        evolution_lifecycle,
+        "_resume_evolution_terminal_effects",
+        lambda _campaign_id, _task_id, value: dict(value),
+    )
+
+    first = evolution_lifecycle.update_evolution_campaign_after_task(
         tx["task_id"],
         cost_usd=1.0,
         outcome_axes={"execution": {"status": "ok"}},
@@ -326,13 +573,114 @@ def test_terminal_write_cas_preserves_concurrent_transaction_state(tmp_path, mon
         transaction=tx,
     )
 
-    assert result["accepted"] is True
-    assert result["persisted"] is False
-    assert result["reason"] == "campaign_write_refused"
+    assert first["transaction"]["cycle_outcome"] == "waiting_for_restart"
+    restart_calls = []
+    monkeypatch.setattr(evolution_lifecycle, "_resume_evolution_terminal_effects", real_resume)
+    monkeypatch.setattr(
+        evolution_lifecycle,
+        "request_evolution_restart",
+        lambda drive_root, value, log=None: restart_calls.append(
+            (pathlib.Path(drive_root), value["commit_sha"])
+        ),
+    )
+
+    replay = evolution_lifecycle.update_evolution_campaign_after_task(
+        tx["task_id"],
+        cost_usd=1.0,
+        outcome_axes={"execution": {"status": "ok"}},
+        rounds=1,
+        transaction=tx,
+    )
+
+    assert replay["replay"] is True
+    assert restart_calls == [(tmp_path, "a" * 40)]
+
+
+def test_terminal_restart_preserves_exact_model_reason(tmp_path, monkeypatch):
+    from supervisor import evolution_lifecycle, workers
+
+    campaign, tx = _active_transaction(tmp_path)
+    sha = "c" * 40
+    assert evolution_lifecycle.record_evolution_commit(
+        campaign["id"], tx["transaction_id"], tx["task_id"], sha,
+    )["ok"] is True
+    current_tx = evolution_lifecycle._read_evolution_campaign()["active_transaction"]
+    claim = {
+        "campaign_id": campaign["id"],
+        "transaction_id": tx["transaction_id"],
+        "task_id": tx["task_id"],
+        "commit_sha": sha,
+    }
+    marker = tmp_path / "state" / "pending_restart_verify.json"
+    marker.write_text(json.dumps({
+        "expected_sha": sha,
+        "reason": "apply reviewed evolution",
+        "evolution_claim": claim,
+    }))
+    events = _CaptureQueue()
+    monkeypatch.setenv("OUROBOROS_EVOLUTION_AUTO_RESTART", "true")
+    monkeypatch.setattr(workers, "get_event_q", lambda: events)
+
+    evolution_lifecycle.request_evolution_restart(tmp_path, current_tx)
+
+    assert json.loads(marker.read_text())["reason"] == "apply reviewed evolution"
+    assert len(events.items) == 1
+    assert events.items[0]["reason"] == "apply reviewed evolution"
+    assert events.items[0]["evolution_restart"] is True
+
+
+def test_terminal_write_serializes_concurrent_campaign_pause(tmp_path, monkeypatch):
+    from supervisor import evolution_lifecycle
+
+    _campaign, tx = _active_transaction(tmp_path)
+    real_write = evolution_lifecycle._write_evolution_campaign
+    entered = threading.Event()
+    release = threading.Event()
+    terminal_result = {}
+    pause_result = {}
+
+    def _hold_terminal_write(data, **kwargs):
+        entered.set()
+        assert release.wait(timeout=2)
+        return real_write(data, **kwargs)
+
+    monkeypatch.setattr(evolution_lifecycle, "_write_evolution_campaign", _hold_terminal_write)
+    monkeypatch.setattr(
+        evolution_lifecycle,
+        "_cleanup_worktree_after_cycle",
+        lambda tx, *_a, **_k: tx.update(cleanup_status="already_clean"),
+    )
+
+    def _terminal():
+        terminal_result.update(evolution_lifecycle.update_evolution_campaign_after_task(
+            tx["task_id"],
+            cost_usd=1.0,
+            outcome_axes={"execution": {"status": "ok"}},
+            rounds=1,
+            transaction=tx,
+        ))
+
+    terminal_thread = threading.Thread(target=_terminal)
+    terminal_thread.start()
+    assert entered.wait(timeout=2)
+
+    def _pause():
+        pause_result.update(evolution_lifecycle.pause_evolution_campaign("concurrent pause"))
+
+    pause_thread = threading.Thread(target=_pause)
+    pause_thread.start()
+    pause_thread.join(timeout=0.05)
+    assert pause_thread.is_alive()
+    release.set()
+    terminal_thread.join(timeout=2)
+    pause_thread.join(timeout=2)
+
+    assert terminal_result["persisted"] is True
+    assert pause_result["status"] == "paused"
     stored = evolution_lifecycle._read_evolution_campaign()
-    assert stored["active_transaction"]["concurrent_evidence"] == "kept"
-    assert stored.get("history", []) == []
-    assert side_effects == []
+    assert stored["status"] == "paused"
+    assert stored["pause_reason"] == "concurrent pause"
+    assert stored["history"][0]["task_id"] == tx["task_id"]
 
 
 def test_terminal_write_exception_has_no_lifecycle_side_effects(tmp_path, monkeypatch):
@@ -500,6 +848,7 @@ def test_evolution_orphan_ref_cannot_be_published_by_later_normal_push(
     _git("config", "user.email", "test@example.com")
     _git("remote", "add", "origin", str(remote))
     (repo / "file.txt").write_text("base\n", encoding="utf-8")
+    (repo / "peer.txt").write_text("peer-base\n", encoding="utf-8")
     _git("add", ".")
     _git("commit", "-m", "base")
     base_sha = _git("rev-parse", "HEAD").stdout.strip()
@@ -511,6 +860,7 @@ def test_evolution_orphan_ref_cannot_be_published_by_later_normal_push(
     _git("commit", "-m", "orphan")
     orphan_sha = _git("rev-parse", "HEAD").stdout.strip()
     _git("tag", "-a", "v-orphan", "-m", "orphan")
+    (repo / "peer.txt").write_text("peer-concurrent-edit\n", encoding="utf-8")
 
     note = git_tools._preserve_evolution_orphan(
         SimpleNamespace(repo_dir=repo), orphan_sha, created_tag="v-orphan",
@@ -522,6 +872,8 @@ def test_evolution_orphan_ref_cannot_be_published_by_later_normal_push(
     assert _git("rev-parse", private_ref).stdout.strip() == orphan_sha
     assert _git("show-ref", "--verify", "refs/tags/v-orphan", check=False).returncode != 0
     assert _git("rev-parse", "refs/tags/v-base^{commit}").stdout.strip() == base_sha
+    assert (repo / "peer.txt").read_text(encoding="utf-8") == "peer-concurrent-edit\n"
+    assert _git("status", "--porcelain").stdout.strip()
 
     monkeypatch.setattr(git_ops, "REPO_DIR", repo)
     pushed, _message = git_ops.push_to_remote("ouroboros", push_tags=True)
@@ -547,16 +899,20 @@ def test_evolution_orphan_ref_cannot_be_published_by_later_normal_push(
         check=True,
         capture_output=True,
     ).stdout.strip()
-    real_run_cmd = git_tools.run_cmd
+    real_subprocess_run = subprocess.run
     interleaved = {"done": False}
 
-    def _interleave_before_worktree_sync(cmd, cwd=None):
-        if cmd[:4] == ["git", "read-tree", "--reset", "-u"] and not interleaved["done"]:
-            _git("update-ref", "refs/heads/ouroboros", concurrent, base_sha)
+    def _interleave_after_ref_transaction(cmd, *args, **kwargs):
+        proc = real_subprocess_run(cmd, *args, **kwargs)
+        if cmd[:3] == ["git", "update-ref", "--stdin"] and proc.returncode == 0 and not interleaved["done"]:
+            real_subprocess_run(
+                ["git", "update-ref", "refs/heads/ouroboros", concurrent, base_sha],
+                cwd=repo, check=True, capture_output=True, text=True,
+            )
             interleaved["done"] = True
-        return real_run_cmd(cmd, cwd=cwd)
+        return proc
 
-    monkeypatch.setattr(git_tools, "run_cmd", _interleave_before_worktree_sync)
+    monkeypatch.setattr(git_tools.subprocess, "run", _interleave_after_ref_transaction)
     note = git_tools._preserve_evolution_orphan(
         SimpleNamespace(repo_dir=repo), second_orphan,
     )
@@ -567,6 +923,61 @@ def test_evolution_orphan_ref_cannot_be_published_by_later_normal_push(
     assert _git(
         "rev-parse", f"refs/ouroboros/evolution-orphans/{second_orphan}",
     ).stdout.strip() == second_orphan
+
+
+def test_orphan_ref_transaction_failure_falls_back_to_safe_ref_cas(tmp_path, monkeypatch):
+    from ouroboros.tools import git as git_tools
+    from supervisor import git_ops
+
+    repo, remote = tmp_path / "repo", tmp_path / "remote.git"
+    real_run = subprocess.run
+
+    def _git(*args, cwd=repo, check=True):
+        return real_run(
+            ["git", *args], cwd=cwd, check=check, capture_output=True, text=True,
+        )
+
+    real_run(["git", "init", "--bare", str(remote)], check=True, capture_output=True, text=True)
+    repo.mkdir()
+    _git("init", "-b", "ouroboros")
+    _git("config", "user.name", "Test")
+    _git("config", "user.email", "test@example.com")
+    _git("remote", "add", "origin", str(remote))
+    (repo / "file.txt").write_text("base\n", encoding="utf-8")
+    _git("add", ".")
+    _git("commit", "-m", "base")
+    base_sha = _git("rev-parse", "HEAD").stdout.strip()
+    _git("push", "-u", "origin", "ouroboros")
+    (repo / "file.txt").write_text("orphan\n", encoding="utf-8")
+    _git("add", ".")
+    _git("commit", "-m", "orphan")
+    orphan_sha = _git("rev-parse", "HEAD").stdout.strip()
+    _git("tag", "-a", "v-orphan", "-m", "orphan")
+
+    def _fail_transactions(cmd, *args, **kwargs):
+        if cmd[:3] == ["git", "update-ref", "--stdin"]:
+            return subprocess.CompletedProcess(cmd, 1, "", "injected transaction failure")
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(git_tools.subprocess, "run", _fail_transactions)
+
+    note = git_tools._preserve_evolution_orphan(
+        SimpleNamespace(repo_dir=repo), orphan_sha, created_tag="v-orphan",
+    )
+
+    assert "CONTAINMENT_FAILED" not in note
+    assert _git("rev-parse", "HEAD").stdout.strip() == base_sha
+    assert _git(
+        "rev-parse", f"refs/ouroboros/evolution-orphans/{orphan_sha}",
+    ).stdout.strip() == orphan_sha
+    assert _git("show-ref", "--verify", "refs/tags/v-orphan", check=False).returncode != 0
+
+    monkeypatch.setattr(git_ops, "REPO_DIR", repo)
+    pushed, _message = git_ops.push_to_remote("ouroboros", push_tags=True)
+
+    assert pushed is True
+    assert _git("rev-parse", "refs/heads/ouroboros", cwd=remote).stdout.strip() == base_sha
+    assert _git("cat-file", "-e", orphan_sha, cwd=remote, check=False).returncode != 0
 
 
 def test_exact_commit_receipt_is_bound_to_campaign_transaction_and_task(tmp_path):
@@ -596,6 +1007,69 @@ def test_exact_commit_receipt_is_bound_to_campaign_transaction_and_task(tmp_path
     assert evolution_lifecycle.check_evolution_authority(
         **claim, commit_sha="a" * 40,
     )["reason"] == "commit_receipt_missing"
+
+
+def test_second_evolution_commit_is_blocked_before_review(tmp_path, monkeypatch):
+    from ouroboros.tools import git as git_tools
+    from supervisor import evolution_lifecycle
+
+    campaign, tx = _active_transaction(tmp_path)
+    assert evolution_lifecycle.record_evolution_commit(
+        campaign["id"], tx["transaction_id"], tx["task_id"], "a" * 40,
+    )["ok"] is True
+    review_calls = []
+    monkeypatch.setattr(git_tools, "_task_attributed_commit_paths", lambda *a, **k: (None, None, "", None))
+    monkeypatch.setattr(git_tools, "_check_overlapping_review_attempt", lambda *a, **k: "")
+    monkeypatch.setattr(git_tools, "_record_commit_attempt", lambda *a, **k: None)
+    monkeypatch.setattr(git_tools, "_acquire_git_lock", lambda *a, **k: pathlib.Path("lock"))
+    monkeypatch.setattr(git_tools, "_release_git_lock", lambda *a, **k: None)
+    monkeypatch.setattr(git_tools, "_prepare_review_commit_worktree", lambda *a, **k: (False, ""))
+    monkeypatch.setattr(
+        git_tools,
+        "_run_reviewed_stage_cycle",
+        lambda *a, **k: review_calls.append(True) or {"status": "passed"},
+    )
+    ctx = SimpleNamespace(
+        repo_dir=tmp_path,
+        drive_root=tmp_path,
+        current_task_type="evolution",
+        task_id=tx["task_id"],
+        task_metadata={"evolution_transaction": tx},
+    )
+
+    result = git_tools._repo_commit_push(ctx, "second commit")
+
+    assert "transaction_already_committed" in result
+    assert "No reviewer was called" in result
+    assert review_calls == []
+
+
+def test_receipt_race_blocks_evolution_before_git_commit(tmp_path, monkeypatch):
+    from ouroboros.tools import git as git_tools
+    from supervisor import evolution_lifecycle
+
+    campaign, tx = _active_transaction(tmp_path)
+    ctx = SimpleNamespace(
+        repo_dir=tmp_path,
+        current_task_type="evolution",
+        task_id=tx["task_id"],
+        task_metadata={"evolution_transaction": tx},
+    )
+    monkeypatch.setattr(git_tools, "_record_commit_attempt", lambda *a, **k: None)
+    claim, error = git_tools._check_evolution_commit_stage(
+        ctx, "commit", 0.0, phase="pre_review_authority",
+    )
+    assert error == ""
+    assert evolution_lifecycle.record_evolution_commit(
+        **claim, commit_sha="b" * 40,
+    )["ok"] is True
+
+    _claim, error = git_tools._check_evolution_commit_stage(
+        ctx, "commit", 0.0, phase="pre_commit_authority",
+    )
+
+    assert "transaction_already_committed" in error
+    assert "Nothing was committed" in error
 
 
 def test_revoked_authority_leaves_commit_unrecorded(tmp_path):
@@ -915,7 +1389,16 @@ def test_postcommit_cas_failure_returns_local_orphan_after_binding(tmp_path, mon
     assert len(contained) == 1
 
 
-def test_final_evolution_authority_check_and_push_stay_under_git_lock(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    ("task_type", "expected_order"),
+    [
+        ("evolution", ["authority", "push", "release", "publish"]),
+        ("task", ["release", "push", "publish"]),
+    ],
+)
+def test_only_evolution_push_stays_under_git_lock(
+    tmp_path, monkeypatch, task_type, expected_order,
+):
     from ouroboros.tools import git as git_tools
 
     claim = {"campaign_id": "camp", "transaction_id": "tx", "task_id": "evo"}
@@ -950,18 +1433,137 @@ def test_final_evolution_authority_check_and_push_stay_under_git_lock(tmp_path, 
         lambda *a, **k: order.append("authority") or "",
     )
     monkeypatch.setattr(git_tools, "_auto_push", lambda *a, **k: order.append("push") or "")
-    monkeypatch.setattr(git_tools, "_publish_reviewed_commit", lambda *a, **k: "ok")
+    monkeypatch.setattr(
+        git_tools,
+        "_publish_reviewed_commit",
+        lambda *a, **k: order.append("publish") or "ok",
+    )
     ctx = SimpleNamespace(
         repo_dir=tmp_path,
         drive_root=tmp_path,
         branch_dev="ouroboros",
-        current_task_type="evolution",
+        current_task_type=task_type,
         task_id="evo",
         task_metadata={"evolution_transaction": claim},
     )
 
     assert git_tools._repo_commit_push(ctx, "test commit", skip_tests=True) == "ok"
-    assert order == ["authority", "push", "release"]
+    assert order == expected_order
+
+
+def test_revoked_publication_does_not_record_or_anchor_success(tmp_path, monkeypatch):
+    from ouroboros import mutation_attribution
+    from ouroboros.tools import git as git_tools
+
+    claim = {"campaign_id": "camp", "transaction_id": "tx", "task_id": "evo"}
+    sha = "d" * 40
+    attempts, baselines, contained, pushed = [], [], [], []
+    authority = iter([
+        (claim, {"ok": True}),
+        (claim, {"ok": True}),
+        (claim, {"ok": True}),
+        (claim, {"ok": False, "reason": "owner_stopped"}),
+    ])
+    monkeypatch.setattr(git_tools, "_task_attributed_commit_paths", lambda *a, **k: (None, None, "", ("root", "task")))
+    monkeypatch.setattr(git_tools, "_check_overlapping_review_attempt", lambda *a, **k: "")
+    monkeypatch.setattr(git_tools, "_record_commit_attempt", lambda *a, **k: attempts.append((k.get("status") or a[2], k)))
+    monkeypatch.setattr(git_tools, "_acquire_git_lock", lambda *a, **k: pathlib.Path("lock"))
+    monkeypatch.setattr(git_tools, "_release_git_lock", lambda *a, **k: None)
+    monkeypatch.setattr(git_tools, "_prepare_review_commit_worktree", lambda *a, **k: (False, ""))
+    monkeypatch.setattr(git_tools, "_evolution_commit_authority", lambda *a, **k: next(authority))
+    monkeypatch.setattr(git_tools, "_verify_reviewed_commit_binding", lambda *a, **k: (True, ""))
+    def reviewed(review_ctx, *args, **kwargs):
+        review_ctx._last_triad_raw_results = [{"raw": "triad"}]
+        review_ctx._last_scope_raw_result = {"raw": "scope"}
+        review_ctx._review_degraded_reasons = ["recorded"]
+        return {
+            "status": "passed",
+            "pre_fingerprint": {"fingerprint": "pre"},
+            "post_fingerprint": {"fingerprint": "post", "binding": {}},
+        }
+    monkeypatch.setattr(git_tools, "_run_reviewed_stage_cycle", reviewed)
+    monkeypatch.setattr(git_tools, "run_cmd", lambda cmd, cwd=None: sha if cmd[:3] == ["git", "rev-parse", "HEAD"] else "")
+    monkeypatch.setattr(git_tools, "_auto_tag_on_version_bump", lambda *a, **k: "")
+    monkeypatch.setattr(git_tools, "_record_evolution_commit_receipt", lambda *a, **k: "")
+    monkeypatch.setattr(git_tools, "_preserve_evolution_orphan", lambda *a, **k: contained.append(True) or "contained")
+    monkeypatch.setattr(git_tools, "_auto_push", lambda *a, **k: pushed.append(True) or "")
+    monkeypatch.setattr(mutation_attribution, "advance_mutation_baseline", lambda *a, **k: baselines.append(a))
+    ctx = SimpleNamespace(
+        repo_dir=tmp_path, drive_root=tmp_path, branch_dev="ouroboros",
+        current_task_type="evolution", task_id="evo",
+        task_metadata={"evolution_transaction": claim},
+        _scope_review_history={"keep": True},
+    )
+
+    result = git_tools._repo_commit_push(ctx, "test commit", skip_tests=True)
+
+    assert "EVOLUTION_PUBLICATION_STOPPED" in result
+    assert contained == [True]
+    assert pushed == []
+    assert baselines == []
+    statuses = [status for status, _details in attempts]
+    assert "succeeded" not in statuses and statuses[-1] == "failed"
+    failed = attempts[-1][1]
+    assert failed["fingerprint_status"] == "matched"
+    assert failed["pre_review_fingerprint"] == "pre"
+    assert failed["post_review_fingerprint"] == "post"
+    assert failed["triad_raw_results"] == [{"raw": "triad"}]
+    assert failed["scope_raw_result"] == {"raw": "scope"}
+    assert failed["degraded_reasons"] == ["recorded"]
+    assert not getattr(ctx, "last_reviewed_commit_sha", "")
+    assert ctx._scope_review_history == {"keep": True}
+
+
+def test_postcommit_binding_failure_contains_evolution_commit(tmp_path, monkeypatch):
+    from ouroboros.tools import git as git_tools
+
+    claim = {"campaign_id": "camp", "transaction_id": "tx", "task_id": "evo"}
+    contained = []
+    monkeypatch.setattr(git_tools, "_task_attributed_commit_paths", lambda *a, **k: (None, None, "", None))
+    monkeypatch.setattr(git_tools, "_check_overlapping_review_attempt", lambda *a, **k: "")
+    monkeypatch.setattr(git_tools, "_record_commit_attempt", lambda *a, **k: None)
+    monkeypatch.setattr(git_tools, "_acquire_git_lock", lambda *a, **k: pathlib.Path("lock"))
+    monkeypatch.setattr(git_tools, "_release_git_lock", lambda *a, **k: None)
+    monkeypatch.setattr(git_tools, "_prepare_review_commit_worktree", lambda *a, **k: (False, ""))
+    monkeypatch.setattr(git_tools, "_evolution_commit_authority", lambda *a, **k: (claim, {"ok": True}))
+    monkeypatch.setattr(
+        git_tools,
+        "_run_reviewed_stage_cycle",
+        lambda *a, **k: {
+            "status": "passed",
+            "pre_fingerprint": {"fingerprint": "pre"},
+            "post_fingerprint": {"fingerprint": "post", "binding": {}},
+        },
+    )
+    monkeypatch.setattr(
+        git_tools,
+        "run_cmd",
+        lambda cmd, cwd=None: "2" * 40 if cmd[:3] == ["git", "rev-parse", "HEAD"] else "",
+    )
+    monkeypatch.setattr(
+        git_tools,
+        "_verify_reviewed_commit_binding",
+        lambda *a, **k: (False, "tree mismatch"),
+    )
+    monkeypatch.setattr(
+        git_tools,
+        "_preserve_evolution_orphan",
+        lambda *a, **k: contained.append((a, k)) or "contained",
+    )
+    ctx = SimpleNamespace(
+        repo_dir=tmp_path,
+        drive_root=tmp_path,
+        current_task_type="evolution",
+        task_id="evo",
+        task_metadata={"evolution_transaction": claim},
+    )
+
+    result = git_tools._repo_commit_push(ctx, "test commit")
+
+    assert "REVIEW_BINDING_FAILED" in result
+    assert "contained" in result
+    assert len(contained) == 1
+    assert contained[0][1] == {}
 
 
 def test_final_tag_binding_failure_cannot_record_restart_receipt(tmp_path, monkeypatch):
@@ -969,6 +1571,7 @@ def test_final_tag_binding_failure_cannot_record_restart_receipt(tmp_path, monke
 
     claim = {"campaign_id": "camp", "transaction_id": "tx", "task_id": "evo"}
     recorded = []
+    contained = []
     binding_results = iter([(True, ""), (False, "tag target mismatch")])
     monkeypatch.setattr(git_tools, "_task_attributed_commit_paths", lambda *a, **k: (None, None, "", None))
     monkeypatch.setattr(git_tools, "_check_overlapping_review_attempt", lambda *a, **k: "")
@@ -985,14 +1588,26 @@ def test_final_tag_binding_failure_cannot_record_restart_receipt(tmp_path, monke
         lambda *a, **k: {
             "status": "passed",
             "pre_fingerprint": {"fingerprint": "pre"},
-            "post_fingerprint": {"fingerprint": "post", "binding": {}},
+            "post_fingerprint": {
+                "fingerprint": "post",
+                "binding": {"expected_tag": "v-test"},
+            },
         },
     )
     monkeypatch.setattr(
         git_tools, "run_cmd",
         lambda cmd, cwd=None: "1" * 40 if cmd[:3] == ["git", "rev-parse", "HEAD"] else "",
     )
-    monkeypatch.setattr(git_tools, "_auto_tag_on_version_bump", lambda *a, **k: "")
+    monkeypatch.setattr(
+        git_tools,
+        "_auto_tag_on_version_bump",
+        lambda *a, **k: " [tagged: v-test]",
+    )
+    monkeypatch.setattr(
+        git_tools,
+        "_preserve_evolution_orphan",
+        lambda *a, **k: contained.append((a, k)) or "contained",
+    )
     monkeypatch.setattr(
         git_tools,
         "_record_evolution_commit_receipt",
@@ -1011,6 +1626,8 @@ def test_final_tag_binding_failure_cannot_record_restart_receipt(tmp_path, monke
 
     assert "REVIEW_BINDING_FAILED" in result
     assert recorded == []
+    assert len(contained) == 1
+    assert contained[0][1]["created_tag"] == "v-test"
 
 
 def test_evolution_publication_authority_requires_exact_head(tmp_path, monkeypatch):
@@ -1039,6 +1656,117 @@ def test_evolution_publication_authority_requires_exact_head(tmp_path, monkeypat
 
     assert authority["ok"] is False
     assert authority["reason"] == "head_mismatch"
+
+
+def test_evolution_promote_event_carries_exact_claim():
+    from ouroboros.tools import control
+
+    ctx = SimpleNamespace(
+        current_task_type="evolution",
+        task_id="evo-task",
+        task_metadata={"evolution_transaction": {
+            "campaign_id": "campaign",
+            "transaction_id": "transaction",
+            "task_id": "evo-task",
+            "commit_sha": "",
+        }},
+        last_reviewed_commit_sha="a" * 40,
+        pending_events=[],
+    )
+
+    control._promote_to_stable(ctx, "reviewed")
+
+    event = ctx.pending_events[0]
+    assert event["type"] == "promote_to_stable"
+    assert event["reason"] == "reviewed"
+    assert event["evolution_claim"] == {
+        "campaign_id": "campaign",
+        "transaction_id": "transaction",
+        "task_id": "evo-task",
+        "commit_sha": "a" * 40,
+    }
+
+
+def test_promote_to_stable_rechecks_evolution_claim_without_changing_normal_flow(
+    tmp_path, monkeypatch,
+):
+    from supervisor import events, evolution_lifecycle
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def _git(*args):
+        return subprocess.run(
+            ["git", *args], cwd=repo, check=True, capture_output=True, text=True,
+        ).stdout.strip()
+
+    _git("init", "-b", "ouroboros")
+    _git("config", "user.name", "Test")
+    _git("config", "user.email", "test@example.com")
+    (repo / "file.txt").write_text("base\n", encoding="utf-8")
+    _git("add", ".")
+    _git("commit", "-m", "base")
+    base_sha = _git("rev-parse", "HEAD")
+    _git("branch", "ouroboros-stable", base_sha)
+    (repo / "file.txt").write_text("reviewed\n", encoding="utf-8")
+    _git("add", ".")
+    _git("commit", "-m", "reviewed")
+    reviewed_sha = _git("rev-parse", "HEAD")
+    sent = []
+    ctx = SimpleNamespace(
+        REPO_DIR=repo,
+        BRANCH_DEV="ouroboros",
+        BRANCH_STABLE="ouroboros-stable",
+        load_state=lambda: {"owner_chat_id": 1},
+        send_with_budget=lambda chat_id, message: sent.append(message),
+    )
+    monkeypatch.setattr(
+        evolution_lifecycle,
+        "check_evolution_authority",
+        lambda **claim: {
+            "ok": claim.get("campaign_id") == "valid",
+            "reason": "owner_stopped" if claim.get("campaign_id") != "valid" else "",
+        },
+    )
+
+    events._handle_promote_to_stable({
+        "type": "promote_to_stable",
+        "evolution_claim": {
+            "campaign_id": "revoked",
+            "transaction_id": "tx",
+            "task_id": "evo",
+            "commit_sha": reviewed_sha,
+        },
+    }, ctx)
+    assert _git("rev-parse", "ouroboros-stable") == base_sha
+    assert "owner_stopped" in sent[-1]
+
+    events._handle_promote_to_stable({
+        "type": "promote_to_stable",
+        "evolution_claim": {
+            "campaign_id": "",
+            "transaction_id": "",
+            "task_id": "",
+            "commit_sha": "",
+        },
+    }, ctx)
+    assert _git("rev-parse", "ouroboros-stable") == base_sha
+    assert "commit_receipt_missing" in sent[-1]
+
+    events._handle_promote_to_stable({
+        "type": "promote_to_stable",
+        "evolution_claim": {
+            "campaign_id": "valid",
+            "transaction_id": "tx",
+            "task_id": "evo",
+            "commit_sha": reviewed_sha,
+        },
+    }, ctx)
+    assert _git("rev-parse", "ouroboros-stable") == reviewed_sha
+
+    _git("branch", "-f", "ouroboros-stable", base_sha)
+    events._handle_promote_to_stable({"type": "promote_to_stable"}, ctx)
+    assert _git("rev-parse", "ouroboros-stable") == reviewed_sha
 
 
 def test_restart_requires_the_exact_active_commit_receipt(tmp_path, monkeypatch):

--- a/tests/test_evolution_stop_and_cost.py
+++ b/tests/test_evolution_stop_and_cost.py
@@ -90,11 +90,23 @@ def _drive_hard_timeout(tmp_path, monkeypatch, *, evolution_enabled):
 
     import supervisor.queue as q
     import supervisor.state as state
+    from supervisor import evolution_lifecycle
     from supervisor import workers as workers_mod
     import ouroboros.tools.services as services_mod
 
-    monkeypatch.setattr(q, "DRIVE_ROOT", tmp_path)
-    monkeypatch.setattr(state, "DRIVE_ROOT", tmp_path)
+    state.init(tmp_path)
+    q.init(tmp_path, 600, 1800)
+    campaign = evolution_lifecycle.start_evolution_campaign("Improve", source="test")
+    state.update_state(lambda live: live.update(
+        owner_chat_id=7,
+        evolution_mode_enabled=True,
+        evolution_owner_stopped=False,
+    ))
+    transaction = evolution_lifecycle.begin_evolution_transaction(
+        "evo1", cycle=1, campaign=campaign,
+    )
+    if not evolution_enabled:
+        state.update_state(lambda live: live.update(evolution_mode_enabled=False))
     monkeypatch.setattr(q, "FINALIZATION_GRACE_SEC", 0)
     # Activity model: drive an IDLE kill (no progress for the idle window), not a flat
     # wall-clock/ceiling kill — small idle/ceiling getters + a recent started_at keep
@@ -115,7 +127,13 @@ def _drive_hard_timeout(tmp_path, monkeypatch, *, evolution_enabled):
         for index in range(3)
     ])
 
-    task = {"id": "evo1", "type": "evolution", "chat_id": 7, "_attempt": 1, "metadata": {}}
+    task = {
+        "id": "evo1",
+        "type": "evolution",
+        "chat_id": 7,
+        "_attempt": 1,
+        "metadata": {"evolution_transaction": transaction},
+    }
     monkeypatch.setattr(q, "RUNNING", {
         "evo1": {"task": task, "started_at": time.time() - 1000, "worker_id": 0, "attempt": 1},
     })
@@ -184,14 +202,22 @@ def test_hard_timeout_evolution_stopped_no_requeue_records_cost(tmp_path, monkey
 def test_handle_task_done_reconstructs_cost_from_physical_ledger(tmp_path):
     """A zeroed terminal event and stale result cannot override the ledger."""
     from ouroboros import usage_accounting as accounting
-    from supervisor import queue
+    from supervisor import evolution_lifecycle as lifecycle, queue
     from supervisor import state as supervisor_state
     from supervisor.events import _handle_task_done
     from ouroboros.task_results import STATUS_CANCELLED, write_task_result
 
     supervisor_state.init(tmp_path)
     queue.init(tmp_path, 600, 1800)
-    queue.start_evolution_campaign("Improve", source="test")
+    campaign = queue.start_evolution_campaign("Improve", source="test")
+    supervisor_state.update_state(lambda live: live.update(
+        owner_chat_id=1,
+        evolution_mode_enabled=True,
+        evolution_owner_stopped=False,
+    ))
+    transaction = lifecycle.begin_evolution_transaction(
+        "evo-zero", cycle=1, campaign=campaign,
+    )
 
     reservation = accounting.reserve_attempt(accounting.AttemptRequest(
         model="openai/gpt-5.2", provider="openai", reservation_usd=2.5,
@@ -221,6 +247,7 @@ def test_handle_task_done_reconstructs_cost_from_physical_ledger(tmp_path):
         {
             "type": "task_done", "task_id": "evo-zero", "task_type": "evolution",
             "result_status": "cancelled", "cost_usd": 0, "total_rounds": 0,
+            "metadata": {"evolution_transaction": transaction},
         },
         ctx,
     )

--- a/tests/test_post_task_evolution.py
+++ b/tests/test_post_task_evolution.py
@@ -157,7 +157,11 @@ def test_v5_apply_pending_request_activates_gated_campaign(tmp_path, monkeypatch
     import supervisor.evolution_lifecycle as lifecycle
     import supervisor.state as st
     monkeypatch.setattr(lifecycle, "evolution_block_reason", lambda: "")
-    monkeypatch.setattr(lifecycle, "start_evolution_campaign", lambda objective, source="": started.update(objective=objective, source=source))
+    monkeypatch.setattr(
+        lifecycle,
+        "start_evolution_campaign",
+        lambda objective, source="": started.update(objective=objective, source=source) or {"id": "test"},
+    )
     monkeypatch.setattr(st, "load_state", lambda: {"owner_chat_id": 7})
     monkeypatch.setattr(st, "save_state", lambda s: saved.update(s))
 
@@ -340,7 +344,7 @@ def test_toggle_evolution_on_clears_owner_stop(tmp_path, monkeypatch):
     monkeypatch.setattr(lifecycle, "complete_evolution_campaign",
                         lambda reason="", *, status="stopped": calls["complete"].append((reason, status)))
     monkeypatch.setattr(lifecycle, "start_evolution_campaign",
-                        lambda objective="", *, source="": calls["start"].append((objective, source)))
+                        lambda objective="", *, source="": calls["start"].append((objective, source)) or {"id": "test"})
 
     ctx = types.SimpleNamespace(
         load_state=lambda: {"owner_chat_id": 7},
@@ -352,6 +356,22 @@ def test_toggle_evolution_on_clears_owner_stop(tmp_path, monkeypatch):
     assert captured["evolution_owner_stopped"] is False  # cleared on owner start
     assert calls["start"] == [("improve X", "agent_tool")]
     assert calls["complete"] == []
+
+
+def test_toggle_evolution_start_failure_sends_owner_correction(monkeypatch):
+    from supervisor import evolution_lifecycle, events
+
+    monkeypatch.setattr(evolution_lifecycle, "evolution_block_reason", lambda: "")
+    monkeypatch.setattr(evolution_lifecycle, "start_evolution_campaign", lambda *a, **k: {})
+    sent = []
+    ctx = types.SimpleNamespace(
+        load_state=lambda: {"owner_chat_id": 7, "evolution_mode_enabled": False},
+        send_with_budget=lambda chat_id, text: sent.append((chat_id, text)),
+    )
+
+    events._handle_toggle_evolution({"enabled": True}, ctx)
+
+    assert sent == [(7, "🧬 Evolution stayed OFF: campaign state could not be created.")]
 
 
 def test_apply_pending_request_atomic_recheck_aborts_on_raced_owner_stop(tmp_path, monkeypatch):
@@ -371,7 +391,7 @@ def test_apply_pending_request_atomic_recheck_aborts_on_raced_owner_stop(tmp_pat
     calls = {"start": [], "complete": []}
     monkeypatch.setattr(lifecycle, "evolution_block_reason", lambda: "")
     monkeypatch.setattr(lifecycle, "start_evolution_campaign",
-                        lambda objective, source="": calls["start"].append((objective, source)))
+                        lambda objective, source="": calls["start"].append((objective, source)) or {"id": "test"})
     monkeypatch.setattr(lifecycle, "complete_evolution_campaign",
                         lambda reason="", *, status="stopped": calls["complete"].append((reason, status)))
     # Snapshot passes the chokepoint (flag False, not yet enabled)...
@@ -473,6 +493,7 @@ def test_complete_evolution_campaign_cleans_worktree_before_popping_tx(tmp_path,
 
     # Emergency Stop Invariant: cleanup_worktree=False (panic path) still pops the tx but
     # runs NO git worktree cleanup, so nothing can delay the panic hard-exit.
+    (tmp_path / "state" / "evolution_campaign.json").unlink()
     lifecycle._write_evolution_campaign({
         "id": "OLD2", "status": "active",
         "active_transaction": {"task_id": "t10", "commit_sha": "", "base_head": "def456"},
@@ -576,7 +597,11 @@ def _apply_with_request(tmp_path, monkeypatch, backlog_id):
     import supervisor.state as stt
     camp: dict = {}
     monkeypatch.setattr(lifecycle, "evolution_block_reason", lambda: "")
-    monkeypatch.setattr(lifecycle, "start_evolution_campaign", lambda *a, **k: None)
+    monkeypatch.setattr(
+        lifecycle,
+        "start_evolution_campaign",
+        lambda *a, **k: {"id": "C", "status": "active"},
+    )
     monkeypatch.setattr(lifecycle, "_read_evolution_campaign", lambda: camp)
     monkeypatch.setattr(lifecycle, "_write_evolution_campaign", lambda c: camp.update(c))
     monkeypatch.setattr(stt, "load_state", lambda: {"owner_chat_id": 7})

--- a/tests/test_promote_chat_flow.py
+++ b/tests/test_promote_chat_flow.py
@@ -511,7 +511,7 @@ def test_restart_drain_defers_then_completes_without_sleeping(tmp_path, monkeypa
 
     monkeypatch.setenv("OUROBOROS_RESTART_DRAIN_MAX_SEC", "120")
     performed = []
-    monkeypatch.setattr(server, "_perform_supervisor_restart", lambda ctx: performed.append(True))
+    monkeypatch.setattr(server, "_perform_supervisor_restart", lambda ctx, **kw: performed.append(True))
     server._pending_restart.clear()
 
     now = __import__("time").time()
@@ -545,7 +545,7 @@ def test_restart_drain_no_live_tasks_restarts_immediately(tmp_path, monkeypatch)
 
     monkeypatch.setenv("OUROBOROS_RESTART_DRAIN_MAX_SEC", "120")
     performed = []
-    monkeypatch.setattr(server, "_perform_supervisor_restart", lambda ctx: performed.append(True))
+    monkeypatch.setattr(server, "_perform_supervisor_restart", lambda ctx, **kw: performed.append(True))
     server._pending_restart.clear()
 
     ctx = types.SimpleNamespace(
@@ -573,7 +573,7 @@ def test_restart_drain_uses_generic_queue_heartbeat_not_retired_planning_knob(
     monkeypatch.setenv("OUROBOROS_RESTART_DRAIN_MAX_SEC", "120")
     monkeypatch.setenv("OUROBOROS_PLAN_TASK_SWARM_HEARTBEAT_STALE_SEC", "999999")
     performed = []
-    monkeypatch.setattr(server, "_perform_supervisor_restart", lambda ctx: performed.append(True))
+    monkeypatch.setattr(server, "_perform_supervisor_restart", lambda ctx, **kw: performed.append(True))
     server._pending_restart.clear()
 
     ctx = types.SimpleNamespace(

--- a/tests/test_server_shutdown.py
+++ b/tests/test_server_shutdown.py
@@ -166,6 +166,8 @@ def test_panic_stop_kills_services_without_log_finalization(monkeypatch, tmp_pat
     monkeypatch.setattr("ouroboros.local_model.get_manager", lambda: SimpleNamespace(stop_server=lambda: None))
     monkeypatch.setattr("supervisor.state.load_state", lambda: {})
     monkeypatch.setattr("supervisor.state.save_state", lambda _state: None)
+    monkeypatch.setattr("supervisor.evolution_lifecycle.complete_evolution_campaign", lambda *a, **k: {})
+    monkeypatch.setattr("ouroboros.post_task_evolution.drop_pending_request", lambda *a, **k: None)
     monkeypatch.setattr("ouroboros.extension_companion.panic_kill_all", lambda: None)
     monkeypatch.setattr("multiprocessing.active_children", lambda: [])
     monkeypatch.setattr("ouroboros.platform_layer.kill_process_on_port", lambda _port: None)

--- a/tests/test_terminal_durability_v664.py
+++ b/tests/test_terminal_durability_v664.py
@@ -150,7 +150,11 @@ def test_self_finalized_reaper_preserves_evolution_transaction_metadata(
         "id": "evo-reaped",
         "type": "evolution",
         "chat_id": 0,
-        "metadata": {"evolution_transaction": tx},
+        "metadata": {
+            "evolution_transaction": tx,
+            "secret_sentinel": "must-not-reach-terminal-event",
+            "workspace_root": "/private/workspace",
+        },
     }
     write_task_result(tmp_path, task["id"], STATUS_CANCELLED, result="cancelled")
 
@@ -169,7 +173,7 @@ def test_self_finalized_reaper_preserves_evolution_transaction_metadata(
     terminal = [event for event in events if event.get("type") == "task_done"]
     assert enqueued == []
     assert len(terminal) == 1
-    assert terminal[0]["metadata"]["evolution_transaction"] == tx
+    assert terminal[0]["metadata"] == {"evolution_transaction": tx}
 
 
 def test_top_level_retry_preserves_logical_root_and_typed_attempt_lineage(

--- a/tests/test_terminal_durability_v664.py
+++ b/tests/test_terminal_durability_v664.py
@@ -138,6 +138,40 @@ def test_headless_reaper_still_emits_task_done(tmp_path, monkeypatch):
     assert terminal[0]["chat_id"] == 0
 
 
+def test_self_finalized_reaper_preserves_evolution_transaction_metadata(
+    tmp_path, monkeypatch,
+):
+    from ouroboros.task_results import STATUS_CANCELLED, write_task_result
+    from supervisor.task_reaper import reap_timed_out_task
+
+    events, enqueued = _patch_reaper(tmp_path, monkeypatch)
+    tx = {"campaign_id": "camp", "transaction_id": "tx", "task_id": "evo-reaped"}
+    task = {
+        "id": "evo-reaped",
+        "type": "evolution",
+        "chat_id": 0,
+        "metadata": {"evolution_transaction": tx},
+    }
+    write_task_result(tmp_path, task["id"], STATUS_CANCELLED, result="cancelled")
+
+    reap_timed_out_task({
+        "worker_id": 4,
+        "proc": None,
+        "task_id": task["id"],
+        "task": task,
+        "task_type": "evolution",
+        "terminal_reason": "idle_timeout",
+        "attempt": 1,
+        "owner_chat_id": 0,
+        "will_retry": False,
+    })
+
+    terminal = [event for event in events if event.get("type") == "task_done"]
+    assert enqueued == []
+    assert len(terminal) == 1
+    assert terminal[0]["metadata"]["evolution_transaction"] == tx
+
+
 def test_top_level_retry_preserves_logical_root_and_typed_attempt_lineage(
     tmp_path, monkeypatch,
 ):

--- a/tests/test_worker_crash_retry.py
+++ b/tests/test_worker_crash_retry.py
@@ -494,6 +494,8 @@ def test_signal_crash_is_terminal_no_retry(tmp_path):
     import queue as _queue
 
     task = _make_task(task_id="sig01", attempt=1, chat_id=7)  # ordinary task type
+    evolution_tx = {"campaign_id": "camp", "transaction_id": "tx", "task_id": "sig01"}
+    task["metadata"] = {"evolution_transaction": evolution_tx}
     worker = _make_worker(busy_task_id="sig01", exitcode=-11)
 
     W.DRIVE_ROOT = tmp_path
@@ -538,7 +540,8 @@ def test_signal_crash_is_terminal_no_retry(tmp_path):
     drained = []
     while not event_q.empty():
         drained.append(event_q.get_nowait())
-    assert any(e.get("type") == "task_done" and e.get("task_id") == "sig01" for e in drained)
+    terminal = next(e for e in drained if e.get("type") == "task_done" and e.get("task_id") == "sig01")
+    assert terminal["metadata"]["evolution_transaction"] == evolution_tx
     incident_notice.assert_called_once()
     notice_args, notice_kwargs = incident_notice.call_args
     assert notice_args[0] == 7


### PR DESCRIPTION
## Summary

A full pytest subprocess inherited supervisor modules whose process-global roots still pointed at the live data directory. During the incident, a lifecycle test enabled real evolution task `19ae022b`; it spent `$13.828185`, ended `budget_exhausted`, and a later lifecycle test wrote `panic stop` into the same live campaign.

The task did create local commit `7caf7c136fc94907dbb7df104934377edf9f9d95` and local tag `v6.88.0`, but publication was skipped because no user remote was configured. The terminal demo was therefore never published and is deliberately absent from this branch. The missing durable commit receipt is why the task card/report incorrectly looked like no commit had been made.

This PR makes the test root hermetic and binds evolution work to one exact durable campaign/transaction/task claim from scheduling through dispatch, reviewed commit, publication, terminal lifecycle, and restart. It also makes the lifecycle the sole producer of evolution restart events while preserving the model's exact claimed restart reason.

## Scope

In scope:

- rebind process-global supervisor roots to the disposable pytest data root and fail closed on live-root writes;
- require a live sourced campaign and exact uncommitted transaction authority before evolution dispatch;
- persist exact commit/publication/restart receipts and reconcile them across process generations;
- make terminal lifecycle effects CAS-bound and idempotent;
- contain an authority-lost commit outside normal branch/tag publication refs;
- preserve evolution metadata on terminal reaper paths;
- avoid duplicate evolution restart events without changing the ordinary restart flow.

Non-goals:

- no UI or terminal-demo changes;
- no version bump or release metadata;
- no historical log rewrite, new ledger, or broad new safety restriction.

## Verification

```text
Focused changed/lifecycle suites: PASS
Restart regression tests: 7 passed
Ruff F checks and py_compile: PASS

LC_ALL=C LANG=C OUROBOROS_DATA_DIR=<temp> app-python -m pytest
6860 passed, 1 skipped, 75 deselected in 413.96s
```

The full suite ran from a detached worktree bound to final head `bd9aaf3d40d91e1b6cebc52cef0b55ef349e944f` and tree `35cc31b0701fa279ac58daabbdcca34f3a32c958`. HEAD/tree and the live settings/campaign hashes were identical before and after; the verification worktree was clean.

No visual verification is needed because this PR has no visible UI change.

## Governance and review

- Base: `fc9c1523aa30d98f12f6684c041270340f8f0a96`
- Head: `bd9aaf3d40d91e1b6cebc52cef0b55ef349e944f`
- Tree: `35cc31b0701fa279ac58daabbdcca34f3a32c958`
- Base-to-head binary diff SHA-256: `1dc2bac27e053aed8ebc6f599036af9b0229b364178ea5ae308a5edbbfebf87c`

The exact final tree received the required formal panel at max effort:

- `openai/gpt-5.6-sol`: no findings;
- `google/gemini-3.6-flash`: no findings;
- `anthropic/claude-fable-5`: core behavior/tests/docs passed; its only blocking label was the release version, which `CONTRIBUTING.md` explicitly assigns to the maintainer during integration;
- scope review with exactly `openai/gpt-5.6-sol`: completed without a critical finding.

There were no substitutions or degraded lanes. Independent GPT-5.6-sol max reviewers also reproduced and cleared the final restart delta. An additional Claudexor/Fable run exhausted its configured turn limit while reading the full evidence pack, so it produced no terminal verdict and is not counted as review evidence.

The remaining review notes are intentionally deferred as rare P2 hardening: a second failure while containing an already unauthorized commit, an exceptional reaper write failure that could leave a campaign marked `reaping`, and a latent `supervisor.git_ops` import-time root mismatch that did not write to live state in focused or full-suite reproduction. None is default-reachable in this patch, and expanding them would restart the reviewer-driven whack-a-mole loop.

## Final checklist

- [x] Base branch is `ouroboros` at the current remote target SHA.
- [x] The local-only terminal demo commit/tag is not an ancestor and is not pushed.
- [x] `VERSION` and all release-only version carriers are unchanged, per `CONTRIBUTING.md`.
- [x] No secrets, runtime state, logs, caches, or generated review artifacts are committed.
- [x] Architecture/development documentation and tests cover the changed behavior.
- [x] Ready for maintainer review; this PR is not merged by the contributor.
