### PR TITLE
Fix plan review closure and context fallback

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -197,7 +197,7 @@ server.py (Starlette+uvicorn) ← HTTP + WebSocket on configurable host:port (de
       ├── tools/               ← Auto-discovered tool plugins
       │   ├── extension_dispatch.py ← Extension tool dispatch helper extracted from registry.py; preserves liveness, safety, async, and out-of-process error contracts
       │   ├── release_sync.py    ← Release-metadata sync library; advisory_review uses sync_release_metadata before provider spend when VERSION is in scope; _preflight_check uses check_history_limit for P9 row caps; agents can also call it directly for version-carrier sync
-      │   ├── review_synthesis.py ← LLM-based commit-finding synthesis (fail-open to the original findings on synthesis error) plus the strict plan-review parser/aggregator and fingerprint-bound `review_disposition` validator; plan outcomes are exactly `GREEN`, `REVIEW_REQUIRED`, or `REVISE_PLAN`
+      │   ├── review_synthesis.py ← LLM-based commit-finding synthesis (fail-open to the original findings on synthesis error) plus the strict plan-review parser/aggregator, reference-only `review_disposition` validator, and requested/effective context disclosure; plan outcomes are exactly `GREEN`, `REVIEW_REQUIRED`, or `REVISE_PLAN`
       │   ├── ci.py              ← CI trigger and monitoring (GitHub Actions API)
       │   ├── claude_advisory_review.py ← Advisory pre-review tool (read-only Claude Agent SDK)
       │   ├── recent_tasks.py    ← Read-only context recovery tool exposing recent task_results summaries/traces for LLM-first continuation recovery
@@ -206,8 +206,8 @@ server.py (Starlette+uvicorn) ← HTTP + WebSocket on configurable host:port (de
       │   ├── git_pr.py          ← PR integration tools: fetch_pr_ref, create_integration_branch, cherry_pick_pr_commits, stage_adaptations, stage_pr_merge (non-core, require enable_tools)
       │   ├── github.py          ← GitHub integration: issues (list/get/comment/close) + PR tools: list_github_prs, get_github_pr, comment_on_pr (non-core; github.py is in _FROZEN_TOOL_MODULES so PR inspection/comment tools work in packaged builds)
       │   ├── parallel_review.py ← Parallel triad+scope orchestration and verdict aggregation (extracted from git.py)
-      │   ├── plan_review.py     ← Pre-implementation design review (adaptive context levels, shared ReviewCoordinator slots, duplicate model IDs allowed, `plan_task` tool); one scout wave per exact fingerprint waits to a shared boundary, sends every ready non-empty handoff plus explicit omissions to the panel, exact-hash binds included snapshots when still current, and keeps every post-review scout change audit-only. (v6.61.0) Agent-declared `plan_class` (self_mod|external|creative|research) structurally escalates to self_mod when files_to_touch resolve under the system repo (path fact, P5); non-self_mod reviewers get BIBLE+DEVELOPMENT full but ARCHITECTURE as the lossless nav map, context_level defaults to minimal, and planning scouts are framed to the plan's own domain instead of repo archaeology.
-      │   ├── plan_review_runtime.py ← Reviewer-slot execution and plan-envelope resolution policy used by `plan_review.py`
+      │   ├── plan_review.py     ← Pre-implementation design review (adaptive context levels, shared ReviewCoordinator slots, duplicate model IDs allowed, `plan_task` tool); one scout wave per exact requested-envelope fingerprint waits to a shared boundary, sends every ready non-empty handoff plus explicit omissions to the panel, exact-hash binds included snapshots when still current, and keeps every post-review scout change audit-only. Typed non-minimal Atlas/quorum-fit failures rebuild that same wave once at loud `minimal`; `REVIEW_REQUIRED` closes through a separate latest-reference disposition call with no envelope replay. (v6.61.0) Agent-declared `plan_class` (self_mod|external|creative|research) structurally escalates to self_mod when files_to_touch resolve under the system repo (path fact, P5); non-self_mod reviewers get BIBLE+DEVELOPMENT full but ARCHITECTURE as the lossless nav map, context_level defaults to minimal, and planning scouts are framed to the plan's own domain instead of repo archaeology.
+      │   ├── plan_review_runtime.py ← Reviewer-slot execution plus plan-envelope, deadline-rail, and handoff-hash runtime helpers used by `plan_review.py`
       │   ├── review.py          ← Task acceptance review tool plus multi-review adapters backed by the shared review substrate
       │   ├── review_context_atlas.py ← Deterministic bounded-context compiler for scope_review, plan_task, and deep_self_review; raw-inlines selected files and accounts for every tracked path in the manifest. Optional additive `centrality_scores` (rel_path→bonus) consumed in candidate scoring; empty default keeps scope/plan selection byte-identical (deep self-review is the only producer)
       │   ├── query_code.py     ← Read-only structured code intelligence tool (`query_code`) over the code inventory: symbols, definitions, references, callers/callees, impact, structural search, and relevant file ranking (v6.47.0: generalized `root=user_files` for read-only intelligence over an external target, e.g. a benchmark `/app`, with search_code-shape path guards + bounded symlink-safe structural walks)
@@ -2230,9 +2230,10 @@ for the same pinned reviewer — never the reviewer model or the ≥1M window fl
 sizes it PER SLOT from the same calibrated helper — closing the former "planned
 follow-up work" gap that made a Claude plan slot 400 deterministically: a slot the
 shared prompt cannot fit gets a FREE deterministic `preflight_oversize` record instead
-of a guaranteed-400 call, and fewer callable slots than the review quorum is a loud
-typed `PLAN_REVIEW_DEGRADED_PREFLIGHT_OVERSIZE` with NO reviewer called — never a
-silent absence of review.
+of a guaranteed-400 call. If the requested non-minimal prompt leaves fewer callable
+slots than quorum, plan review rebuilds once at loud `minimal`; only a minimal prompt
+that still leaves fewer than quorum returns typed
+`PLAN_REVIEW_DEGRADED_PREFLIGHT_OVERSIZE` with no reviewer called.
 Non-responded scope actor records also surface the provider failure text
 (`error` field in `build_scope_actor_record`) so a deterministic 400 is visible
 in the verdict without observability digging. The scope coverage contract
@@ -2278,23 +2279,29 @@ that, a missing-artifact stop was reported on BOTH branches as an overflow,
 quoting a token count below the budget it claimed to exceed and prescribing a
 diff split that cannot shrink an unchanged artifact. The refusal is also a
 recorded `atlas_refused` ladder step naming what did not assemble, so the
-terminal is explainable after the fact. Both atlas assembly failures are one
-predicate — `review_context_atlas.atlas_assembly_failed` over
-`ATLAS_ASSEMBLY_FAILURE_STATUSES` — consulted by every consumer (scope review,
-plan review, deep self-review) instead of each re-deriving a status test, so a
-new failure status refuses everywhere at once; `atlas_unassembled_required`
-reads the ONE carrier (`manifest["unassembled_required"]`) that discriminates
-the two, and `ATLAS_MISSING_ARTIFACT_REMEDY` is the single remedy sentence for
-the artifact case, since narrowing the reviewed change (a smaller diff, a
-smaller plan, a lower plan `context_level`) leaves the artifact just as
-required. The two terminal causes are not exclusive: an atlas refusal that
+terminal is explainable after the fact. Both atlas assembly failures are
+classified by one predicate — `review_context_atlas.atlas_assembly_failed` over
+`ATLAS_ASSEMBLY_FAILURE_STATUSES` — instead of each consumer re-deriving a
+status test. Scope review and deep self-review remain strict consumers and do
+not review the remainder. Plan review is the deliberate consumer-specific
+carve-out: a typed failure of a requested non-minimal Atlas rebuilds the SAME
+fingerprint/scout wave once at `minimal`, with the generated Atlas absent and a
+loud persisted requested/effective level and reason disclosure. A planned-touch
+snapshot that could not fit stays an explicit omission. The same one-shot
+fallback applies when the final requested prompt leaves fewer than reviewer
+quorum callable; preflight exclusions that still leave quorum do not trigger
+it. If the minimal prompt still cannot fit, review stops. Compiler exceptions and monetary
+budget admission do not trigger fallback. `atlas_unassembled_required` reads
+the ONE carrier (`manifest["unassembled_required"]`) that discriminates the
+typed causes, and `ATLAS_MISSING_ARTIFACT_REMEDY` remains the strict-consumer
+remedy. The two terminal causes are not exclusive: an atlas refusal that
 dropped a required artifact can ITSELF be a hard-budget overflow, and that mixed
 state reports BOTH causes and picks `ATLAS_MIXED_ASSEMBLY_REMEDY`, because either
 single-cause remedy states something false about the other half (read the second
 cause with `atlas_hard_budget_overflowed`; pinned by
-`test_mixed_terminal_reports_both_causes_and_the_mixed_remedy`). The
-`budget_exceeded` and provider-oversize
-outcomes are recorded as evidence but never satisfy the P3 gate, and since v6.80.0
+`test_mixed_terminal_reports_both_causes_and_the_mixed_remedy`). For scope
+review, `budget_exceeded` and provider-oversize outcomes are recorded
+as evidence but never satisfy the P3 gate, and since v6.80.0
 no setting makes them non-blocking — in `max` they block. The P3-aligned remedy
 for a structurally oversized repo stays shrinking/splitting the reviewed tree,
 never lowering the reviewer below the 1M context floor.
@@ -2316,7 +2323,46 @@ the normal actor's authoritative or fail-closed status in `max`.
 
 `plan_review.py` runs the existing multi-model Atlas-backed panel before large implementation plans. Read-only planning scouts use the normal subagent pool and persist full raw handoff artifacts. (v6.79.0) A NEW wave is admitted before launch — and only a new one: worker capacity, the shared `review_helpers.review_wave_budget_gate` (the same admission the reviewer wave and skill review use, no second budget authority; it prices one opening round per scout, a deliberate lower bound), and a consumable window. Each scout's contract deadline is bound to that window (the wave's shared cutoff minus the finalization grace and a margin, the reserve capped at a fraction of a short window) instead of inheriting the parent deadline verbatim, so a scout cannot keep spending past the moment the parent stops reading; a wave whose window has already closed is refused with a typed reason instead of being launched and then omitted. The recovery/collection path is never admitted against — those handoffs are already paid for, and refusing them would abandon spend rather than save it. With delegation disabled (`OUROBOROS_MAX_SUBAGENT_DEPTH=0`) the same gate that refuses any child refuses the scouts, and plan review completes on the existing `degraded_evidence` path. Authoritative wave/review history is the bounded additive `plan_review_state` inside the existing `task_results/<id>.json`, updated under that result's per-file lock; the task-writable `plan_task_handoffs.json` projection is audit-only and is never read for closure or scout identity. Immediately before the first panel dispatch, the host writes the exact planning-scout handoff component of the reviewer input once to a fingerprint-keyed continuity snapshot. Normal retries reuse that handoff snapshot, including pure outage and A→B→A; governance documents, HEAD snapshots, Atlas content, and other live review context are rebuilt. Once a panel attempt is durably recorded, `reviewed_result_hashes` in `plan_review_state` additionally fail closed on included-result drift. An exceptional retry after the snapshot write but before that durable panel record still relies on the host write-once audit projection, which is continuity evidence rather than a security boundary against deliberate self-tampering by the same root task. The host persists every intended scout and one absolute cutoff before the first launch, then persists each issued task id or scheduling failure immediately; if launch completed before that second write, resume recovers the exact durable direct-child id instead of scheduling again. Fingerprint-keyed history therefore survives A→B→A without launching a duplicate wave; an older open `REVIEW_REQUIRED` result is re-presented from cache before it can accept a disposition, and every resume spends only the remainder of the original cutoff. Every successfully launched scout is awaited until terminal state or that shared cutoff; the panel receives every ready non-empty handoff plus exactly one typed omission per unfulfilled scout intent, including bounded redacted scheduling/terminal detail. A reviewer-included snapshot receives the common exact-hash `integrated` disposition when still current. If the child changes after the snapshot entered the prompt, the old hash remains non-authoritative, the paid review still persists once with a bounded `CHILD_RESULT_STALE` warning, and the newer result is audit-only. All task ids in a reviewed planning wave — included or omitted — are excluded from the generic child-absorption gate and root-acceptance quiescence once their review is authoritative, so late arrivals cannot reopen either boundary. A pre-panel unavailable/rail attempt may stop those scouts from holding quiescence open, but completed results remain visible to the generic absorption path until a panel attempt is recorded. Governance documents always come from the system repo, while planned file snapshots and Atlas inventory come from `active_repo_dir_for(ctx)`. A missing/mixed subject root or any planned path escaping that root fails loudly instead of silently reviewing Ouroboros in place of an external workspace.
 
-The reviewer horizon carries the goal, mandatory invariants, scope boundaries, non-goals, chosen existing extension seam, and explicitly rejected expansions together with task aliases, forensic refs, handoffs, and omissions. Reviewers stay generative, but each finding must identify a concrete defect or a concrete smaller existing extension point; there is no numeric finding quota. The only public aggregate values are `GREEN`, `REVIEW_REQUIRED`, and `REVISE_PLAN`. `REVIEW_REQUIRED` may be closed on the same fingerprint without another reviewer call only by a valid fingerprint-bound `review_disposition` that addresses every finding exactly once with `accept | reject | defer`, evidence-based rationale, and a plan-revision reference for accepted findings. `REVISE_PLAN` requires changed plan text and therefore a changed fingerprint followed by a new `plan_task` call. Unknown, duplicate, contradictory, incomplete, or stale dispositions fail closed where a bindable review exists. A VACUOUS `review_disposition` (the empty object schema-filling models emit instead of omitting the optional field) still means "absent" and runs a real wave with a disclosed note. A NON-EMPTY disposition that can close nothing now FAILS FAST (v6.80.0) instead of being discarded before a paid wave: `PLAN_REVIEW_DISPOSITION_UNBINDABLE` reports the claimed fingerprint, the latest stored review fingerprint, the submitted request fingerprint, whether the plan text still matches, any `ENVELOPE_MISMATCH` components, and the two ways forward — the anti-wedge escape ("omit the field entirely") is stated EXPLICITLY in the error text, which is what the v6.65.0/1 silent discard was protecting. A disposition may also HONESTLY bind the wave it NAMES when all FOUR conditions hold: its `review_fingerprint` EQUALS the fingerprint of the envelope being submitted, that fingerprint is the state's `latest_review_fingerprint`, that review is an open `REVIEW_REQUIRED`, and the plan text still hashes to the stored `plan_text_hash`. The first condition is the P3 gate itself: `files_to_touch` is exported in the tool schema as part of the review IDENTITY, so binding a DRIFTED envelope with a prepended `ENVELOPE_MISMATCH` warning let a review of `[a.py]` close a submission for `[a.py, b.py, c.py]` — stale plan-review evidence authorising materially expanded scope. Agent-authored drift is therefore UNBINDABLE (fail-fast, no wave, no money; the escape is to omit the disposition and get a real review of the new envelope). The binding fingerprint is a pure function of the AGENT-PASSED envelope — host-resolved `plan_class` and `context_level` are EXCLUDED (they made the identity unreproducible by the agent), while per-field `component_hashes` stored at wave creation may include resolved values, so `ENVELOPE_MISMATCH` on a BOUND wave now reports exactly that host-resolved drift. Stored fingerprints from earlier releases are invalidated once by this change, harmlessly (the affected review simply re-runs). State-lookup failures stay loud `PLAN_REVIEW_STATE_INVALID` errors, never treated as absence. `scripts/run_plan_review.py` remains a thin operator wrapper over this production panel.
+Planning scouts deliberately keep the shared scheduler's `executor=auto` contract.
+When a harness route is selected and healthy, they run through that harness; when it
+is unavailable, the existing resolver may fall back loudly to native execution. Plan
+review contains no harness-name branch or duplicate route policy.
+
+The reviewer horizon carries the goal, mandatory invariants, scope boundaries,
+non-goals, chosen existing extension seam, rejected expansions, task aliases,
+forensic refs, scout handoffs, and omissions. Reviewers stay generative, but each
+finding must identify a concrete defect or a concrete smaller existing extension
+point; there is no numeric finding quota. The only public aggregate values are
+`GREEN`, `REVIEW_REQUIRED`, and `REVISE_PLAN`. `GREEN` means every responding
+reviewer returned GREEN; a preflight-excluded slot was not called and did not
+vote.
+
+`REVIEW_REQUIRED` is main-agent-first. The agent reads every raw response and
+may `accept | reject | defer` every finding, including all of them. In blocking
+mode it closes the latest result through a second `plan_task` call containing
+`review_disposition` ONLY; the call references the durable fingerprint and
+addresses every finding exactly once, with rationale and a plan-revision
+reference for accepted findings, and makes no LLM call. Plan, goal, scope,
+files, and context are not replayed. Mixed disposition/envelope calls and a
+vacuous disposition-only call are rejected before recording a new attempt.
+Closure is allowed only when the claimed fingerprint is both the latest review
+and the still-current open attempt, and its wave is `reviewed`, `integrated`,
+non-degraded `REVIEW_REQUIRED`; exact replay is idempotent. Thus a newer raw,
+invalid, or unavailable plan attempt cannot resurrect older authority. In
+advisory mode the agent may proceed without closure under the existing loud
+host disclosure.
+
+Quorum `REVISE_PLAN` cannot be converted into a disposition. Blocking mode
+requires changed plan text, a new requested-envelope fingerprint, and a fresh
+panel. Advisory mode may still proceed under loud host disclosure and the main
+agent's rationale. Reviewer unavailability remains retryable and
+non-dispositionable. Ordinary invalid review-mode envelopes continue to record
+a domain-separated current attempt before semantic validation, preventing a
+fallback to stale GREEN/REVIEW_REQUIRED. State-lookup failures stay loud
+`PLAN_REVIEW_STATE_INVALID` errors. The requested agent envelope remains the
+fingerprint identity; a host-resolved effective context level is evidence
+metadata and never creates a second wave. `scripts/run_plan_review.py` remains
+a thin operator wrapper over this production panel.
 
 Force-plan reuses those authorities rather than adding a second review state machine. `ouroboros/tools/plan_review.py` owns the tool workflow and durable transitions; its small sibling `ouroboros/tools/plan_review_runtime.py` owns reviewer execution and plan-envelope resolution. The bounded `plan_review_state` in `task_results/<id>.json` remains the durable review SSOT, while `OUROBOROS_REVIEW_ENFORCEMENT` remains the owner policy SSOT. Every submitted envelope that reaches `plan_task` supersedes prior authority: invalid plan/goal/scope input stores a domain-separated open attempt, while a valid envelope stores its canonical fingerprint before repository/path validation. The reducer therefore cannot resurrect an older durable GREEN when a newer envelope fails validation. Reviewer unavailability remains non-dispositionable audit evidence plus `current_attempt=unavailable`; retrying the unchanged plan reuses the paid scout wave and reruns the panel against the immutable first-attempt scout snapshot. In `blocking`, the LLM-first obligation permits analysis and non-mutating preparation while review recovers but begins implementation only after closure or a real task-wide rail; this is deliberately not a mechanical write/shell gate. In `advisory`, a reviewed-open or unavailable attempt may proceed by agent judgment with a host-owned disclosure. A planning deadline skip records `current_attempt=rail_degraded` before returning, so the same durable reducer releases best-effort work instead of re-requesting an impossible `plan_task`. Existing deadline, budget, provider, and round rails preserve the open planning state in the disclosure; they never replace the useful delivery candidate with `SWARM_INITIATIVE_BLOCKED`.
 

