### PR TITLE
Credit Ouroboros on Hub submission commits

### DIFF
--- a/ouroboros/tools/skill_publish.py
+++ b/ouroboros/tools/skill_publish.py
@@ -324,7 +324,10 @@ mutation($input: CreateCommitOnBranchInput!) {
         "variables": {
             "input": {
                 "branch": {"repositoryNameWithOwner": f"{login}/{repo}", "branchName": branch},
-                "message": {"headline": headline},
+                "message": {
+                    "headline": headline,
+                    "body": "Co-authored-by: Ouroboros <311266734+ouroboros-agent@users.noreply.github.com>",
+                },
                 "fileChanges": {"additions": additions},
                 "expectedHeadOid": base_sha,
             }

--- a/tests/test_skill_publish.py
+++ b/tests/test_skill_publish.py
@@ -7,6 +7,7 @@ surfaced in the generated PR body while the secret scan stays enforced.
 """
 from __future__ import annotations
 
+import json
 import types
 
 import pytest
@@ -59,6 +60,34 @@ def _patch_validate(monkeypatch, loaded: LoadedSkill, computed_hash: str = "h") 
     monkeypatch.setattr(skill_publish, "github_token_from_env_or_settings", lambda: "tok")
     monkeypatch.setattr(skill_publish, "find_skill", lambda root, name: loaded)
     monkeypatch.setattr(skill_publish, "compute_content_hash", lambda *a, **k: computed_hash)
+
+
+# --- _commit_payload attribution ------------------------------------------
+
+def test_commit_payload_hardcodes_ouroboros_coauthor(monkeypatch):
+    captured = {}
+
+    def fake_gh_json(_ctx, _args, *, timeout, input_data):
+        captured.update(json.loads(input_data))
+        return {"data": {"createCommitOnBranch": {"commit": {"oid": "commit-sha"}}}}
+
+    monkeypatch.setattr(skill_publish, "_gh_json", fake_gh_json)
+
+    result = skill_publish._commit_payload(
+        types.SimpleNamespace(),
+        "razzant",
+        "OuroborosHub",
+        "submit/demo-v1.0.0",
+        "base-sha",
+        "Add skill: demo v1.0.0",
+        [],
+    )
+
+    assert result == "commit-sha"
+    assert captured["variables"]["input"]["message"] == {
+        "headline": "Add skill: demo v1.0.0",
+        "body": "Co-authored-by: Ouroboros <311266734+ouroboros-agent@users.noreply.github.com>",
+    }
 
 
 # --- _advisory_findings_section (pure) ------------------------------------


### PR DESCRIPTION
## Summary
- Always add the GitHub-recognized Ouroboros co-author trailer to commits created by `submit_skill_to_hub`.
- Add a focused regression test for the GraphQL commit payload.

## Test plan
- [x] `python -m pytest -q tests/test_skill_publish.py`
- [x] `ruff check ouroboros/tools/skill_publish.py tests/test_skill_publish.py --select F`
- [x] Ouroboros checklist review with GPT-5.6 Sol (1M route, high effort) and Claude Fable 5 (high effort), both clean