### PR TITLE
fix(claudexor): drop empty PATH components from the owned daemon's child env

### DIFF
--- a/ouroboros/claudexor_daemon.py
+++ b/ouroboros/claudexor_daemon.py
@@ -319,7 +319,15 @@ class OwnedClaudexorDaemon:
                 # a PATH holding only the Node bin dir (the engine then reports
                 # git_missing). Prepend onto whichever key the host actually has.
                 path_key = next((k for k in env if k.upper() == "PATH"), "PATH")
-                env[path_key] = f"{command_bin}{os.pathsep}{env.get(path_key, '')}"
+                # An EMPTY PATH component means the CURRENT WORKING DIRECTORY on
+                # POSIX. A host with no PATH (a scrubbed service manager, a bare
+                # container unit) would otherwise leave a trailing empty entry
+                # here and make CWD an executable search root for a long-lived
+                # daemon that shells out to tools of its own. Drop every empty
+                # component; order is otherwise preserved exactly.
+                inherited = str(env.get(path_key, "") or "")
+                composed = [str(command_bin), *inherited.split(os.pathsep)]
+                env[path_key] = os.pathsep.join(part for part in composed if part)
             runtime = get_runtime_manager().status()
             log_path = config_dir / "daemon.log"
             from ouroboros.config import DATA_DIR

--- a/tests/test_claudexor_owned_daemon.py
+++ b/tests/test_claudexor_owned_daemon.py
@@ -1270,3 +1270,68 @@ def test_spawn_env_prepends_onto_the_hosts_own_path_key(monkeypatch, tmp_path):
     assert "PATH" not in env, "a second differently-cased PATH key was added"
     assert env["Path"].startswith(node_bin + os_mod.pathsep)
     assert env["Path"].endswith("C:/hostedtoolcache/git/bin")
+
+
+def test_spawn_env_never_leaves_an_empty_path_component(monkeypatch, tmp_path):
+    """EMPTY PATH COMPONENT == CWD. The env builder composes the child's PATH as
+    f"{command_bin}{os.pathsep}{inherited}", so a host whose environment carries
+    no PATH at all (a scrubbed service manager, a bare container unit) yields a
+    TRAILING EMPTY component -- and an empty component means the current working
+    directory on POSIX. That would make CWD an executable search root for a
+    long-lived daemon that shells out to tools of its own.
+
+    Measured, not argued: with a trailing-empty PATH a bare-name binary in the
+    working directory EXECUTED (rc 0); the same exec with the empty component
+    removed raised FileNotFoundError."""
+    import os as os_mod
+    import sys
+
+    from ouroboros.gateways.claudexor import ClaudexorUnavailable
+
+    data_dir = tmp_path / "data"
+    config_dir = data_dir / "claudexor"
+    _point_owned_home(monkeypatch, config_dir, data_dir)
+    config_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("OUROBOROS_CLAUDEXOR_BIN", sys.executable)
+    monkeypatch.setattr(owned, "_SPAWN_WAIT_SEC", 0.05)
+    monkeypatch.setattr(owned, "_SPAWN_POLL_SEC", 0.01)
+
+    # A host environment with no PATH key in any casing.
+    fake_environ = {k: v for k, v in os_mod.environ.items() if k.upper() != "PATH"}
+    monkeypatch.setattr(os_mod, "environ", fake_environ)
+
+    captured = {}
+
+    class _NeverReadyChild:
+        pid = 424245
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            pass
+
+    def _capture_spawn(command, **kwargs):
+        captured["env"] = kwargs["env"]
+        return _NeverReadyChild()
+
+    import ouroboros.platform_layer as platform_layer
+
+    monkeypatch.setattr(platform_layer, "process_group_id", lambda _pid: 0)
+    import ouroboros.process_custody as custody_mod
+
+    monkeypatch.setattr(custody_mod, "spawn_supervised", _capture_spawn)
+
+    manager = owned.OwnedClaudexorDaemon()
+    with pytest.raises(ClaudexorUnavailable):
+        manager.ensure_running()
+
+    env = captured["env"]
+    path_key = next((k for k in env if k.upper() == "PATH"), "")
+    assert path_key, "the child received no PATH at all"
+    components = env[path_key].split(os_mod.pathsep)
+    assert "" not in components, (
+        "an empty PATH component reached the daemon's child environment "
+        f"({env[path_key]!r}); on POSIX that is the current working directory"
+    )
+    assert components[0] == str(pathlib.Path(sys.executable).parent)