--- a/docs/CHECKLISTS.md
+++ b/docs/CHECKLISTS.md
@@ -645,6 +645,13 @@ and an agent-selected context level: `minimal`, `localized`, `broad`, or
 but omits the generated Atlas; `localized` adds a bounded neighborhood around
 planned files, `broad` is for shared contracts, and `constitutional` is
 reserved for self-evolution / immune-system surfaces.
+If a requested non-minimal Atlas has a typed assembly failure, or its final
+prompt leaves fewer than reviewer quorum callable, plan review rebuilds the
+same fingerprint/scout wave once at loud `minimal`. Reviewers must judge only
+the evidence actually present; the requested/effective levels, cause, Atlas
+omission, and any planned-touch snapshot omission remain explicit. A compiler
+exception, monetary budget refusal, or minimal prompt that still does not fit
+does not trigger another fallback.
 
 **Reviewer role is GENERATIVE, not audit.** The primary job is to contribute
 ideas the implementer may not see, using the repository evidence available for
@@ -699,7 +706,8 @@ duplicates allowed) via `config.adaptive_quorum(N)` — the same reviewer-slot
 SSOT used by commit/scope/skill review: `2` for `N ≥ 3`, `N` for `N` in
 `{1, 2}` (i.e. `min(2, N)`).
 
-- **GREEN** — all reviewers PASS. Read every reviewer's `## PROPOSALS` section
+- **GREEN** — all responding reviewers PASS. A preflight-excluded slot was not
+  called and did not vote. Read every called reviewer's `## PROPOSALS` section
   (they are the point of this call), then proceed with implementation.
 - **REVIEW_REQUIRED** — one or more of: (a) a `REVISE_PLAN` count BELOW the
   adaptive quorum (minority dissent — e.g. exactly one dissent in a 2+-slot
@@ -707,25 +715,37 @@ SSOT used by commit/scope/skill review: `2` for `N ≥ 3`, `N` for `N` in
   degradation occurred (a reviewer errored, timed out, or returned an
   unparseable response, so `GREEN` cannot be confirmed). Read every reviewer's
   full response and all PROPOSALS before deciding: a single dissenting reviewer
-  often sees the structural issue the others missed.
+  often sees the structural issue the others missed. Findings are inputs to the
+  main agent, which may accept, reject, or defer each one, including all of them.
 - **REVISE_PLAN** — a `REVISE_PLAN` count **at or above `adaptive_quorum(N)`**
   (2-of-N for 3+ slots, both in a 2-slot setup, and the lone reviewer in a
-  1-slot setup). Quorum confirms a structural problem with the plan. Redesign
-  before writing code. A single dissent in a multi-reviewer setup surfaces as
-  `REVIEW_REQUIRED`, not `REVISE_PLAN`.
+  1-slot setup). Quorum confirms a structural problem with the plan. Blocking
+  mode requires changed plan text and a fresh panel; advisory mode may proceed
+  only under loud host disclosure and the main agent's rationale. A single
+  dissent in a multi-reviewer setup surfaces as `REVIEW_REQUIRED`, not
+  `REVISE_PLAN`.
 
 ### Rules for reviewers
 
 - Outside the force-plan gate, `plan_review` remains advisory: the implementer
   decides what to do with the feedback. Force-plan follows the owner-selected
   `OUROBOROS_REVIEW_ENFORCEMENT`: `blocking` holds normal finalization until
-  `GREEN` or a valid fingerprint-bound disposition closes `REVIEW_REQUIRED`,
+  `GREEN` or a valid reference-only disposition closes `REVIEW_REQUIRED`,
   while `advisory` permits agent judgment and preserves an explicit disclosure.
+  The disposition is a separate `plan_task` call containing only
+  `review_disposition`; it may close only the latest still-current, reviewed,
+  integrated, non-degraded `REVIEW_REQUIRED` fingerprint. It never resends the
+  plan envelope or calls a reviewer, covers every finding exactly once, and
+  exact replay is idempotent. Mixed disposition/envelope calls and vacuous
+  disposition-only calls are rejected before recording a new attempt. Ordinary
+  invalid review-mode envelopes still record a new current attempt so stale
+  review authority cannot revive.
   Reviewer unavailability is audit evidence, not a disposition-able verdict:
   blocking retries the same fingerprint/wave against its immutable first-panel
   scout snapshot until review returns or a real rail fires.
   `REVISE_PLAN` still requires changed plan text/fingerprint and a fresh review
-  in the blocking lane. Blocking permits analysis and non-mutating preparation
+  in the blocking lane; advisory may proceed only with loud disclosure and the
+  main agent's rationale. Blocking permits analysis and non-mutating preparation
   while review recovers, but implementation starts only after closure or a real
   task-wide rail. This remains an LLM-first obligation, not a per-write/per-shell
   gate; real deadline, budget, provider, or round rails preserve useful best-effort

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -543,8 +543,11 @@ deliverable) while tripling cost. The agent must choose `context_level`
 explicitly for `self_mod` plans; non-self_mod plans may omit it (defaults to
 `minimal`). That field controls only the generated repository Atlas: `minimal`
 omits Atlas accounting for bounded/local plans, while `localized`, `broad`, and
-`constitutional` add progressively larger Atlas packs. Planning scouts are
-likewise class-framed: `self_mod` scouts keep the repo-archaeology emphasis;
+`constitutional` add progressively larger Atlas packs. A typed non-minimal
+Atlas assembly failure or final quorum-fit failure rebuilds the same requested
+fingerprint/scout wave once at loud `minimal`; compiler exceptions, monetary
+budget refusal, and a minimal prompt that still cannot fit do not. Planning
+scouts are likewise class-framed: `self_mod` scouts keep the repo-archaeology emphasis;
 external/creative/research scouts are steered to the plan's own domain
 (requirements, verification, sources, design) and never default to Ouroboros
 internals.
@@ -554,7 +557,9 @@ the system repository; planned snapshots and Atlas inventory always use
 `active_repo_dir_for(ctx)`. A workspace/subject mismatch, an unavailable root,
 or a `files_to_touch` path escaping that subject must fail loudly. Do not fall
 back to reviewing the Ouroboros repo for an external plan. Read-only scouts use
-the existing worker pool and persist full raw handoffs. Wait for every launched
+the existing worker pool with its generic `executor=auto` route (selected
+healthy harness first, existing loud native fallback) and persist full raw
+handoffs. Wait for every launched
 scout until it is terminal or the shared swarm ceiling is reached; give the
 panel every ready non-empty handoff and an explicit reason for every omission.
 Launch only one scout wave per exact plan fingerprint. A handoff is marked
@@ -566,13 +571,18 @@ shared evidence horizon—not copied corpora or a second planning engine.
 The planning horizon must state the goal, mandatory invariants, scope
 boundaries, non-goals, chosen existing extension seam, and explicitly rejected
 expansions. Plan review publishes exactly `GREEN`, `REVIEW_REQUIRED`, or
-`REVISE_PLAN`. A `REVIEW_REQUIRED` result may close without a second LLM call
-only through `review_disposition` bound to the immediately preceding plan
-fingerprint: every finding appears exactly once as `accept`, `reject`, or
-`defer`, with evidence-based rationale, and each acceptance names the matching
-plan revision. `REVISE_PLAN` requires changed plan text/fingerprint and another
-`plan_task` call. Unknown, stale, duplicate, contradictory, or incomplete
-dispositions fail closed. Reviewers remain generative, but a finding must name
+`REVISE_PLAN`. `REVIEW_REQUIRED` findings are inputs: the main agent may accept,
+reject, or defer any/all of them. Blocking closes the latest still-current,
+reviewed, integrated, non-degraded result without a second LLM call through a
+separate `plan_task` call containing `review_disposition` only: every finding
+appears exactly once with evidence-based rationale, and each acceptance names
+the matching plan revision. Never replay plan/goal/scope/files/context with the
+disposition. Mixed calls and vacuous disposition-only calls fail before a new
+attempt is recorded; exact replay is idempotent. Blocking `REVISE_PLAN` requires
+changed plan text/fingerprint and another panel, while advisory may proceed only
+under loud host disclosure and the main agent's rationale. Unknown, stale,
+duplicate, contradictory, or incomplete dispositions fail closed. Reviewers
+remain generative, but a finding must name
 a concrete defect or a concrete smaller existing extension seam; never require
 a fixed number of findings.
 
@@ -589,7 +599,8 @@ the remaining live reviewer context is rebuilt. An unavailable reviewer
 never becomes a disposition-able verdict; a repeat call reuses that handoff snapshot and
 retries the panel, including after A→B→A. Blocking stays in
 analysis and non-mutating preparation until closure or a real task-wide rail;
-advisory may proceed by agent judgment with a host-owned disclosure. A planning
+advisory may proceed by agent judgment with a host-owned disclosure, including
+an explicitly rejected `REVISE_PLAN`. A planning
 deadline skip records a typed rail attempt before returning so the reducer cannot
 misread it as an absent `plan_task` call.
 The short-lived Swarm router admits one new root and transfers the intent; it