### PR DESCRIPTION
## An empty PATH component reaches the owned daemon's child environment, and on POSIX that means CWD

`OwnedClaudexorDaemon.ensure_running()` composes the child's PATH as:

```python
path_key = next((k for k in env if k.upper() == "PATH"), "PATH")
env[path_key] = f"{command_bin}{os.pathsep}{env.get(path_key, '')}"
```

When the host environment carries **no PATH key in any casing** — a scrubbed
service manager, a bare container unit — `env.get(path_key, '')` is `''` and the
result is `"<command_bin>:"`: a **trailing empty component**. An empty PATH
component is the *current working directory* on POSIX, so the long-lived daemon
(which shells out to tools of its own) gets CWD as an executable search root.

### Measured, not argued

The semantics, on this host:

```
trailing-empty PATH, exec a bare name present in cwd -> rc 0, "EXECUTED_FROM_CWD"
same exec with the empty component removed           -> FileNotFoundError
```

And the composed value, reproduced through your own test harness (explicit
`OUROBOROS_CLAUDEXOR_BIN` branch, `spawn_supervised` captured):

```
child env PATH == '/…/python-standalone/bin:'
components     == ['/…/python-standalone/bin', '']
```

### The change

One hunk in `ouroboros/claudexor_daemon.py`: build the component list and drop
every empty entry. Ordering is otherwise preserved exactly — `command_bin` still
comes first, the inherited entries keep their order, and the `path_key` casing
behaviour added for the Windows native `Path` key is untouched.

Empty entries are dropped everywhere in the list, not only at the tail: an
interior empty component is the same CWD hazard, and it can only arrive from an
already-malformed inherited PATH.

### Verification

- `tests/test_claudexor_owned_daemon.py::test_spawn_env_never_leaves_an_empty_path_component`
  is **proven to fail against this branch's base** (`AssertionError: an empty PATH
  component reached the daemon's child environment ('/…/bin:')`) and to pass with
  the hunk applied. It reuses the existing `_point_owned_home` harness and asserts
  both directions: no empty component, and `command_bin` still first.
- The whole `tests/test_claudexor_owned_daemon.py` file passes with the change
  (34 passed), including
  `test_spawn_env_prepends_onto_the_hosts_own_path_key`.

**Not verified:** no daemon was actually spawned from a real PATH-less host
environment — the evidence is the composed child env captured at the
`spawn_supervised` seam plus the exec-semantics measurement above, not a live
boot under a scrubbed service manager.

### No version carriers

`VERSION`, `pyproject.toml`, the `README.md` badge/changelog rows,
`web/package.json`, `web/modules/api_types.js` and the `docs/ARCHITECTURE.md`
version header are deliberately **absent** from this diff. A contributor does not
allocate a release; the maintainer squash-lands and picks the number.

### One thing I deliberately did not send

I came here to port a wider fix: widening tool discovery beyond `PATH` so a
GUI-launched packaged app (launchd PATH, no `/opt/homebrew/bin`) could find an
`npm -g` installed `claudexord`, plus resolving the `#!/usr/bin/env node`
interpreter that lives in that same invisible directory.

Reading the current tip first, that is **already solved here, and better**:
`ouroboros/claudexor_runtime.py` plus the populated `claudexor_runtime_pin.json`
install a sha256-verified pinned engine and a pinned Node, and `resolve_command()`
returns an absolute `[node, entrypoint]`, so the owner's PATH is irrelevant on the
live path and no `env node` shebang is involved at all. Porting my version would
have reintroduced a PATH-widening resolution layer for a seam you replaced with a
verified runtime, leaned on a `_MANAGED_NODE_BIN` constant this tree no longer
has, and shipped architecture prose contradicting the code. So it is dropped;
only the residual above is real.

(The remaining PATH-only lookup, `_compatibility_binary()`, is reachable only when
`load_runtime_pin()` returns `None`, which the shipped populated pin prevents — I
left it alone for that reason.)