--- a/ouroboros/loop.py
+++ b/ouroboros/loop.py
@@ -274,8 +274,8 @@ def _force_plan_reminder(decision: Dict[str, Any]) -> str:
     if outcome == "REVIEW_REQUIRED":
         return (
             "[SWARM_INITIATIVE] Blocking plan review remains REVIEW_REQUIRED. Re-call "
-            "plan_task with the exact fingerprint and a complete review_disposition, then "
-            "continue; do not rerun the reviewer wave."
+            "plan_task with a complete review_disposition as the only field, naming the "
+            "latest fingerprint, then continue; do not resend the plan or rerun reviewers."
         )
     if outcome == "REVISE_PLAN":
         return (

--- a/ouroboros/task_results.py
+++ b/ouroboros/task_results.py
@@ -657,6 +657,16 @@ def _validated_plan_review_state(value: Any) -> Dict[str, Any]:
     attempt = copied.get("current_attempt", {})
     if not isinstance(attempt, dict):
         raise ValueError("PLAN_REVIEW_STATE_INVALID: current_attempt must be an object")
+    if not attempt and latest:
+        # Schema v1 originally had no current_attempt pointer: its validated
+        # latest review was the current authority. Normalize it in-memory; the
+        # next locked write persists it, while any new raw attempt supersedes it.
+        attempt = {
+            "fingerprint": latest,
+            "status": "open",
+            "reason": "legacy_latest_review",
+        }
+        copied["current_attempt"] = attempt
     if attempt:
         fingerprint = str(attempt.get("fingerprint") or "")
         status = str(attempt.get("status") or "")
@@ -871,7 +881,6 @@ def reserve_plan_review_wave(
     plan_text_hash: str,
     scout_roles: List[str],
     cutoff_at: str,
-    component_hashes: Optional[Dict[str, str]] = None,
 ) -> tuple[Dict[str, Any], bool]:
     created = False
 
@@ -885,9 +894,6 @@ def reserve_plan_review_wave(
         state["waves"].append({
             "request_fingerprint": fingerprint,
             "plan_text_hash": plan_text_hash,
-            # Per-field hashes of the envelope this wave was created from — diagnostics
-            # only (ENVELOPE_MISMATCH), never part of the binding identity.
-            "component_hashes": dict(component_hashes or {}),
             "created_at": utc_now_iso(),
             "scout_cutoff_at": cutoff_at,
             "phase": "scheduling",
@@ -1022,8 +1028,14 @@ def record_plan_review_result(
         wave = next((item for item in state["waves"] if item["request_fingerprint"] == fingerprint), None)
         if wave is None:
             raise ValueError("PLAN_REVIEW_STATE_INVALID: reviewed wave is missing")
-        if require_latest and str(state.get("latest_review_fingerprint") or "") != fingerprint:
-            raise ValueError("PLAN_REVIEW_DISPOSITION_STALE: review is not immediately preceding")
+        current = state.get("current_attempt")
+        if require_latest and (
+            str(state.get("latest_review_fingerprint") or "") != fingerprint
+            or not isinstance(current, dict)
+            or str(current.get("status") or "") != "open"
+            or str(current.get("fingerprint") or "") != fingerprint
+        ):
+            raise ValueError("PLAN_REVIEW_DISPOSITION_STALE: review is not latest still-current")
         existing_review = wave.get("review") if isinstance(wave.get("review"), dict) else {}
         if existing_review.get("closed"):
             existing_comparable = copy.deepcopy(existing_review)

--- a/ouroboros/tools/plan_review.py
+++ b/ouroboros/tools/plan_review.py
@@ -39,7 +39,9 @@ from ouroboros.tools.plan_review_runtime import (
     classify_reviewer_error as _classify_reviewer_error,  # noqa: F401 — test-compat re-export
     get_review_models as _get_review_models,
     load_plan_checklist as _load_plan_checklist,
+    plan_deadline_skip as _plan_deadline_skip,
     record_raw_plan_request_attempt as _record_raw_plan_request_attempt,
+    reviewed_handoff_hashes as _reviewed_handoff_hashes,
     resolve_plan_class as _resolve_plan_class,
     run_plan_review_slots as _run_plan_review_slots,
     validate_plan_request_envelope as _validate_plan_request_envelope,
@@ -49,7 +51,6 @@ from ouroboros.tools.review_context_atlas import (
     ReviewContextAtlasRequest,
     atlas_assembly_failed,
     atlas_assembly_failure_reason,
-    atlas_assembly_remedy,
     compile_review_context_atlas,
 )
 from ouroboros.tools.review_helpers import (
@@ -73,23 +74,21 @@ from ouroboros.tools.review_synthesis import (
     format_plan_review_output as _format_output,
     normalize_plan_scope as _normalize_plan_scope,
     parse_plan_review_signal,
-    bindable_claimed_wave as _bindable_claimed_wave,
     minted_plan_slot_ids as _minted_plan_slot_ids,  # noqa: F401 — test-compat re-export
     per_slot_input_token_limits as _per_slot_input_token_limits,
-    plan_envelope_mismatch_note as _envelope_note,
-    plan_review_component_hashes as _plan_component_hashes,
     plan_review_fingerprint as _plan_request_fingerprint,
     plan_context_target_tokens as _plan_context_target_tokens,
     plan_slot_fit_with_identity as _plan_slot_fit_with_identity,
     plan_text_fingerprint,
     resolve_plan_context_level as _resolve_plan_context_level,
     quorum_input_token_limit as _quorum_input_token_limit,
-    unbindable_disposition_error as _unbindable_disposition_error,
     planning_handoff_selection as _planning_handoff_selection,
     planning_scout_framing as _planning_scout_framing,
     planning_scout_wave_plan as _planning_scout_wave_plan,
     planning_swarm_context as _planning_swarm_context,
+    render_plan_context_degradation as _render_plan_context_degradation,
     render_plan_review_result as _render_existing_plan_review,
+    replay_closed_review_disposition as _replay_closed_review_disposition,
     summarize_plan_review_results as _summarize_plan_review_results,
     validate_plan_review_disposition,
 )
@@ -142,6 +141,9 @@ class _PlanReviewFinalization:
     request_fingerprint: str
     degraded_scout_note: str
     reviewed_result_hashes: dict[str, str]
+    requested_context_level: str = ""
+    effective_context_level: str = ""
+    context_degradation_reason: str = ""
 
 
 def get_tools():
@@ -164,14 +166,16 @@ def get_tools():
                     "slot as the commit triad); duplicate model IDs are allowed and count as separate stochastic "
                     "slots. Returns structured feedback from every reviewer slot with detailed explanations and "
                     "alternative approaches. GREEN closes the exact plan fingerprint; REVIEW_REQUIRED "
-                    "is closed by an exact fingerprint-bound review_disposition without another LLM call; "
-                    "REVISE_PLAN requires changed plan text and a fresh review."
+                    "is closed by a second call containing review_disposition ONLY, bound to the latest "
+                    "stored fingerprint and requiring no new LLM call; "
+                    "Blocking REVISE_PLAN requires changed plan text and a fresh review; "
+                    "advisory mode may proceed under loud disclosure with main-agent rationale."
                 ),
                 "parameters": {
                     "type": "object",
                     "properties": {
-                        "plan": {"type": "string", "description": "Describe what you plan to implement: which files you will change, what the key design decisions are, and what you will NOT change."},
-                        "goal": {"type": "string", "description": "The high-level goal of the task (what problem is being solved)."},
+                        "plan": {"type": "string", "description": "Review mode only: describe what you plan to implement, including files, key decisions, and non-goals. Omit this field in disposition mode."},
+                        "goal": {"type": "string", "description": "Review mode only: the high-level goal. Omit this field in disposition mode."},
                         "plan_class": {
                             "type": "string",
                             "enum": ["self_mod", "external", "creative", "research"],
@@ -184,7 +188,7 @@ def get_tools():
                                 "a navigation map) and task-fit scout framing."
                             ),
                         },
-                        "files_to_touch": {"type": "array", "description": "Optional list of repo-relative file paths you plan to modify. Their current content (HEAD snapshot) will be injected so reviewers can reason about concrete code, not just abstract plans. This list is PART OF THE REVIEW IDENTITY: changing it changes the review fingerprint, so a review_disposition can only close a review submitted with the SAME list.", "items": {"type": "string"}},
+                        "files_to_touch": {"type": "array", "description": "Review mode only: repo-relative files you plan to modify. Their HEAD snapshots inform reviewers, and the list enters the review fingerprint. Omit this field in disposition mode; never resend it with review_disposition.", "items": {"type": "string"}},
                         "context_level": {
                             "type": "string",
                             "enum": ["minimal", "localized", "broad", "constitutional"],
@@ -221,9 +225,10 @@ def get_tools():
                             "type": "object",
                             "additionalProperties": False,
                             "description": (
-                                "Resolve a prior REVIEW_REQUIRED result for the exact unchanged plan "
-                                "fingerprint without another reviewer call. Every reported finding id "
-                                "must appear exactly once. Omit the field on a first submission."
+                                "Disposition mode only: resolve the latest integrated, non-degraded "
+                                "REVIEW_REQUIRED result without another reviewer call. Send ONLY this "
+                                "field; do not resend plan, goal, scope, files, or context. Every reported "
+                                "finding id must appear exactly once."
                             ),
                             "properties": {
                                 "review_fingerprint": {"type": "string"},
@@ -259,9 +264,9 @@ def get_tools():
                             "description": "Whether generated Atlas context may include related tests.",
                         },
                     },
-                    # context_level is enforced HOST-SIDE by _resolve_plan_context_level:
-                    # explicit-choice for self_mod, optional (defaults minimal) otherwise.
-                    "required": ["plan", "goal"],
+                    # The handler enforces two mutually exclusive modes: plan+goal for a
+                    # fresh review, or review_disposition alone for a stored result.
+                    "required": [],
                 },
             },
             handler=_handle_plan_task,
@@ -271,14 +276,37 @@ def get_tools():
 
 
 def _handle_plan_task(ctx: ToolContext, **params) -> str:
+    raw_disposition = params.get("review_disposition")
+    disposition_present = "review_disposition" in params
+    vacuous_disposition = _vacuous_review_disposition(raw_disposition)
+    envelope_fields = sorted(set(params) - {"review_disposition"})
+    if disposition_present and raw_disposition is not None and not vacuous_disposition:
+        if envelope_fields:
+            return (
+                "ERROR: PLAN_REVIEW_DISPOSITION_MIXED_ENVELOPE: disposition mode accepts "
+                "review_disposition only. Do not resend plan, goal, scope, files_to_touch, "
+                "or context fields; edits require a new review-mode call without "
+                "review_disposition. No plan attempt was recorded."
+            )
+        if not isinstance(raw_disposition, dict):
+            return "ERROR: PLAN_REVIEW_DISPOSITION_INVALID: review_disposition must be an object"
+        claimed = str(raw_disposition.get("review_fingerprint") or "").strip()
+        if not claimed:
+            return "ERROR: PLAN_REVIEW_DISPOSITION_INVALID: review_fingerprint is required"
+        result = _reuse_or_disposition_plan_review(ctx, claimed, raw_disposition)
+        return result or "ERROR: PLAN_REVIEW_DISPOSITION_UNBINDABLE: stored review disappeared"
+    if disposition_present and vacuous_disposition and not envelope_fields:
+        return (
+            "ERROR: PLAN_REVIEW_DISPOSITION_EMPTY: submit non-empty plan and goal for "
+            "review mode, or a "
+            "complete review_disposition as the only field for disposition mode. "
+            "No plan attempt was recorded."
+        )
     try:
         state_root, state_task_id = _planning_state_location(ctx)
         _record_raw_plan_request_attempt(params, state_root, state_task_id, reason="plan_envelope_pending")
     except (OSError, TimeoutError, ValueError) as exc:
         return f"ERROR: PLAN_REVIEW_STATE_PERSIST_FAILED: {exc}"
-    review_disposition = params.get("review_disposition")
-    vacuous_disposition = _vacuous_review_disposition(review_disposition)
-    review_disposition = None if vacuous_disposition else review_disposition
     request = _PlanReviewRequest(
         plan=str(params.get("plan") or ""),
         goal=str(params.get("goal") or ""),
@@ -288,7 +316,7 @@ def _handle_plan_task(ctx: ToolContext, **params) -> str:
         include_tests=bool(params.get("include_tests", False)),
         plan_class=str(params.get("plan_class") or ""),
         scope=params.get("scope"),
-        review_disposition=review_disposition,
+        review_disposition=None,
     )
     try:
         try:
@@ -685,7 +713,6 @@ def _start_planning_swarm(
             wave, created = reserve_plan_review_wave(
                 root, parent_id, fingerprint=fingerprint, plan_text_hash=plan_text_fingerprint(plan),
                 scout_roles=roles, cutoff_at=(_planning_now() + timedelta(seconds=max_wait)).isoformat(),
-                component_hashes=_plan_component_hashes(request),
             )
             resumed = not created
             if created:
@@ -744,24 +771,6 @@ def _start_planning_swarm(
                 "task_ids": task_ids, "handoffs": handoffs, "resumed": resumed}
     return {"started": True, "task_ids": task_ids, "handoffs": handoffs, "resumed": resumed,
             "degraded_evidence": not bool(completed)}
-
-
-def _reviewed_handoff_hashes(handoffs: dict) -> dict[str, str]:
-    """Hash the exact in-memory scout snapshots before the panel is dispatched."""
-    included = [str(item) for item in (handoffs.get("included_task_ids") or []) if str(item)]
-    wait = handoffs.get("wait") if isinstance(handoffs.get("wait"), dict) else {}
-    tasks = wait.get("tasks") if isinstance(wait.get("tasks"), dict) else {}
-    from ouroboros.tools.join_ledger import _child_result_sha256
-
-    result: dict[str, str] = {}
-    for child_task_id in included:
-        snapshot = tasks.get(child_task_id)
-        if not isinstance(snapshot, dict):
-            raise ValueError(
-                f"PLAN_REVIEW_STATE_INVALID: included scout {child_task_id} has no reviewed snapshot"
-            )
-        result[child_task_id] = _child_result_sha256(snapshot)
-    return result
 
 
 def _mark_planning_handoffs_consumed(ctx: ToolContext, handoffs: dict) -> dict:
@@ -964,55 +973,36 @@ def _planning_disposition_warning_note(handoffs: dict) -> str:
     )
 
 
-def _replay_closed_review_disposition(
-    review: dict,
-    fingerprint: str,
-    disposition: dict,
-) -> str:
-    """Accept only a semantic replay of the disposition that already closed review."""
-    updated, error = validate_plan_review_disposition(review, fingerprint, disposition)
-    if error or updated is None:
-        return error
-
-    def _signature(value: object) -> tuple[str, tuple[tuple[str, str, str, str], ...]]:
-        payload = value if isinstance(value, dict) else {}
-        items = payload.get("items") if isinstance(payload.get("items"), list) else []
-        normalized = sorted(
-            (
-                str(item.get("finding_id") or ""),
-                str(item.get("decision") or ""),
-                str(item.get("rationale") or ""),
-                str(item.get("plan_revision") or ""),
-            )
-            for item in items
-            if isinstance(item, dict)
-        )
-        return str(payload.get("review_fingerprint") or ""), tuple(normalized)
-
-    if _signature(review.get("disposition")) != _signature(updated.get("disposition")):
-        return (
-            "ERROR: PLAN_REVIEW_DISPOSITION_IMMUTABLE: this exact review was already "
-            "closed by a different disposition."
-        )
-    return _render_existing_plan_review(review, cached=True)
-
-
 def _reuse_or_disposition_plan_review(
     ctx: ToolContext,
     fingerprint: str,
     review_disposition: dict | None,
-    plan_text_hash: str = "", request: _PlanReviewRequest | None = None,
+    plan_text_hash: str = "",
 ) -> str | None:
     if _vacuous_review_disposition(review_disposition):
         review_disposition = None  # vacuous == absent (see review_synthesis)
-    root, task_id = _planning_state_location(ctx)
     try:
+        root, task_id = _planning_state_location(ctx)
         state = load_plan_review_state(root, task_id)
     except (OSError, TimeoutError, ValueError) as exc:
         return "ERROR: PLAN_REVIEW_STATE_INVALID: " + str(exc)
     wave = plan_review_wave(state, fingerprint)
     review = wave.get("review") if isinstance((wave or {}).get("review"), dict) else {}
     expected_fp = str(review.get("request_fingerprint") or "")
+    latest = str(state.get("latest_review_fingerprint") or "")
+    attempt = state.get("current_attempt") if isinstance(state.get("current_attempt"), dict) else {}
+    disposition_is_current = (
+        str(attempt.get("status") or "") == "open"
+        and str(attempt.get("fingerprint") or "") == fingerprint
+    )
+    if review_disposition is not None and (
+        fingerprint != latest or not disposition_is_current
+    ):
+        return (
+            "ERROR: PLAN_REVIEW_DISPOSITION_STALE: disposition mode can close only the "
+            "latest still-current review; a newer or unavailable plan attempt supersedes "
+            f"it (latest={latest or 'none'}, claimed={fingerprint}). No plan attempt was recorded."
+        )
     prior_revise = next((
         item for item in state.get("waves") or []
         if isinstance(item.get("review"), dict)
@@ -1022,19 +1012,25 @@ def _reuse_or_disposition_plan_review(
     ), None)
     if prior_revise is not None:
         return (
-            "ERROR: PLAN_REVIEW_REVISION_REQUIRED: REVISE_PLAN requires changed plan "
-            "text as well as a new request fingerprint."
+            "ERROR: PLAN_REVIEW_REVISION_REQUIRED: blocking mode requires changed plan "
+            "text and a fresh fingerprint; advisory mode may instead proceed only under "
+            "the host's loud disclosure."
         )
     if not review or expected_fp != fingerprint:
         if review_disposition is None:
             return None
-        bound = _bindable_claimed_wave(state, review_disposition, plan_text_hash, fingerprint)
-        if bound is None:
-            return _unbindable_disposition_error(
-                state, fingerprint, review_disposition, plan_text_hash, request,
-            )
-        wave, fingerprint = bound, str(bound.get("request_fingerprint") or "")
-        review = wave.get("review") if isinstance(wave.get("review"), dict) else {}
+        return (
+            "ERROR: PLAN_REVIEW_DISPOSITION_UNBINDABLE: the latest fingerprint has no "
+            "stored reviewer result. No plan attempt was recorded."
+        )
+    if review_disposition is not None and (
+        str((wave or {}).get("phase") or "") != "reviewed"
+        or str((wave or {}).get("review_evidence_status") or "integrated") != "integrated"
+    ):
+        return (
+            "ERROR: PLAN_REVIEW_DISPOSITION_NOT_READY: the latest reviewer result is not "
+            "fully integrated into durable scout evidence. No plan attempt was recorded."
+        )
     if str((wave or {}).get("review_evidence_status") or "") == "pending":
         try:
             wave = _mark_planning_handoffs_consumed(ctx, dict(wave or {}))
@@ -1063,9 +1059,15 @@ def _reuse_or_disposition_plan_review(
     aggregate = str(review.get("aggregate_signal") or "")
     if aggregate == "REVISE_PLAN":
         return (
-            "ERROR: PLAN_REVIEW_REVISION_REQUIRED: this unchanged fingerprint already "
-            "received REVISE_PLAN. Change the plan text and call plan_task again; no "
-            "duplicate scout or reviewer wave was started."
+            "ERROR: PLAN_REVIEW_REVISION_REQUIRED: this unchanged fingerprint received "
+            "REVISE_PLAN. Blocking mode requires changed plan text and a fresh panel; "
+            "advisory mode may proceed only under loud host disclosure and the main "
+            "agent's rationale. A disposition cannot override it."
+        )
+    if review_disposition is not None and aggregate != "REVIEW_REQUIRED":
+        return (
+            "ERROR: PLAN_REVIEW_DISPOSITION_NOT_APPLICABLE: the latest review does not "
+            "require a main-agent disposition."
         )
     if bool(review.get("closed")):
         if review_disposition is not None:
@@ -1081,8 +1083,7 @@ def _reuse_or_disposition_plan_review(
             review, cached=True,
         )
     if review_disposition is not None:
-        note = _envelope_note(wave, request)
-        return note + _apply_review_disposition(ctx, audit, review, fingerprint, review_disposition)
+        return _apply_review_disposition(ctx, audit, review, fingerprint, review_disposition)
     if str(state.get("latest_review_fingerprint") or "") != fingerprint:
         try:
             represented = represent_plan_review(
@@ -1100,51 +1101,13 @@ def _reuse_or_disposition_plan_review(
         )
     return (
         "ERROR: PLAN_REVIEW_DISPOSITION_REQUIRED: this unchanged fingerprint already "
-        "received REVIEW_REQUIRED. Re-call plan_task with review_disposition covering "
+        "received REVIEW_REQUIRED. Re-call plan_task with review_disposition as the only "
+        "field, covering "
         f"every finding. fingerprint={fingerprint}; finding_ids="
         + json.dumps([
             item.get("finding_id") for item in (review.get("findings") or [])
             if isinstance(item, dict)
         ], ensure_ascii=False)
-    )
-
-
-def _plan_deadline_skip(ctx: ToolContext, *, emit: bool = False) -> str:
-    from ouroboros.config import get_plan_task_deadline_min_sec
-
-    metadata = getattr(ctx, "task_metadata", {})
-    metadata = metadata if isinstance(metadata, dict) else {}
-    deadline = parse_deadline_ts(metadata.get("deadline_at"))
-    if deadline is None:
-        return ""
-    remaining = (deadline - _planning_now()).total_seconds()
-    scaled = max(0.0, remaining / 4.0)
-    minimum = get_plan_task_deadline_min_sec()
-    if remaining > 0 and scaled >= minimum:
-        return ""
-    if emit:
-        try:
-            event_queue = getattr(ctx, "event_queue", None)
-            if event_queue is not None:
-                event_queue.put_nowait({
-                    "type": "plan_task_deadline_skip",
-                    "task_id": str(getattr(ctx, "task_id", "") or ""),
-                    "remaining_sec": round(remaining, 1),
-                    "scaled_ceiling_sec": round(scaled, 1),
-                    "min_useful_sec": minimum,
-                    "ts": utc_now_iso(),
-                })
-        except Exception:
-            pass
-    cause = (
-        "the task deadline has expired; no new planning scout or reviewer work was started."
-        if remaining <= 0 else
-        f"insufficient time for useful planning — remaining {int(remaining)}s gives a "
-        f"swarm window of {int(scaled)}s (< {int(minimum)}s useful floor)."
-    )
-    return (
-        f"PLAN_TASK_SKIPPED_DEADLINE: {cause} Proceed with your own best plan "
-        "directly; do not re-call plan_task under this deadline."
     )
 
 
@@ -1182,7 +1145,11 @@ def _finalize_plan_review_output(
             for item in (planning_handoffs.get("omissions") or [])
             if isinstance(item, dict) and str(item.get("task_id") or "")
         ],
+        "requested_context_level": finalization.requested_context_level,
+        "effective_context_level": finalization.effective_context_level,
     }
+    if finalization.context_degradation_reason:
+        review_record["context_degradation_reason"] = finalization.context_degradation_reason
     if planning_handoffs:
         try:
             wave = record_plan_review_result(
@@ -1219,21 +1186,26 @@ def _finalize_plan_review_output(
 
     if reviewer_slots_degraded:
         next_step = (
-            "Reviewer availability prevented an authoritative verdict. Re-call plan_task "
-            "with the same unchanged plan and no review_disposition; the existing scout "
+            "Reviewer availability prevented an authoritative verdict. Re-submit the same "
+            "unchanged plan in review mode without review_disposition; the existing scout "
             "wave is reused while the reviewer panel retries."
         )
     elif aggregate_signal == "GREEN":
         next_step = "Proceed with the reviewed plan."
     elif aggregate_signal == "REVIEW_REQUIRED":
         next_step = (
-            "Re-call plan_task with this exact unchanged fingerprint and a "
-            "review_disposition covering every finding id; that path makes no new LLM call."
+            "Re-call plan_task with review_disposition as the only field, naming this "
+            "fingerprint and covering every finding id. Do not resend or edit the plan, "
+            "goal, scope, files, or context; this path makes no new LLM call. Unanimous "
+            "GREEN is not required: the main agent may accept, reject, or defer each finding. "
+            "Blocking mode requires that closure; advisory mode may proceed under the "
+            "host-owned loud disclosure without pretending the review was GREEN."
         )
     else:
         next_step = (
-            "Change the plan text so its fingerprint changes, then call plan_task again. "
-            "A disposition cannot override REVISE_PLAN."
+            "Blocking mode requires changed plan text and a fresh fingerprint review. "
+            "Advisory mode may proceed only under loud host disclosure and the main "
+            "agent's rationale. A disposition cannot override REVISE_PLAN."
         )
     footer = "\n".join([
         "", "## Plan Review Contract", "", f"**Plan fingerprint:** `{request_fingerprint}`",
@@ -1256,8 +1228,14 @@ def _finalize_plan_review_output(
         )
     else:
         availability_note = ""
+    context_note = _render_plan_context_degradation(
+        finalization.requested_context_level,
+        finalization.effective_context_level,
+        finalization.context_degradation_reason,
+    )
     return (
-        finalization.degraded_scout_note
+        context_note
+        + finalization.degraded_scout_note
         + availability_note
         + _planning_disposition_warning_note(planning_handoffs)
         + _format_output(
@@ -1271,6 +1249,34 @@ def _finalize_plan_review_output(
         + "\n\n"
         + footer
     )
+
+
+def _compile_plan_atlas(
+    ctx: ToolContext,
+    request: _PlanReviewRequest,
+    subject_repo: pathlib.Path,
+    governance_repo: pathlib.Path,
+    snapshot_included: frozenset[str],
+    fixed_prompt_tokens: int,
+    plan_budget_limit: int,
+):
+    canonical_docs = {
+        "BIBLE.md", "docs/DEVELOPMENT.md", "docs/ARCHITECTURE.md", "docs/CHECKLISTS.md",
+    }
+    return compile_review_context_atlas(ReviewContextAtlasRequest(
+        repo_dir=subject_repo,
+        anchors=tuple(request.files_to_touch),
+        already_included=frozenset(
+            set(snapshot_included)
+            | (canonical_docs if subject_repo == governance_repo else set())
+        ),
+        fixed_prompt_tokens=fixed_prompt_tokens,
+        target_total_tokens=_plan_context_target_tokens(request.context_level),
+        hard_total_tokens=plan_budget_limit,
+        include_tests=request.include_tests,
+        title=f"Generated Plan Review Atlas ({request.context_level})",
+        drive_root=pathlib.Path(ctx.drive_root),
+    ))
 
 
 async def _run_plan_review_async(
@@ -1287,7 +1293,15 @@ async def _run_plan_review_async(
     context_notes = request.context_notes
     include_tests = request.include_tests
     plan_class = request.plan_class
-    review_disposition = request.review_disposition
+    if request.review_disposition is not None and not _vacuous_review_disposition(
+        request.review_disposition
+    ):
+        return (
+            "ERROR: PLAN_REVIEW_DISPOSITION_MIXED_ENVELOPE: disposition mode accepts "
+            "review_disposition only; a review request cannot carry both modes."
+        )
+    if request.review_disposition is not None:
+        request = replace(request, review_disposition=None)
     try:
         state_root, state_task_id = _planning_state_location(ctx)
     except ValueError as exc:
@@ -1323,26 +1337,17 @@ async def _run_plan_review_async(
         except ValueError as exc:
             return f"ERROR: {exc}"
         resolved_request = replace(
-            request,
-            context_level=resolved_context_level,
-            plan_class=resolved_class,
-            scope=scope,
+            request, context_level=resolved_context_level, plan_class=resolved_class, scope=scope,
         )
         if deadline_blocked:
             try:
                 decision = plan_review_gate_projection(
-                    load_plan_review_state(state_root, state_task_id),
-                    "blocking",
-                )
+                    load_plan_review_state(state_root, state_task_id), "blocking")
             except (OSError, TimeoutError, ValueError) as exc:
                 return f"ERROR: PLAN_REVIEW_STATE_INVALID: {exc}"
-            if str(decision.get("status") or "") == "closed" or review_disposition is not None:
+            if str(decision.get("status") or "") == "closed":
                 existing = _reuse_or_disposition_plan_review(
-                    ctx,
-                    request_fingerprint,
-                    review_disposition,
-                    plan_text_fingerprint(plan),
-                    resolved_request,
+                    ctx, request_fingerprint, None, plan_text_fingerprint(plan),
                 )
                 if existing is not None:
                     return existing
@@ -1356,7 +1361,7 @@ async def _run_plan_review_async(
                 return _plan_deadline_skip(ctx, emit=True) or deadline_skip
         else:
             existing = _reuse_or_disposition_plan_review(
-                ctx, request_fingerprint, review_disposition, plan_text_fingerprint(plan), resolved_request,
+                ctx, request_fingerprint, None, plan_text_fingerprint(plan),
             )
             if existing is not None:
                 return existing
@@ -1372,10 +1377,12 @@ async def _run_plan_review_async(
         return _plan_unavailable(
             ctx, "ERROR: No review models configured. Set OUROBOROS_REVIEW_MODELS in settings.",
             "review_models_unconfigured")
-    models = _get_review_models()
+    configured_models = _get_review_models()
     slot_limits = _per_slot_input_token_limits(
-        models, output_reserve=_PLAN_REVIEW_MAX_TOKENS, tokenizer_margin=155_000)
-    plan_budget_limit = _quorum_input_token_limit(models, slot_limits)  # quorum, not the smallest window
+        configured_models, output_reserve=_PLAN_REVIEW_MAX_TOKENS, tokenizer_margin=155_000)
+    plan_budget_limit = _quorum_input_token_limit(
+        configured_models, slot_limits
+    )  # quorum, not the smallest window
     degraded_scout_note = ""
     planning_handoffs: dict = {}
     reviewed_result_hashes: dict[str, str] = {}
@@ -1414,109 +1421,102 @@ async def _run_plan_review_async(
             arch_md, title="ARCHITECTURE.md", rel_path="docs/ARCHITECTURE.md"
         )
     ctx.emit_progress_fn("📐 plan_task: reading planned-touch file snapshots…")
-    canonical_docs = {
-        "BIBLE.md",
-        "docs/DEVELOPMENT.md",
-        "docs/ARCHITECTURE.md",
-        "docs/CHECKLISTS.md",
-    }
     head_snapshots = ""
-    # Only paths whose FULL snapshot text actually made it into the prompt may
-    # be declared `already_included` to the atlas below: the atlas trusts that
-    # claim, so an omission marker (oversized/sensitive/binary/error) reported
-    # as "included" would bypass the BIBLE P3 required-artifact refusal
-    # (XG-1R.4). Omitted paths flow into the normal atlas classification
-    # instead, where the hoisted requiredness predicate decides.
+    # Atlas inclusion claims only snapshots that survived; omission markers stay explicit.
     snapshot_included: frozenset[str] = frozenset()
     if files_to_touch:
         head_snapshots, snapshot_included = build_head_snapshot_section(
             subject_repo, files_to_touch
         )
-    system_prompt = _build_system_prompt(
-        checklist,
-        bible_text,
-        dev_md,
-        arch_md,
-        checklists_md,
-        context_level=resolved_context_level,
-        plan_class=resolved_class,
-    )
+    requested_context_level = resolved_context_level
+    effective_context_level = requested_context_level
+    context_degradation_reason = ""
     placeholder = "__GENERATED_PLAN_ATLAS_PENDING__"
-    user_content, user_stable_len = _build_user_content(
-        resolved_request,
-        head_snapshots,
-        placeholder if resolved_context_level != "minimal" else "",
-        "",
-    )
-    user_content += "\n\n" + _planning_evidence_horizon(
-        ctx,
-        governance_repo=governance_repo,
-        subject_repo=subject_repo,
-        scope=scope,
-    )
-    if planning_handoff_raw:
-        user_content += "\n\n" + planning_handoff_raw
-    if additional_context:
-        user_content += "\n\n" + additional_context
+
+    def build_prompt(level: str, degradation_reason: str = "") -> tuple[str, str, int]:
+        effective_request = replace(resolved_request, context_level=level)
+        system = _build_system_prompt(
+            checklist, bible_text, dev_md, arch_md, checklists_md,
+            context_level=level, plan_class=resolved_class,
+        )
+        user, stable_len = _build_user_content(
+            effective_request, head_snapshots,
+            placeholder if level != "minimal" else "",
+            _render_plan_context_degradation(
+                requested_context_level, level, degradation_reason,
+            ),
+        )
+        user += "\n\n" + _planning_evidence_horizon(
+            ctx, governance_repo=governance_repo, subject_repo=subject_repo, scope=scope,
+        )
+        if planning_handoff_raw:
+            user += "\n\n" + planning_handoff_raw
+        if additional_context:
+            user += "\n\n" + additional_context
+        return system, user, stable_len
+
+    system_prompt, user_content, user_stable_len = build_prompt(effective_context_level)
     fixed_prompt_tokens = estimate_tokens(system_prompt + user_content)
-    if resolved_context_level != "minimal":
-        target_tokens = _plan_context_target_tokens(resolved_context_level)
+    if effective_context_level != "minimal":
         ctx.emit_progress_fn(
-            f"📐 plan_task: building {resolved_context_level} Generated Plan Review Atlas…"
+            f"📐 plan_task: building {effective_context_level} Generated Plan Review Atlas…"
         )
         try:
-            atlas = compile_review_context_atlas(
-                ReviewContextAtlasRequest(
-                    repo_dir=subject_repo,
-                    anchors=tuple(files_to_touch),
-                    # NOT files_to_touch: only the snapshots that SURVIVED into
-                    # the prompt (see snapshot_included above, XG-1R.4).
-                    already_included=frozenset(
-                        set(snapshot_included)
-                        | (canonical_docs if subject_repo == governance_repo else set())
-                    ),
-                    fixed_prompt_tokens=fixed_prompt_tokens,
-                    target_total_tokens=target_tokens,
-                    hard_total_tokens=plan_budget_limit,
-                    include_tests=bool(include_tests),
-                    title=f"Generated Plan Review Atlas ({resolved_context_level})",
-                    drive_root=pathlib.Path(ctx.drive_root),
-                )
+            atlas = _compile_plan_atlas(
+                ctx, resolved_request, subject_repo, governance_repo, snapshot_included,
+                fixed_prompt_tokens, plan_budget_limit,
             )
         except Exception as e:
             return _plan_unavailable(
                 ctx, f"ERROR: Failed to build review context atlas: {e}", "review_atlas_failed")
 
         if atlas_assembly_failed(atlas):
-            # Review does not proceed on the remainder; the typed reason renders
-            # EVERY cause and the shared remedy pick follows the cause set —
-            # `context_level` moves only `target_total_tokens` (inert here).
-            return _plan_unavailable(
-                ctx,
-                "⚠️ PLAN_REVIEW_SKIPPED: " + atlas_assembly_failure_reason(atlas) + ". "
-                + atlas_assembly_remedy(
-                    atlas.manifest,
-                    "Split the plan into a smaller scope or choose a smaller context_level.",
-                ),
-                "review_atlas_assembly_failed",
+            context_degradation_reason = atlas_assembly_failure_reason(atlas)
+            effective_context_level = "minimal"
+            system_prompt, user_content, user_stable_len = build_prompt(
+                effective_context_level, context_degradation_reason,
             )
-
-        # Replace only the stable-prefix slot, not a copy quoted by plan text or a snapshot.
-        slot = user_content.rfind(placeholder, 0, user_stable_len)
-        if slot < 0:
-            return _plan_unavailable(
-                ctx, "ERROR: Failed to build review context atlas: placeholder missing.",
-                "review_atlas_invalid")
-        user_content = user_content[:slot] + atlas.text + user_content[slot + len(placeholder):]
-        user_stable_len += len(atlas.text) - len(placeholder)
+        else:
+            # Replace only the stable-prefix slot, not a copy quoted by the plan/snapshot.
+            slot = user_content.rfind(placeholder, 0, user_stable_len)
+            if slot < 0:
+                return _plan_unavailable(
+                    ctx, "ERROR: Failed to build review context atlas: placeholder missing.",
+                    "review_atlas_invalid")
+            user_content = user_content[:slot] + atlas.text + user_content[slot + len(placeholder):]
+            user_stable_len += len(atlas.text) - len(placeholder)
     estimated_tokens = estimate_tokens(system_prompt + user_content)
     if estimated_tokens > plan_budget_limit and planning_handoff_raw:
         user_content = user_content.replace(planning_handoff_raw, planning_handoff_compact)
         estimated_tokens = estimate_tokens(system_prompt + user_content)
     models, callable_slot_ids, oversize_results, fit_error = _plan_slot_fit_with_identity(
-        models, slot_limits, estimated_tokens)
+        configured_models, slot_limits, estimated_tokens)
+    if fit_error and effective_context_level != "minimal":
+        context_degradation_reason = (
+            f"the {effective_context_level} prompt (~{estimated_tokens:,} tokens) exceeded "
+            "enough calibrated reviewer input caps to leave fewer than quorum callable"
+        )
+        effective_context_level = "minimal"
+        system_prompt, user_content, user_stable_len = build_prompt(
+            effective_context_level, context_degradation_reason,
+        )
+        estimated_tokens = estimate_tokens(system_prompt + user_content)
+        if estimated_tokens > plan_budget_limit and planning_handoff_raw:
+            user_content = user_content.replace(planning_handoff_raw, planning_handoff_compact)
+            estimated_tokens = estimate_tokens(system_prompt + user_content)
+        models, callable_slot_ids, oversize_results, fit_error = _plan_slot_fit_with_identity(
+            configured_models, slot_limits, estimated_tokens)
     if fit_error:
-        return _plan_unavailable(ctx, fit_error, "review_context_unavailable")
+        return _plan_unavailable(
+            ctx,
+            _render_plan_context_degradation(
+                requested_context_level, effective_context_level, context_degradation_reason,
+            ) + fit_error,
+            "review_context_unavailable",
+        )
+    context_degradation_note = _render_plan_context_degradation(
+        requested_context_level, effective_context_level, context_degradation_reason,
+    )
 
     # Decline an unaffordable whole wave before paying for partial slots; fail open on unknowns.
     _admission = review_wave_budget_gate(
@@ -1527,7 +1527,8 @@ async def _run_plan_review_async(
     if _admission is not None:
         return _plan_unavailable(
             ctx,
-            "⚠️ PLAN_REVIEW_SKIPPED_BUDGET: the reviewer wave was declined before "
+            context_degradation_note
+            + "⚠️ PLAN_REVIEW_SKIPPED_BUDGET: the reviewer wave was declined before "
             f"dispatch — estimated cost ~${_admission.get('estimated_wave_usd')} exceeds "
             f"the remaining root budget ${_admission.get('remaining_usd')} "
             f"(limit ${_admission.get('limit_usd')}). No reviewer was called. "
@@ -1538,11 +1539,13 @@ async def _run_plan_review_async(
         snapshot = _persist_planning_snapshot(ctx, planning_handoffs)
         if snapshot.get("error"):
             return _plan_unavailable(
-                ctx, "ERROR: PLAN_REVIEW_STATE_PERSIST_FAILED: " + str(snapshot["error"]),
+                ctx,
+                context_degradation_note
+                + "ERROR: PLAN_REVIEW_STATE_PERSIST_FAILED: " + str(snapshot["error"]),
                 "planning_evidence_snapshot_failed")
     ctx.emit_progress_fn(
         f"📐 plan_task: running {len(models)} parallel reviewers "
-        f"(context={resolved_context_level}, ~{estimated_tokens:,} tokens each)…"
+        f"(context={effective_context_level}, ~{estimated_tokens:,} tokens each)…"
     )
 
     raw_results = _assemble_plan_raw_results(oversize_results, await _run_plan_review_slots(
@@ -1562,4 +1565,7 @@ async def _run_plan_review_async(
         request_fingerprint=request_fingerprint,
         degraded_scout_note=degraded_scout_note,
         reviewed_result_hashes=reviewed_result_hashes,
+        requested_context_level=requested_context_level,
+        effective_context_level=effective_context_level,
+        context_degradation_reason=context_degradation_reason,
     ))

--- a/ouroboros/tools/plan_review_runtime.py
+++ b/ouroboros/tools/plan_review_runtime.py
@@ -10,10 +10,12 @@ import os
 import pathlib
 
 from ouroboros.config import review_model_uses_local
+from ouroboros.deadline_utils import parse_deadline_ts, utc_now
 from ouroboros.llm import LLMClient
 from ouroboros.tools.registry import ToolContext, active_repo_dir_for
 from ouroboros.tools.review_helpers import load_checklist_section
 from ouroboros.tools.review_synthesis import build_plan_review_messages, normalize_plan_scope
+from ouroboros.utils import utc_now_iso
 
 
 PLAN_REVIEW_MAX_TOKENS = 65536
@@ -22,6 +24,46 @@ PLAN_REVIEW_SLOT_TIMEOUT_SEC = 560
 PLAN_CLASSES = ("self_mod", "external", "creative", "research")
 
 log = logging.getLogger(__name__)
+
+
+def plan_deadline_skip(ctx: ToolContext, *, emit: bool = False) -> str:
+    """Project the existing deadline rail without starting paid planning work."""
+    from ouroboros.config import get_plan_task_deadline_min_sec
+
+    metadata = getattr(ctx, "task_metadata", {})
+    metadata = metadata if isinstance(metadata, dict) else {}
+    deadline = parse_deadline_ts(metadata.get("deadline_at"))
+    if deadline is None:
+        return ""
+    remaining = (deadline - utc_now()).total_seconds()
+    scaled = max(0.0, remaining / 4.0)
+    minimum = get_plan_task_deadline_min_sec()
+    if remaining > 0 and scaled >= minimum:
+        return ""
+    if emit:
+        try:
+            event_queue = getattr(ctx, "event_queue", None)
+            if event_queue is not None:
+                event_queue.put_nowait({
+                    "type": "plan_task_deadline_skip",
+                    "task_id": str(getattr(ctx, "task_id", "") or ""),
+                    "remaining_sec": round(remaining, 1),
+                    "scaled_ceiling_sec": round(scaled, 1),
+                    "min_useful_sec": minimum,
+                    "ts": utc_now_iso(),
+                })
+        except Exception:
+            pass
+    cause = (
+        "the task deadline has expired; no new planning scout or reviewer work was started."
+        if remaining <= 0 else
+        f"insufficient time for useful planning — remaining {int(remaining)}s gives a "
+        f"swarm window of {int(scaled)}s (< {int(minimum)}s useful floor)."
+    )
+    return (
+        f"PLAN_TASK_SKIPPED_DEADLINE: {cause} Proceed with your own best plan "
+        "directly; do not re-call plan_task under this deadline."
+    )
 
 
 def record_raw_plan_request_attempt(
@@ -38,6 +80,24 @@ def record_raw_plan_request_attempt(
         state_root, task_id, fingerprint=fingerprint, status="open", reason=reason,
     )
     return fingerprint
+
+
+def reviewed_handoff_hashes(handoffs: dict) -> dict[str, str]:
+    """Hash the exact in-memory scout snapshots before reviewer dispatch."""
+    from ouroboros.tools.join_ledger import _child_result_sha256
+
+    included = [str(item) for item in handoffs.get("included_task_ids") or [] if str(item)]
+    wait = handoffs.get("wait") if isinstance(handoffs.get("wait"), dict) else {}
+    tasks = wait.get("tasks") if isinstance(wait.get("tasks"), dict) else {}
+    result: dict[str, str] = {}
+    for task_id in included:
+        snapshot = tasks.get(task_id)
+        if not isinstance(snapshot, dict):
+            raise ValueError(
+                f"PLAN_REVIEW_STATE_INVALID: included scout {task_id} has no reviewed snapshot"
+            )
+        result[task_id] = _child_result_sha256(snapshot)
+    return result
 
 
 def validate_plan_request_envelope(request, state_root: pathlib.Path, task_id: str) -> tuple[dict, str]:

--- a/ouroboros/tools/review_synthesis.py
+++ b/ouroboros/tools/review_synthesis.py
@@ -362,147 +362,6 @@ def plan_text_fingerprint(plan: str) -> str:
     return sha256(plan.encode("utf-8")).hexdigest()
 
 
-# Review identity is the fingerprint of the AGENT-PASSED envelope only. Component
-# hashes exist purely to DIAGNOSE a mismatch, so they may carry host-resolved values
-# (resolved plan_class / context_level) that must never enter the binding identity.
-_PLAN_COMPONENT_KEYS = (
-    "goal", "files_to_touch", "context_notes", "scope",
-    "include_tests", "plan_class", "context_level",
-)
-
-
-def plan_review_component_hashes(request: Any) -> Dict[str, str]:
-    """Per-field hashes of one plan-review envelope, for ENVELOPE_MISMATCH detail."""
-    hashes: Dict[str, str] = {}
-    for key in _PLAN_COMPONENT_KEYS:
-        value = getattr(request, key, None)
-        if key == "scope":
-            value = normalize_plan_scope(value if isinstance(value, dict) else None)
-        encoded = json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
-        hashes[key] = sha256(encoded.encode("utf-8")).hexdigest()[:16]
-    return hashes
-
-
-def plan_envelope_mismatch_fields(stored: Any, submitted: Any) -> List[str]:
-    """Component names that differ between two envelopes.
-
-    Only components present in BOTH maps are compared, so a wave stored before per-slot
-    hashes existed reports nothing. There is no "omitted vs explicitly empty" axis to
-    honour: ``_handle_plan_task`` coerces every omitted optional field to ``""``/``[]``/
-    ``False`` before it is hashed OR fingerprinted, so an omission and an explicit empty
-    are the same envelope — and both already changed the request fingerprint."""
-    stored_map = dict(stored or {})
-    submitted_map = dict(submitted or {})
-    return [
-        key for key in _PLAN_COMPONENT_KEYS
-        if key in stored_map and key in submitted_map
-        and stored_map[key] != submitted_map[key]
-    ]
-
-
-def plan_envelope_mismatch_note(wave: Any, request: Any) -> str:
-    """Free ENVELOPE_MISMATCH warning when a disposition BOUND a drifted envelope.
-
-    Since the binding identity is the agent envelope's own fingerprint and a disposition
-    may only close a review of the SAME fingerprint (``bindable_claimed_wave``), a bound
-    wave can differ only in HOST-RESOLVED components (resolved ``plan_class`` /
-    ``context_level``), which are diagnosed here and deliberately excluded from identity.
-    Agent-authored drift such as ``files_to_touch`` is no longer bindable at all — it is
-    rejected by ``unbindable_disposition_error``, which reports the same field list."""
-    if request is None:
-        return ""
-    drifted = plan_envelope_mismatch_fields(
-        (wave or {}).get("component_hashes"), plan_review_component_hashes(request),
-    )
-    if not drifted:
-        return ""
-    return (
-        "NOTE: ENVELOPE_MISMATCH on: " + ", ".join(drifted) + ". Your review_disposition "
-        "closed the review it named, but that review saw a DIFFERENT envelope for these "
-        "components, so the findings you dispositioned do not cover what changed.\n\n"
-    )
-
-
-def bindable_claimed_wave(
-    state: Any, disposition: Any, plan_text_hash: str, request_fingerprint: str,
-) -> Optional[Dict[str, Any]]:
-    """The wave a disposition HONESTLY names, or None.
-
-    Binds only when all four hold: the claimed ``review_fingerprint`` equals the
-    SUBMITTED envelope's fingerprint, it is the state's latest review fingerprint,
-    that wave's review is an OPEN ``REVIEW_REQUIRED``, and the submitted plan text
-    still hashes to the stored ``plan_text_hash``.
-
-    The envelope-equality condition is the P3 plan gate itself. ``files_to_touch`` is
-    exported in the tool schema as PART OF THE REVIEW IDENTITY ("a review_disposition
-    can only close a review submitted with the SAME list"), and the binding fingerprint
-    is a pure function of the AGENT's envelope, so a claimed fingerprint that differs
-    from the submitted one means the reviewers never saw what is now being planned.
-    Binding it with a warning let a review of ``[a.py]`` authorise ``[a.py, b.py,
-    c.py]`` — stale evidence closing materially expanded scope. A mismatch is therefore
-    UNBINDABLE: the caller fails fast (no wave, no money) and the always-available
-    escape is to omit the disposition and run a real review of the new envelope."""
-    claimed = str((disposition or {}).get("review_fingerprint") or "").strip()
-    if not claimed or not isinstance(state, dict):
-        return None
-    if claimed != str(request_fingerprint or "").strip():
-        return None
-    if str(state.get("latest_review_fingerprint") or "") != claimed:
-        return None
-    for wave in state.get("waves") or []:
-        if str(wave.get("request_fingerprint") or "") != claimed:
-            continue
-        review = wave.get("review") if isinstance(wave.get("review"), dict) else {}
-        if str(review.get("aggregate_signal") or "") != "REVIEW_REQUIRED" or bool(review.get("closed")):
-            return None
-        if not plan_text_hash or str(wave.get("plan_text_hash") or "") != str(plan_text_hash):
-            return None
-        return dict(wave)
-    return None
-
-
-def unbindable_disposition_error(
-    state: Any, fingerprint: str, disposition: Any, plan_text_hash: str = "",
-    request: Any = None,
-) -> str:
-    """Fail-fast text for a non-empty disposition that can close nothing.
-
-    Discarding it silently and paying for a whole scout+reviewer wave hid the real
-    cause from the agent (v6.65.0/1 chose the discard to un-wedge submissions; the
-    wedge escape is preserved EXPLICITLY in this message instead).
-
-    The submitted envelope comes from the CALLER's ``request``: a disposition never
-    carries component hashes, so reading them off it made the ENVELOPE_MISMATCH clause
-    unreachable and the wave's stored hashes write-only data."""
-    claimed = str((disposition or {}).get("review_fingerprint") or "").strip() or "(none)"
-    latest = str((state or {}).get("latest_review_fingerprint") or "") or "(none)"
-    stored_plan_hash = ""
-    for wave in (state or {}).get("waves") or []:
-        if str(wave.get("request_fingerprint") or "") == latest:
-            stored_plan_hash = str(wave.get("plan_text_hash") or "")
-            break
-    plan_matches = bool(plan_text_hash) and stored_plan_hash == str(plan_text_hash)
-    mismatches = plan_envelope_mismatch_fields(
-        (next((w for w in (state or {}).get("waves") or []
-               if str(w.get("request_fingerprint") or "") == latest), {}) or {}).get("component_hashes"),
-        plan_review_component_hashes(request) if request is not None else None,
-    )
-    return (
-        "ERROR: PLAN_REVIEW_DISPOSITION_UNBINDABLE: your review_disposition names "
-        f"review_fingerprint={claimed}, but that does not name an OPEN REVIEW_REQUIRED "
-        "review OF THE ENVELOPE YOU JUST SUBMITTED "
-        f"(latest stored review fingerprint={latest}; submitted request fingerprint="
-        f"{str(fingerprint or '') or '(none)'}; plan text "
-        f"{'matches' if plan_matches else 'does NOT match'} the stored plan)."
-        + (f" ENVELOPE_MISMATCH on: {', '.join(mismatches)}." if mismatches else "")
-        + " Nothing was reviewed and no wave was launched, so no money was spent. Two "
-        "ways forward: (1) OMIT review_disposition entirely — that is ALWAYS available "
-        "and runs a real review of this plan; or (2) re-submit the exact plan and "
-        "envelope that produced the REVIEW_REQUIRED result you are trying to close, "
-        "with its own review_fingerprint."
-    )
-
-
 def quorum_input_token_limit(models: Any, slot_limits: Any) -> int:
     """Assembly budget for ONE shared prompt fanned across mixed-window slots: the largest cap that
     still leaves a review QUORUM callable, i.e. the quorum-th largest per-slot cap.
@@ -905,7 +764,11 @@ def format_plan_review_output(
         )
     lines.append("")
     if aggregate == "GREEN":
-        lines.append("All reviewers converged on GREEN. Read every reviewer's PROPOSALS section and proceed with implementation.")
+        lines.append(
+            "All responding reviewers returned GREEN. Read every called reviewer's "
+            "PROPOSALS section and proceed with implementation. Any preflight-excluded "
+            "slot shown above was not called and did not return a verdict."
+        )
     elif aggregate == "REVIEW_REQUIRED":
         reasons = []
         if summary["revise_count"] == 1:
@@ -920,12 +783,15 @@ def format_plan_review_output(
             "Read every full response, then retry the same fingerprint without a disposition; "
             "the existing scout wave is reused."
             if reviewer_retry_required else
-            "Read every full response and disposition the addressable findings before coding."
+            "Read every full response. In blocking mode, close the result through the "
+            "main agent's disposition before coding; in advisory mode, the main agent may "
+            "proceed under the host's loud disclosure."
         )
     else:
         lines.append(
             f"{summary['revise_count']} reviewer(s) independently flagged REVISE_PLAN; "
-            "change the plan before writing code."
+            "blocking mode requires a changed plan and fresh panel; advisory mode may "
+            "proceed only under loud host disclosure and the main agent's rationale."
         )
     if availability_only:
         findings_heading = "## Reviewer Availability Evidence (audit only)"
@@ -948,15 +814,27 @@ def render_plan_review_result(review: Dict[str, Any], *, cached: bool = False) -
     elif aggregate == "REVIEW_REQUIRED" and closed:
         explanation = "Every finding was dispositioned for this unchanged fingerprint; no reviewer was called."
     elif aggregate == "REVISE_PLAN":
-        explanation = "The plan text must change, producing a new fingerprint and review."
+        explanation = (
+            "Blocking mode requires changed plan text and a fresh review. Advisory mode "
+            "may proceed only under loud host disclosure and the main agent's rationale."
+        )
     else:
-        explanation = "Disposition every finding id before implementation; do not rerun reviewers."
+        explanation = (
+            "Blocking mode requires a main-agent disposition; advisory mode may proceed "
+            "under loud host disclosure. Do not rerun reviewers."
+        )
     findings = [item for item in (review.get("findings") or []) if isinstance(item, dict)]
-    return "\n".join([
+    findings_heading = "## Resolved Findings" if closed else "## Findings Requiring Disposition"
+    context_note = render_plan_context_degradation(
+        str(review.get("requested_context_level") or ""),
+        str(review.get("effective_context_level") or ""),
+        str(review.get("context_degradation_reason") or ""),
+    )
+    return context_note + "\n".join([
         "## Plan Review Results", "",
         f"**Plan fingerprint:** `{review.get('request_fingerprint') or ''}`",
         f"**Cached exact review:** {bool(cached)}", "",
-        "## Findings Requiring Disposition", "", "```json",
+        findings_heading, "", "```json",
         json.dumps(findings, ensure_ascii=False, indent=2, default=str), "```", "",
         "## Aggregate Signal", "", f"**{aggregate}**", "", explanation, "",
         PLAN_REVIEW_CONTROL_PREFIX + json.dumps(
@@ -966,10 +844,25 @@ def render_plan_review_result(review: Dict[str, Any], *, cached: bool = False) -
     ])
 
 
+def render_plan_context_degradation(requested: str, effective: str, reason: str) -> str:
+    """Render the one loud disclosure shared by fresh and cached plan results."""
+    if not requested or not effective or requested == effective:
+        return ""
+    return (
+        "⚠️ PLAN_CONTEXT_DEGRADED: "
+        f"requested context_level={requested}; effective context_level={effective}. "
+        f"Reason: {reason or 'the requested generated context could not fit'}. "
+        "The same plan fingerprint, scout wave, and handoffs were preserved. The "
+        "effective review packet retained the governance documents, plan, scout evidence, "
+        "and surviving planned-touch snapshots; Generated Atlas evidence was omitted and "
+        "snapshot omissions remained explicit.\n\n"
+    )
+
+
 VACUOUS_DISPOSITION_NOTE = (
-    "\n\nNOTE: an empty review_disposition was ignored as absent. Omit the field "
-    "entirely unless you are closing the immediately preceding REVIEW_REQUIRED "
-    "result for this exact unchanged plan."
+    "\n\nNOTE: an empty review_disposition was ignored in this review-mode call. "
+    "Omit the field when submitting a plan; to close REVIEW_REQUIRED, make a separate "
+    "call containing a complete review_disposition only."
 )
 
 def vacuous_review_disposition(value: object) -> bool:
@@ -988,6 +881,37 @@ def vacuous_review_disposition(value: object) -> bool:
     return items is None or items == []
 
 
+def same_review_disposition(left: object, right: object) -> bool:
+    """Semantic equality for idempotent replay, ignoring storage-only timestamps."""
+    def signature(value: object) -> tuple[str, tuple[tuple[str, str, str, str], ...]]:
+        payload = value if isinstance(value, dict) else {}
+        items = payload.get("items") if isinstance(payload.get("items"), list) else []
+        normalized = sorted(
+            (
+                str(item.get("finding_id") or ""), str(item.get("decision") or ""),
+                str(item.get("rationale") or ""), str(item.get("plan_revision") or ""),
+            )
+            for item in items if isinstance(item, dict)
+        )
+        return str(payload.get("review_fingerprint") or ""), tuple(normalized)
+    return signature(left) == signature(right)
+
+
+def replay_closed_review_disposition(
+    review: Dict[str, Any], fingerprint: str, disposition: Dict[str, Any],
+) -> str:
+    """Accept only an exact semantic replay of the disposition that closed review."""
+    updated, error = validate_plan_review_disposition(review, fingerprint, disposition)
+    if error or updated is None:
+        return error
+    if not same_review_disposition(review.get("disposition"), updated.get("disposition")):
+        return (
+            "ERROR: PLAN_REVIEW_DISPOSITION_IMMUTABLE: this exact review was already "
+            "closed by a different disposition."
+        )
+    return render_plan_review_result(review, cached=True)
+
+
 def validate_plan_review_disposition(
     review: Dict[str, Any], fingerprint: str, disposition: Any
 ) -> tuple[Optional[Dict[str, Any]], str]:
@@ -1001,11 +925,14 @@ def validate_plan_review_disposition(
     if str(disposition.get("review_fingerprint") or "").strip() != expected_fp or fingerprint != expected_fp:
         return None, (
             "ERROR: PLAN_REVIEW_DISPOSITION_STALE: review_disposition must name the "
-            "exact immediately preceding plan fingerprint."
+            "exact latest still-current plan fingerprint."
         )
     aggregate = str(review.get("aggregate_signal") or "")
     if aggregate == "REVISE_PLAN":
-        return None, "ERROR: PLAN_REVIEW_REVISION_REQUIRED: change the plan text before a fresh review."
+        return None, (
+            "ERROR: PLAN_REVIEW_REVISION_REQUIRED: blocking mode requires changed plan "
+            "text and a fresh review; advisory mode may proceed under loud host disclosure."
+        )
     if aggregate == "GREEN":
         return None, invalid + "the prior result is already GREEN"
     if aggregate != "REVIEW_REQUIRED":

--- a/tests/test_plan_review.py
+++ b/tests/test_plan_review.py
@@ -339,7 +339,6 @@ def test_reviewer_unavailability_stays_retryable_not_durable_verdict(tmp_path):
         fingerprint,
         None,
         pr.plan_text_fingerprint(request.plan),
-        request,
     ) is None
     other_handoffs = {
         "schema_version": 1,
@@ -650,7 +649,6 @@ def test_substantive_finding_survives_peer_outage_and_retries_same_wave(tmp_path
         fingerprint,
         None,
         pr.plan_text_fingerprint(request.plan),
-        request,
     ) is None
     write_task_result(
         tmp_path,
@@ -675,7 +673,6 @@ def test_substantive_finding_survives_peer_outage_and_retries_same_wave(tmp_path
         fingerprint,
         {"review_fingerprint": fingerprint, "items": []},
         pr.plan_text_fingerprint(request.plan),
-        request,
     )
     assert rejected.startswith("ERROR: PLAN_REVIEW_RETRY_REQUIRED")
 
@@ -760,6 +757,21 @@ def test_planning_state_requires_real_task_id(tmp_path):
     with pytest.raises(ValueError, match="PLAN_REVIEW_TASK_ID_REQUIRED"):
         _planning_state_location(ctx)
     assert not (tmp_path / "task_results" / "plan_review.json").exists()
+
+
+def test_disposition_without_task_id_returns_typed_state_error(tmp_path):
+    import ouroboros.tools.plan_review as pr
+    from ouroboros.tools.registry import ToolContext
+
+    ctx = ToolContext(repo_dir=tmp_path, drive_root=tmp_path)
+    result = pr._handle_plan_task(
+        ctx,
+        review_disposition={"review_fingerprint": "a" * 64, "items": []},
+    )
+
+    assert result.startswith("ERROR: PLAN_REVIEW_STATE_INVALID:")
+    assert "PLAN_REVIEW_TASK_ID_REQUIRED" in result
+    assert not (tmp_path / "task_results").exists()
 
 
 def _contract_review_text(signal: str) -> str:
@@ -1232,6 +1244,9 @@ def test_planning_swarm_persists_intents_before_launch_and_partial_failure(monke
     leaked = "abcdefghijklmnop-secret-value"
 
     def fake_schedule(ctx_arg, _internal=None, **_kwargs):
+        # Planning scouts use the generic scheduler default: a configured live
+        # harness is selected there, with its existing loud native fallback.
+        assert _kwargs.get("executor", "auto") == "auto"
         calls["count"] += 1
         state = load_plan_review_state(tmp_path, str(ctx_arg.task_id))
         assert len(state["waves"]) == 1
@@ -2461,18 +2476,9 @@ class TestPlanReviewFormatOutput(unittest.TestCase):
         self.assertIn("12,345", out)
 
 
-def test_oversized_planned_required_artifact_refuses_typed(tmp_path, monkeypatch):
-    """XG-1R.4. `_run_plan_review_async` used to put EVERY files_to_touch path
-    into `already_included`, while `build_head_snapshot_section` silently
-    replaced a >1MB HEAD snapshot with an omission marker. A planned required
-    artifact (here a force-included `prompts/` file over 1MB) was therefore in
-    NEITHER the plan prompt NOR the atlas — the atlas trusted the false claim
-    and returned an `already_included` row before requiredness ran — and plan
-    review dispatched reviewers anyway, bypassing the BIBLE P3 assembly-failure
-    rule. Now only snapshots that actually SURVIVED into the prompt are
-    declared, the omitted path flows into the normal atlas classification, and
-    the hoisted requiredness predicate refuses with the typed failure naming
-    the artifact — before any reviewer slot is called."""
+def test_oversized_planned_artifact_degrades_loudly_to_minimal(tmp_path, monkeypatch):
+    """A touched file too large for both snapshot and Atlas remains a loud omission,
+    while the same fingerprint/scout wave still receives a minimal panel review."""
     import asyncio
     import subprocess
 
@@ -2519,16 +2525,13 @@ def test_oversized_planned_required_artifact_refuses_typed(tmp_path, monkeypatch
         ),
     ))
 
-    # The typed refusal names the artifact and no reviewer slot was called.
-    assert "PLAN_REVIEW_SKIPPED" in result
+    assert "PLAN_CONTEXT_DEGRADED" in result
+    assert "effective context_level=minimal" in result
     assert "prompts/huge.md" in result
-    assert dispatched["called"] is False
+    assert "PLAN_REVIEW_SKIPPED" not in result
+    assert dispatched["called"] is True
 
-    # Control: in a repo WITHOUT the oversized required artifact, an ordinary
-    # small planned file must NOT trip the refusal — its surviving snapshot
-    # stays declared as included and reviewers are dispatched. (The huge
-    # prompts/ file must go entirely: since XR-1 an untouched >1MB required
-    # artifact refuses ANY review on the repo, by design.)
+    # Control: a small planned file keeps the requested context without degradation.
     repo_ok = tmp_path / "repo_ok"
     repo_ok.mkdir()
     (repo_ok / "ok.py").write_text("print(1)\n", encoding="utf-8")
@@ -2550,6 +2553,7 @@ def test_oversized_planned_required_artifact_refuses_typed(tmp_path, monkeypatch
         ),
     ))
     assert "PLAN_REVIEW_SKIPPED" not in result_ok
+    assert "PLAN_CONTEXT_DEGRADED" not in result_ok
     assert dispatched["called"] is True
 
 
@@ -2562,7 +2566,9 @@ class TestPlanReviewBudgetGate(unittest.IsolatedAsyncioTestCase):
         with tempfile.TemporaryDirectory() as raw:
             ctx = _make_ctx(pathlib.Path(raw))
             freeze = MagicMock(return_value={"path": "unused"})
+            atlas = SimpleNamespace(text="small atlas", manifest={}, status="ok")
             with (
+                patch.object(pr, "compile_review_context_atlas", return_value=atlas) as compile_atlas,
                 patch.object(pr, "build_head_snapshot_section", return_value=""),
                 patch.object(pr, "_load_plan_checklist", return_value="checklist"),
                 patch.object(pr, "load_governance_doc", return_value="doc"),
@@ -2574,60 +2580,71 @@ class TestPlanReviewBudgetGate(unittest.IsolatedAsyncioTestCase):
                     "estimated_wave_usd": 2.0,
                     "remaining_usd": 1.0,
                     "limit_usd": 1.0,
-                }),
+                }) as admission,
+                patch.object(pr, "_run_plan_review_slots", new=AsyncMock()) as slots,
             ):
                 result = await pr._run_plan_review_async(
                     ctx,
-                    _plan_request("my plan", "my goal", [], context_level="minimal"),
+                    _plan_request("my plan", "my goal", [], context_level="localized"),
                 )
 
         self.assertIn("PLAN_REVIEW_SKIPPED_BUDGET", result)
+        self.assertNotIn("PLAN_CONTEXT_DEGRADED", result)
+        compile_atlas.assert_called_once()
+        admission.assert_called_once()
+        slots.assert_not_awaited()
         freeze.assert_not_called()
 
-    async def test_budget_gate_skips_when_oversized(self):
-        """An assembled prompt no slot can fit is a loud typed preflight degradation.
+    async def test_degraded_minimal_budget_refusal_keeps_loud_disclosure(self):
+        from ouroboros.tools import plan_review as pr
 
-        v6.80.0: the shared "assembled prompt too large" gate became a PER-SLOT
-        calibrated fit check, so a prompt above every slot's cap now reports
-        PLAN_REVIEW_DEGRADED_PREFLIGHT_OVERSIZE with NO reviewer called (instead of
-        paying for slots with a guaranteed provider 400)."""
+        ctx = _make_ctx()
+        atlas = SimpleNamespace(
+            text="",
+            manifest={
+                "unassembled_required": [{
+                    "path": "huge.py", "reason": "required file exceeded the atlas hard budget",
+                }],
+            },
+            status="required_artifact_omitted",
+        )
+        with (
+            patch.object(pr, "compile_review_context_atlas", return_value=atlas),
+            patch.object(pr, "_load_plan_checklist", return_value="checklist"),
+            patch.object(pr, "load_governance_doc", return_value=""),
+            patch.object(pr, "_start_planning_swarm", side_effect=_completed_planning_swarm),
+            patch("ouroboros.config.get_review_models", return_value=["model-a", "model-b"]),
+            patch.object(pr, "_get_review_models", return_value=["model-a", "model-b"]),
+            patch.object(pr, "review_wave_budget_gate", return_value={
+                "estimated_wave_usd": 2.0, "remaining_usd": 1.0, "limit_usd": 1.0,
+            }),
+            patch.object(pr, "_run_plan_review_slots", new=AsyncMock()) as slots,
+        ):
+            result = await pr._run_plan_review_async(
+                ctx, _plan_request("P", "G", [], context_level="constitutional"),
+            )
+
+        self.assertIn("PLAN_CONTEXT_DEGRADED", result)
+        self.assertIn("huge.py", result)
+        self.assertIn("PLAN_REVIEW_SKIPPED_BUDGET", result)
+        self.assertIn("effective review packet retained", result)
+        self.assertNotIn("Reviewers received", result)
+        slots.assert_not_awaited()
+
+    async def test_quorum_oversize_degrades_same_call_to_minimal(self):
         from ouroboros.tools import plan_review as pr
 
         ctx = _make_ctx()
         ctx.repo_dir = pathlib.Path(".")
         atlas = SimpleNamespace(text="x" * 1_000_000, manifest={}, status="budget_constrained")
+        reviews = [
+            {"model": model, "text": _review_text("GREEN"), "error": None}
+            for model in ("model-a", "model-b")
+        ]
 
-        with (
-            patch.object(pr, "compile_review_context_atlas", return_value=atlas),
-            patch.object(pr, "build_head_snapshot_section", return_value=("", frozenset())),
-            patch.object(pr, "_load_plan_checklist", return_value="checklist"),
-            patch.object(pr, "load_governance_doc", return_value=""),
-            patch.object(pr, "_start_planning_swarm", side_effect=_completed_planning_swarm),
-            # Two distinct models so the quorum gate (v4.39.0) passes and we
-            # actually reach the budget check under test. Patch BOTH
-            # `_cfg.get_review_models` (quorum gate reads this) and
-            # `pr._get_review_models` (parallel-run reads this) so the test
-            # is hermetic against developer `OUROBOROS_REVIEW_MODELS`.
-            patch("ouroboros.config.get_review_models",
-                  return_value=["model-a", "model-b"]),
-            patch.object(pr, "_get_review_models", return_value=["model-a", "model-b"]),
-            # estimate_tokens returns a large number
-            patch("ouroboros.tools.plan_review.estimate_tokens", return_value=1_100_000),
-        ):
-            result = await pr._run_plan_review_async(
-                ctx,
-                _plan_request(
-                    "my plan", "my goal", [], context_level="constitutional",
-                ),
-            )
+        def sized(text):
+            return 1_100_000 if len(text) > 500_000 else 10_000
 
-        self.assertIn("PLAN_REVIEW_DEGRADED_PREFLIGHT_OVERSIZE", result)
-
-        atlas = SimpleNamespace(
-            text="small atlas",
-            manifest={"estimated_total_tokens": 950_000},
-            status="budget_exceeded",
-        )
         with (
             patch.object(pr, "compile_review_context_atlas", return_value=atlas),
             patch.object(pr, "build_head_snapshot_section", return_value=("", frozenset())),
@@ -2637,7 +2654,9 @@ class TestPlanReviewBudgetGate(unittest.IsolatedAsyncioTestCase):
             patch("ouroboros.config.get_review_models",
                   return_value=["model-a", "model-b"]),
             patch.object(pr, "_get_review_models", return_value=["model-a", "model-b"]),
-            patch("ouroboros.tools.plan_review.estimate_tokens", return_value=10_000),
+            patch("ouroboros.tools.plan_review.estimate_tokens", side_effect=sized),
+            patch.object(pr, "review_wave_budget_gate", return_value=None),
+            patch.object(pr, "_run_plan_review_slots", new=AsyncMock(return_value=reviews)) as slots,
         ):
             result = await pr._run_plan_review_async(
                 ctx,
@@ -2646,19 +2665,46 @@ class TestPlanReviewBudgetGate(unittest.IsolatedAsyncioTestCase):
                 ),
             )
 
-        self.assertIn("PLAN_REVIEW_SKIPPED", result)
-        self.assertIn("generated repository atlas exceeded hard budget", result)
-        # The half that must NOT change: for a genuine overflow the budget knob
-        # IS the remedy, so the original sentence stays.
-        self.assertIn("choose a smaller context_level", result)
+        self.assertIn("PLAN_CONTEXT_DEGRADED", result)
+        self.assertIn("requested context_level=constitutional", result)
+        self.assertIn("effective context_level=minimal", result)
+        self.assertNotIn("PLAN_REVIEW_DEGRADED_PREFLIGHT_OVERSIZE", result)
+        slots.assert_awaited_once()
 
-    async def test_required_artifact_omission_refuses_the_review(self):
-        """Consumer 3 of 3 (BIBLE P3): an atlas that could not assemble a REQUIRED
-        artifact must not be reviewed on the remainder. Before the shared
-        `atlas_assembly_failed` predicate this branch tested `status ==
-        "budget_exceeded"` only, so the new failure status sailed through and
-        plan review ran on a pack missing a required file."""
+    async def test_minimal_still_oversize_stops_after_one_fallback(self):
         from ouroboros.tools import plan_review as pr
+
+        ctx = _make_ctx()
+        atlas = SimpleNamespace(text="small atlas", manifest={}, status="ok")
+        swarm = MagicMock(side_effect=_completed_planning_swarm)
+        with (
+            patch.object(pr, "compile_review_context_atlas", return_value=atlas),
+            patch.object(pr, "_load_plan_checklist", return_value="checklist"),
+            patch.object(pr, "load_governance_doc", return_value=""),
+            patch.object(pr, "_start_planning_swarm", swarm),
+            patch("ouroboros.config.get_review_models", return_value=["model-a", "model-b"]),
+            patch.object(pr, "_get_review_models", return_value=["model-a", "model-b"]),
+            patch.object(pr, "estimate_tokens", return_value=1_100_000),
+            patch.object(
+                pr, "review_wave_budget_gate", side_effect=AssertionError("fit must stop first"),
+            ),
+            patch.object(pr, "_run_plan_review_slots", new=AsyncMock()) as slots,
+        ):
+            result = await pr._run_plan_review_async(
+                ctx, _plan_request("P", "G", [], context_level="constitutional"),
+            )
+
+        self.assertIn("PLAN_CONTEXT_DEGRADED", result)
+        self.assertIn("effective context_level=minimal", result)
+        self.assertIn("PLAN_REVIEW_DEGRADED_PREFLIGHT_OVERSIZE", result)
+        self.assertIn("effective review packet retained", result)
+        self.assertNotIn("Reviewers received", result)
+        swarm.assert_called_once()
+        slots.assert_not_awaited()
+
+    async def test_required_artifact_omission_degrades_loudly_and_persists_resolution(self):
+        from ouroboros.tools import plan_review as pr
+        from ouroboros.task_results import load_plan_review_state
 
         ctx = _make_ctx()
         ctx.repo_dir = pathlib.Path(".")
@@ -2672,72 +2718,66 @@ class TestPlanReviewBudgetGate(unittest.IsolatedAsyncioTestCase):
             },
             status="required_artifact_omitted",
         )
+        reviews = [
+            {"model": model, "text": _review_text("GREEN"), "error": None}
+            for model in ("model-a", "model-b")
+        ]
+        swarm = MagicMock(side_effect=_completed_planning_swarm)
+        request = _plan_request("my plan", "my goal", [], context_level="constitutional")
         with (
             patch.object(pr, "compile_review_context_atlas", return_value=atlas),
+            patch.object(pr, "build_head_snapshot_section", return_value=("", frozenset())),
+            patch.object(pr, "_load_plan_checklist", return_value="checklist"),
+            patch.object(pr, "load_governance_doc", return_value=""),
+            patch.object(pr, "_start_planning_swarm", swarm),
+            patch("ouroboros.config.get_review_models", return_value=["model-a", "model-b"]),
+            patch.object(pr, "_get_review_models", return_value=["model-a", "model-b"]),
+            patch("ouroboros.tools.plan_review.estimate_tokens", return_value=10_000),
+            patch.object(pr, "review_wave_budget_gate", return_value=None),
+            patch.object(pr, "_run_plan_review_slots", new=AsyncMock(return_value=reviews)) as slots,
+        ):
+            result = await pr._run_plan_review_async(ctx, request)
+
+        self.assertIn("PLAN_CONTEXT_DEGRADED", result)
+        self.assertIn("ouroboros/llm.py", result)
+        self.assertNotIn("PLAN_REVIEW_SKIPPED", result)
+        swarm.assert_called_once()
+        slots.assert_awaited_once()
+        state = load_plan_review_state(pathlib.Path(ctx.drive_root), ctx.task_id)
+        wave = state["waves"][0]
+        self.assertEqual(wave["request_fingerprint"], swarm.call_args.args[2])
+        self.assertEqual(wave["review"]["requested_context_level"], "constitutional")
+        self.assertEqual(wave["review"]["effective_context_level"], "minimal")
+        cached = pr._reuse_or_disposition_plan_review(
+            ctx, wave["request_fingerprint"], None, pr.plan_text_fingerprint(request.plan),
+        )
+        self.assertIn("PLAN_CONTEXT_DEGRADED", cached)
+
+    async def test_unexpected_atlas_compiler_exception_does_not_fallback(self):
+        from ouroboros.tools import plan_review as pr
+
+        ctx = _make_ctx()
+        ctx.repo_dir = pathlib.Path(".")
+        with (
+            patch.object(pr, "compile_review_context_atlas", side_effect=RuntimeError("boom")),
             patch.object(pr, "build_head_snapshot_section", return_value=("", frozenset())),
             patch.object(pr, "_load_plan_checklist", return_value="checklist"),
             patch.object(pr, "load_governance_doc", return_value=""),
             patch.object(pr, "_start_planning_swarm", side_effect=_completed_planning_swarm),
             patch("ouroboros.config.get_review_models", return_value=["model-a", "model-b"]),
             patch.object(pr, "_get_review_models", return_value=["model-a", "model-b"]),
-            patch("ouroboros.tools.plan_review.estimate_tokens", return_value=10_000),
+            patch.object(pr, "_run_plan_review_slots", new=AsyncMock()) as slots,
         ):
             result = await pr._run_plan_review_async(
-                ctx,
-                _plan_request("my plan", "my goal", [], context_level="constitutional"),
+                ctx, _plan_request("my plan", "my goal", [], context_level="localized"),
             )
 
-        self.assertIn("PLAN_REVIEW_SKIPPED", result)
-        self.assertIn("ouroboros/llm.py", result)
+        self.assertIn("Failed to build review context atlas: boom", result)
+        self.assertNotIn("PLAN_CONTEXT_DEGRADED", result)
+        slots.assert_not_awaited()
 
-    async def test_required_artifact_remedy_is_not_the_inert_context_level_knob(self):
-        """The refusal reused the `budget_exceeded` remedy verbatim, and "choose a
-        smaller context_level" is INERT here: `context_level` feeds only
-        `target_total_tokens`, while required artifacts are selected against
-        `hard_total_tokens`. Executed at every level the same artifact is missing,
-        so the owner is told to turn a knob that cannot change the outcome."""
+    async def test_mixed_assembly_failure_degrades_and_discloses_both_causes(self):
         from ouroboros.tools import plan_review as pr
-
-        ctx = _make_ctx()
-        ctx.repo_dir = pathlib.Path(".")
-        atlas = SimpleNamespace(
-            text="atlas without ouroboros/llm.py",
-            manifest={
-                "estimated_total_tokens": 500_000,
-                "unassembled_required": [
-                    {"path": "ouroboros/llm.py", "reason": "required file exceeded the atlas hard budget"}
-                ],
-            },
-            status="required_artifact_omitted",
-        )
-        results = {}
-        for level in ("localized", "broad", "constitutional"):
-            with (
-                patch.object(pr, "compile_review_context_atlas", return_value=atlas),
-                patch.object(pr, "build_head_snapshot_section", return_value=("", frozenset())),
-                patch.object(pr, "_load_plan_checklist", return_value="checklist"),
-                patch.object(pr, "load_governance_doc", return_value=""),
-                patch.object(pr, "_start_planning_swarm", side_effect=_completed_planning_swarm),
-                patch("ouroboros.config.get_review_models", return_value=["model-a", "model-b"]),
-                patch.object(pr, "_get_review_models", return_value=["model-a", "model-b"]),
-                patch("ouroboros.tools.plan_review.estimate_tokens", return_value=10_000),
-            ):
-                results[level] = await pr._run_plan_review_async(
-                    ctx, _plan_request("my plan", "my goal", [], context_level=level),
-                )
-
-        for level, result in results.items():
-            self.assertNotIn("choose a smaller context_level", result, level)
-            self.assertIn("Shrink or split the named artifact(s)", result, level)
-
-    async def test_mixed_assembly_failure_reports_both_causes_and_mixed_remedy(self):
-        """The MIXED failure: required rows survive on a pack that ALSO overflowed
-        the hard budget (required candidates are marked budget_omitted before the
-        rendered pack is tested against it). The refusal must render BOTH causes
-        and prescribe the mixed remedy — each single-cause remedy states something
-        false for the other cause ("narrowing cannot help" vs "split the plan")."""
-        from ouroboros.tools import plan_review as pr
-        from ouroboros.tools.review_context_atlas import ATLAS_MIXED_ASSEMBLY_REMEDY
 
         ctx = _make_ctx()
         ctx.repo_dir = pathlib.Path(".")
@@ -2752,6 +2792,10 @@ class TestPlanReviewBudgetGate(unittest.IsolatedAsyncioTestCase):
             },
             status="budget_exceeded",
         )
+        reviews = [
+            {"model": model, "text": _review_text("GREEN"), "error": None}
+            for model in ("model-a", "model-b")
+        ]
         with (
             patch.object(pr, "compile_review_context_atlas", return_value=atlas),
             patch.object(pr, "build_head_snapshot_section", return_value=("", frozenset())),
@@ -2761,20 +2805,19 @@ class TestPlanReviewBudgetGate(unittest.IsolatedAsyncioTestCase):
             patch("ouroboros.config.get_review_models", return_value=["model-a", "model-b"]),
             patch.object(pr, "_get_review_models", return_value=["model-a", "model-b"]),
             patch("ouroboros.tools.plan_review.estimate_tokens", return_value=10_000),
+            patch.object(pr, "review_wave_budget_gate", return_value=None),
+            patch.object(pr, "_run_plan_review_slots", new=AsyncMock(return_value=reviews)) as slots,
         ):
             result = await pr._run_plan_review_async(
                 ctx,
                 _plan_request("my plan", "my goal", [], context_level="constitutional"),
             )
 
-        self.assertIn("PLAN_REVIEW_SKIPPED", result)
-        # Both causes are rendered — the overflow is not suppressed behind the rows…
+        self.assertIn("PLAN_CONTEXT_DEGRADED", result)
+        self.assertNotIn("PLAN_REVIEW_SKIPPED", result)
         self.assertIn("ouroboros/llm.py", result)
         self.assertIn("exceeded hard budget", result)
-        # …and the remedy is the mixed one, neither single-cause half-truth.
-        self.assertIn(ATLAS_MIXED_ASSEMBLY_REMEDY, result)
-        self.assertNotIn("choose a smaller context_level", result)
-        self.assertNotIn("narrowing the reviewed change cannot help", result)
+        slots.assert_awaited_once()
 
     async def test_proceeds_when_within_budget(self):
         """When prompt is within budget, reviewers are called."""
@@ -2892,7 +2935,8 @@ class TestPlanReviewToolRegistration(unittest.TestCase):
         # context_level is NOT schema-required (triad r2 self_consistency): the host
         # enforces explicit choice for self_mod while non-self_mod may omit it
         # (defaults to minimal) — an unconditional `required` contradicted that.
-        self.assertEqual(tool.schema["parameters"]["required"], ["plan", "goal"])
+        self.assertEqual(tool.schema["parameters"]["required"], [])
+        self.assertIn("review_disposition ONLY", tool.schema["description"])
         self.assertNotIn("auto", params["context_level"].get("enum", []))
 
     def test_public_registry_rejects_unknown_plan_task_arguments(self):
@@ -3104,9 +3148,10 @@ class TestPlanReviewIntentAndDisposition(unittest.TestCase):
         self.assertEqual(summary["aggregate_signal"], "REVIEW_REQUIRED")
         self.assertIn("must precede AGGREGATE", summary["projection_errors"][1])
 
-    def _write_review(self, tmp_path, *, aggregate="REVIEW_REQUIRED", component_hashes=None):
+    def _write_review(self, tmp_path, *, aggregate="REVIEW_REQUIRED"):
         from ouroboros.task_results import (
             plan_review_wave_handoffs,
+            record_plan_review_attempt,
             record_plan_review_collection,
             record_plan_review_result,
             reserve_plan_review_wave,
@@ -3128,6 +3173,7 @@ class TestPlanReviewIntentAndDisposition(unittest.TestCase):
                 {"finding_id": "plan-slot-2:f2", "summary": "two"},
             ],
         }
+        record_plan_review_attempt(tmp_path, "parent", fingerprint=fingerprint)
         reserve_plan_review_wave(
             tmp_path,
             "parent",
@@ -3135,7 +3181,6 @@ class TestPlanReviewIntentAndDisposition(unittest.TestCase):
             plan_text_hash=hashlib.sha256(b"P").hexdigest(),
             scout_roles=[],
             cutoff_at="2099-01-01T00:00:00+00:00",
-            component_hashes=component_hashes,
         )
         record_plan_review_collection(
             tmp_path,
@@ -3350,6 +3395,7 @@ class TestPlanReviewIntentAndDisposition(unittest.TestCase):
         import ouroboros.tools.plan_review as pr
         from ouroboros.task_results import (
             load_plan_review_state,
+            record_plan_review_attempt,
             record_plan_review_collection,
             record_plan_review_result,
             reserve_plan_review_wave,
@@ -3397,6 +3443,9 @@ class TestPlanReviewIntentAndDisposition(unittest.TestCase):
                     },
                 )
 
+            # A valid A re-presentation selects A as the current authority before
+            # the free reference-only disposition call.
+            record_plan_review_attempt(root, ctx.task_id, fingerprint=a_fp)
             represented = pr._reuse_or_disposition_plan_review(ctx, a_fp, None, a_hash)
             self.assertIn("PLAN_REVIEW_OUTCOME: REVIEW_REQUIRED", represented)
             self.assertIn("Cached exact review:** True", represented)
@@ -3456,6 +3505,106 @@ class TestPlanReviewIntentAndDisposition(unittest.TestCase):
             self.assertTrue(stored["review"]["closed"])
             self.assertEqual(len(stored["review"]["disposition"]["items"]), 2)
 
+    def test_legacy_integrated_review_without_status_accepts_disposition(self):
+        import tempfile
+
+        import ouroboros.tools.plan_review as pr
+        from ouroboros.task_results import (
+            PLAN_REVIEW_STATE_KEY,
+            load_plan_review_state,
+            task_result_path,
+        )
+
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            ctx, fingerprint = self._write_review(root)
+            result_path = task_result_path(root, ctx.task_id, create=False)
+            result = json.loads(result_path.read_text(encoding="utf-8"))
+            result[PLAN_REVIEW_STATE_KEY]["waves"][0].pop("review_evidence_status")
+            result_path.write_text(json.dumps(result), encoding="utf-8")
+            self.assertNotIn(
+                "review_evidence_status",
+                load_plan_review_state(root, ctx.task_id)["waves"][0],
+            )
+
+            out = pr._handle_plan_task(ctx, review_disposition={
+                "review_fingerprint": fingerprint,
+                "items": [
+                    {
+                        "finding_id": "plan-slot-1:f1",
+                        "decision": "reject",
+                        "rationale": "The finding does not change the selected seam.",
+                    },
+                    {
+                        "finding_id": "plan-slot-2:f2",
+                        "decision": "reject",
+                        "rationale": "The finding is outside the explicit non-goals.",
+                    },
+                ],
+            })
+
+            self.assertIn('"outcome":"REVIEW_REQUIRED","closed":true', out)
+            stored = load_plan_review_state(root, ctx.task_id)["waves"][0]
+            self.assertEqual(stored["review_evidence_status"], "integrated")
+
+    def test_legacy_open_review_without_current_attempt_accepts_disposition(self):
+        import tempfile
+
+        import ouroboros.tools.plan_review as pr
+        from ouroboros.task_results import (
+            PLAN_REVIEW_STATE_KEY,
+            load_plan_review_state,
+            plan_review_gate_projection,
+            task_result_path,
+        )
+
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            ctx, fingerprint = self._write_review(root)
+            result_path = task_result_path(root, ctx.task_id, create=False)
+            result = json.loads(result_path.read_text(encoding="utf-8"))
+            result[PLAN_REVIEW_STATE_KEY].pop("current_attempt")
+            result_path.write_text(json.dumps(result), encoding="utf-8")
+
+            legacy = load_plan_review_state(root, ctx.task_id)
+            self.assertEqual(
+                legacy["current_attempt"],
+                {
+                    "fingerprint": fingerprint,
+                    "status": "open",
+                    "reason": "legacy_latest_review",
+                },
+            )
+            self.assertFalse(plan_review_gate_projection(legacy, "blocking")["allow"])
+
+            disposition = {
+                "review_fingerprint": fingerprint,
+                "items": [
+                    {
+                        "finding_id": "plan-slot-1:f1",
+                        "decision": "reject",
+                        "rationale": "The finding does not change the selected seam.",
+                    },
+                    {
+                        "finding_id": "plan-slot-2:f2",
+                        "decision": "reject",
+                        "rationale": "The finding is outside the explicit non-goals.",
+                    },
+                ],
+            }
+            out = pr._handle_plan_task(ctx, review_disposition=disposition)
+
+            self.assertIn('"outcome":"REVIEW_REQUIRED","closed":true', out)
+            stored = load_plan_review_state(root, ctx.task_id)
+            self.assertEqual(stored["current_attempt"], legacy["current_attempt"])
+            self.assertTrue(plan_review_gate_projection(stored, "blocking")["allow"])
+
+            result = json.loads(result_path.read_text(encoding="utf-8"))
+            result[PLAN_REVIEW_STATE_KEY].pop("current_attempt")
+            result_path.write_text(json.dumps(result), encoding="utf-8")
+            replayed = pr._handle_plan_task(ctx, review_disposition=disposition)
+            self.assertIn('"outcome":"REVIEW_REQUIRED","closed":true', replayed)
+
     def test_closed_disposition_replay_is_idempotent_and_contradiction_is_rejected(self):
         import tempfile
 
@@ -3514,6 +3663,7 @@ class TestPlanReviewIntentAndDisposition(unittest.TestCase):
         from ouroboros.task_results import (
             load_plan_review_state,
             plan_review_wave,
+            record_plan_review_attempt,
             record_plan_review_result,
         )
 
@@ -3566,8 +3716,21 @@ class TestPlanReviewIntentAndDisposition(unittest.TestCase):
                     require_latest=True,
                 )
 
+            record_plan_review_attempt(
+                root, ctx.task_id, fingerprint="b" * 64, reason="newer raw attempt",
+            )
+            before = load_plan_review_state(root, ctx.task_id)
+            with pytest.raises(ValueError, match="PLAN_REVIEW_DISPOSITION_STALE"):
+                record_plan_review_result(
+                    root,
+                    ctx.task_id,
+                    fingerprint=fingerprint,
+                    review=replay,
+                    require_latest=True,
+                )
+            self.assertEqual(load_plan_review_state(root, ctx.task_id), before)
+
     def test_disposition_closes_near_deadline_without_configured_reviewers(self):
-        import asyncio
         import tempfile
         from datetime import datetime, timedelta, timezone
 
@@ -3586,11 +3749,13 @@ class TestPlanReviewIntentAndDisposition(unittest.TestCase):
                 context_notes="", plan_class="external", scope={}, include_tests=False,
             )
             from ouroboros.task_results import (
+                record_plan_review_attempt,
                 record_plan_review_collection,
                 record_plan_review_result,
                 reserve_plan_review_wave,
             )
 
+            record_plan_review_attempt(root, "parent", fingerprint=fingerprint)
             reserve_plan_review_wave(
                 root,
                 "parent",
@@ -3630,18 +3795,12 @@ class TestPlanReviewIntentAndDisposition(unittest.TestCase):
             with (
                 patch("ouroboros.config.get_review_models", return_value=[]),
                 patch.object(pr, "_get_review_models", side_effect=AssertionError("no reviewer call")),
+                patch.object(
+                    pr, "_record_raw_plan_request_attempt",
+                    side_effect=AssertionError("disposition-only must not create a raw attempt"),
+                ),
             ):
-                out = asyncio.run(pr._run_plan_review_async(
-                    ctx,
-                    _plan_request(
-                        "P",
-                        "G",
-                        [],
-                        context_level="minimal",
-                        plan_class="external",
-                        review_disposition=disposition,
-                    ),
-                ))
+                out = pr._handle_plan_task(ctx, review_disposition=disposition)
             self.assertIn('"outcome":"REVIEW_REQUIRED","closed":true', out)
             self.assertNotIn("PLAN_TASK_SKIPPED_DEADLINE", out)
 
@@ -3719,124 +3878,51 @@ class TestPlanReviewIntentAndDisposition(unittest.TestCase):
             self.assertIn("PLAN_REVIEW_DISPOSITION_REQUIRED", as_vacuous)
             self.assertNotIn("PLAN_REVIEW_DISPOSITION_STALE", as_vacuous)
 
-    def test_populated_disposition_without_prior_review_is_ignored_unbindable(self):
-        # v6.80.0: an UNBINDABLE non-empty disposition FAILS FAST instead of being
-        # discarded before a paid wave. The v6.65.2 anti-wedge guarantee is preserved
-        # EXPLICITLY in the error text ("OMIT review_disposition entirely"), so a model
-        # that fabricated a placeholder learns the exact way out instead of silently
-        # paying for a full scout+reviewer wave it did not intend.
+    def test_disposition_without_prior_review_is_stale_and_free(self):
         import tempfile
         import ouroboros.tools.plan_review as pr
         from ouroboros.tools.registry import ToolContext
 
         with tempfile.TemporaryDirectory() as raw:
             root = pathlib.Path(raw)
-            for populated in (
-                {"review_fingerprint": "d" * 64, "items": []},
-                {"review_fingerprint": "dummy", "items": [{
-                    "finding_id": "dummy",
-                    "decision": "reject",
-                    "rationale": "not prior review",
-                }]},
-                {"review_fingerprint": "", "items": [{
-                    "finding_id": "plan-slot-1:f1",
-                    "decision": "reject",
-                    "rationale": "n/a",
-                }]},
-            ):
-                ctx = ToolContext(repo_dir=root, drive_root=root)
-                ctx.task_id = "parent"
-                out = pr._reuse_or_disposition_plan_review(
-                    ctx, "c" * 64, populated, hashlib.sha256(b"P").hexdigest()
+            ctx = ToolContext(repo_dir=root, drive_root=root)
+            ctx.task_id = "parent"
+            with patch.object(pr, "_run_plan_review_async") as run:
+                out = pr._handle_plan_task(
+                    ctx,
+                    review_disposition={"review_fingerprint": "d" * 64, "items": []},
                 )
-                self.assertIsNotNone(out, f"unbindable={populated!r} must fail fast")
-                self.assertIn("PLAN_REVIEW_DISPOSITION_UNBINDABLE", out)
-                self.assertIn("OMIT review_disposition entirely", out)
-                self.assertIn("no wave was launched", out)
+            self.assertIn("PLAN_REVIEW_DISPOSITION_STALE", out)
+            run.assert_not_called()
+            self.assertFalse((root / "task_results" / "parent.json").exists())
 
-    def test_agent_envelope_drift_is_unbindable_not_a_warning(self):
-        """The P3 plan gate: a review of `[a.py]` must NOT close a submission for
-        `[a.py, b.py, c.py]`.
-
-        `files_to_touch` is exported in the tool schema as PART OF THE REVIEW IDENTITY
-        ("a review_disposition can only close a review submitted with the SAME list"),
-        and the binding fingerprint is a pure function of the agent's envelope. Binding a
-        drifted envelope and merely PREPENDING an ENVELOPE_MISMATCH note let stale plan
-        review authorise materially expanded scope; the claimed fingerprint must equal
-        the submitted one, and a mismatch fails fast so the agent runs a real review."""
+    def test_mixed_disposition_and_plan_envelope_is_rejected_without_mutation(self):
         import tempfile
-
         import ouroboros.tools.plan_review as pr
-        from ouroboros.tools.review_synthesis import plan_review_component_hashes
-
-        reviewed = pr._PlanReviewRequest(plan="P", goal="G", files_to_touch=["a.py"])
-        submitted = pr._PlanReviewRequest(
-            plan="P", goal="G", files_to_touch=["a.py", "b.py", "c.py"],
-        )
-        plan_hash = hashlib.sha256(b"P").hexdigest()
-        disposition = {"review_fingerprint": "a" * 64, "items": [
-            {"finding_id": "plan-slot-1:f1", "decision": "reject", "rationale": "one"},
-            {"finding_id": "plan-slot-2:f2", "decision": "reject", "rationale": "two"},
-        ]}
+        from ouroboros.task_results import load_plan_review_state
 
         with tempfile.TemporaryDirectory() as raw:
-            ctx, _ = self._write_review(
-                pathlib.Path(raw),
-                component_hashes=plan_review_component_hashes(reviewed),
-            )
-            # The submitted envelope grew, so its fingerprint differs from the reviewed
-            # one: the disposition names a review of something else and cannot close it.
-            drifted = pr._reuse_or_disposition_plan_review(
-                ctx, "e" * 64, disposition, plan_hash, submitted,
-            )
-            self.assertIsNotNone(drifted)
-            self.assertIn("PLAN_REVIEW_DISPOSITION_UNBINDABLE", drifted)
-            self.assertIn("ENVELOPE_MISMATCH on: files_to_touch", drifted)
-            self.assertIn("OMIT review_disposition entirely", drifted)
-            self.assertIn("no wave was launched", drifted)
-
-        # The SAME agent envelope still closes its own review, and HOST-RESOLVED drift
-        # (resolved plan_class / context_level, deliberately outside the binding
-        # identity) is reported as a note rather than blocking the close.
-        with tempfile.TemporaryDirectory() as raw:
-            ctx, fingerprint = self._write_review(
-                pathlib.Path(raw),
-                component_hashes=plan_review_component_hashes(reviewed),
-            )
-            escalated = pr._PlanReviewRequest(
-                plan="P", goal="G", files_to_touch=["a.py"], plan_class="self_mod",
-            )
-            bound = pr._reuse_or_disposition_plan_review(
-                ctx, fingerprint,
-                {**disposition, "review_fingerprint": fingerprint},
-                plan_hash, escalated,
-            )
-            self.assertIsNotNone(bound)
-            self.assertNotIn("PLAN_REVIEW_DISPOSITION_UNBINDABLE", bound)
-            self.assertIn("ENVELOPE_MISMATCH on: plan_class", bound)
-
-        # ...and the unbindable path names the same drift instead of nothing.
-        state = {
-            "latest_review_fingerprint": "a" * 64,
-            "waves": [{
-                "request_fingerprint": "a" * 64,
-                "plan_text_hash": plan_hash,
-                "component_hashes": plan_review_component_hashes(reviewed),
-            }],
-        }
-        unbindable = pr._unbindable_disposition_error(
-            state, "e" * 64, {"review_fingerprint": "z" * 64, "items": []}, plan_hash, submitted,
-        )
-        self.assertIn("PLAN_REVIEW_DISPOSITION_UNBINDABLE", unbindable)
-        self.assertIn("ENVELOPE_MISMATCH on: files_to_touch", unbindable)
-        # An UNCHANGED envelope reports nothing, and so does a caller with no request.
-        same = pr._unbindable_disposition_error(
-            state, "e" * 64, {"review_fingerprint": "z" * 64, "items": []}, plan_hash, reviewed,
-        )
-        self.assertNotIn("ENVELOPE_MISMATCH", same)
-        self.assertNotIn("ENVELOPE_MISMATCH", pr._unbindable_disposition_error(
-            state, "e" * 64, {"review_fingerprint": "z" * 64, "items": []}, plan_hash,
-        ))
+            root = pathlib.Path(raw)
+            ctx, fingerprint = self._write_review(root)
+            before = load_plan_review_state(root, ctx.task_id)
+            disposition = {
+                "review_fingerprint": fingerprint,
+                "items": [
+                    {"finding_id": "plan-slot-1:f1", "decision": "reject", "rationale": "one"},
+                    {"finding_id": "plan-slot-2:f2", "decision": "reject", "rationale": "two"},
+                ],
+            }
+            with patch.object(pr, "_record_raw_plan_request_attempt") as record, patch.object(
+                pr, "_run_plan_review_async",
+            ) as run:
+                out = pr._handle_plan_task(
+                    ctx, plan="P changed", goal="G", files_to_touch=["a.py", "b.py"],
+                    review_disposition=disposition,
+                )
+            self.assertIn("PLAN_REVIEW_DISPOSITION_MIXED_ENVELOPE", out)
+            record.assert_not_called()
+            run.assert_not_called()
+            self.assertEqual(load_plan_review_state(root, ctx.task_id), before)
 
     def test_state_lookup_failure_is_error_not_absence(self):
         # Consultation guard: an indeterminate state store must ERROR, never be
@@ -3861,33 +3947,44 @@ class TestPlanReviewIntentAndDisposition(unittest.TestCase):
             self.assertIn("PLAN_REVIEW_STATE_INVALID", out)
             self.assertNotIn("PLAN_REVIEW_DISPOSITION_UNBINDABLE", out)
 
-    def test_handle_plan_task_surfaces_unbindable_disposition_error(self):
-        """v6.80.0: the tool result is the fail-fast error itself, not a note tacked
-        onto a review that was paid for anyway."""
+    def test_disposition_cannot_revive_review_superseded_by_new_attempt(self):
+        import tempfile
         import ouroboros.tools.plan_review as pr
-        from unittest.mock import patch
-        from ouroboros.tools.registry import ToolContext
+        from ouroboros.task_results import load_plan_review_state, record_plan_review_attempt
 
-        async def _stub(ctx, request):
-            return pr._unbindable_disposition_error(
-                {"waves": []}, "c" * 64, request.review_disposition, "planhash",
-            )
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            ctx, fingerprint = self._write_review(root)
+            record_plan_review_attempt(root, ctx.task_id, fingerprint="b" * 64)
+            before = load_plan_review_state(root, ctx.task_id)
+            with patch.object(pr, "_run_plan_review_async") as run:
+                out = pr._handle_plan_task(ctx, review_disposition={
+                    "review_fingerprint": fingerprint,
+                    "items": [
+                        {"finding_id": "plan-slot-1:f1", "decision": "reject", "rationale": "one"},
+                        {"finding_id": "plan-slot-2:f2", "decision": "reject", "rationale": "two"},
+                    ],
+                })
+            self.assertIn("PLAN_REVIEW_DISPOSITION_STALE", out)
+            run.assert_not_called()
+            self.assertEqual(load_plan_review_state(root, ctx.task_id), before)
+
+    def test_vacuous_disposition_only_is_rejected_before_raw_attempt(self):
+        import ouroboros.tools.plan_review as pr
+        from ouroboros.tools.registry import ToolContext
 
         ctx = ToolContext(repo_dir=pathlib.Path("."), drive_root=pathlib.Path("."))
         ctx.task_id = "parent"
-        with patch.object(pr, "_record_raw_plan_request_attempt"), patch.object(
-            pr, "_run_plan_review_async", _stub,
-        ):
+        with patch.object(pr, "_record_raw_plan_request_attempt") as record, patch.object(
+            pr, "_run_plan_review_async",
+        ) as run:
             out = pr._handle_plan_task(
-                ctx,
-                plan="P",
-                goal="G",
-                review_disposition={"review_fingerprint": "dummy", "items": [
-                    {"finding_id": "dummy", "decision": "reject", "rationale": "x"}
-                ]},
+                ctx, review_disposition={"review_fingerprint": "", "items": []},
             )
-        self.assertIn("PLAN_REVIEW_DISPOSITION_UNBINDABLE", out)
-        self.assertIn("OMIT review_disposition entirely", out)
+        self.assertIn("PLAN_REVIEW_DISPOSITION_EMPTY", out)
+        self.assertIn("No plan attempt was recorded", out)
+        record.assert_not_called()
+        run.assert_not_called()
 
     def test_handle_plan_task_notes_ignored_vacuous_disposition(self):
         import ouroboros.tools.plan_review as pr


### PR DESCRIPTION
Partially fixes #102. plan_task now closes REVIEW_REQUIRED from a disposition-only fingerprint reference, keeps main-agent judgment across blocking and advisory modes, and rejects mixed disposition plus plan calls without mutating authority. If a nonminimal Atlas or the final reviewer packet cannot fit, it reuses the same fingerprint and scout wave and falls back once to a loudly disclosed minimal packet. Reviewer counts are now truthful, and planning scouts continue through the generic auto route with its existing visible native fallback.

Verified with 320 focused and smoke tests, ruff, compile and diff checks, two Sol MAX reviewers, a Fable 5 MAX delta review, the final Gemini and GPT-5.6-sol review lanes, and a hermetic production-handler manual test covering Atlas failure, quorum-fit fallback, disposition replay, blocking projection, and harness fallback. The final scope reviewer flagged the intentional rare case where a huge required file cannot fit; Anton explicitly accepted the disclosed minimal fallback. No version bump is included in this proposal branch.