### PR TITLE
fix(onboarding): do not block the master with a saved short key

### DIFF
--- a/ouroboros/settings_setup_contract.py
+++ b/ouroboros/settings_setup_contract.py
@@ -317,7 +317,16 @@ def validate_setup_payload(data: dict, current_settings: dict) -> Tuple[dict, st
     runtime_mode = raw_runtime_mode.lower() if raw_runtime_mode else _string(current_settings.get("OUROBOROS_RUNTIME_MODE")) or str(SETTINGS_DEFAULTS["OUROBOROS_RUNTIME_MODE"])
 
     for field in _PROVIDER_FIELDS:
-        value = keys[field["settingKey"]]
+        setting_key = field["settingKey"]
+        value = keys[setting_key]
+        # Only a credential the owner authored in THIS payload is length-checked.
+        # build_initial_setup_state prefills every provider field from disk, so a
+        # stored value the owner never touched arrives here unchanged; rejecting it
+        # deadlocks the wizard, because the rejection discards the WHOLE payload —
+        # including the replacement key typed in the same form. The value that
+        # triggers the error then becomes the one value that can never be replaced.
+        if value == _string(current_settings.get(setting_key)):
+            continue
         if (
             value
             and (field.get("inputType") or "password") == "password"

--- a/tests/test_onboarding_wizard.py
+++ b/tests/test_onboarding_wizard.py
@@ -619,3 +619,60 @@ def test_launcher_binds_the_settings_writer_the_wizard_callback_calls():
     assert callable(getattr(launcher, "save_settings", None))
     source = pathlib.Path(launcher.__file__).read_text(encoding="utf-8")
     assert "onboarding_safety_default=wizard_authors_safety" in source
+
+
+def test_wizard_rejects_a_newly_typed_short_key():
+    """The length check still guards a credential the owner actually authored."""
+    payload = _base_payload()
+    payload["OPENAI_API_KEY"] = "sk-openai-1234567890"
+    payload["OPENAI_COMPATIBLE_API_KEY"] = "ollama"
+
+    prepared, error = prepare_onboarding_settings(payload, {})
+
+    assert prepared == {}
+    assert error == "OpenAI-compatible API key looks too short."
+
+
+def test_wizard_is_not_deadlocked_by_a_short_key_already_on_disk():
+    """A stored too-short key must not veto the save that replaces it.
+
+    build_initial_setup_state prefills every provider field from disk, so an
+    untouched field posts the stored value back. Rejecting it discards the WHOLE
+    payload — including the replacement typed in the same form — which makes the
+    offending value the one value the wizard can never overwrite.
+    """
+    stored = {
+        "OPENAI_COMPATIBLE_API_KEY": "ollama",
+        "OPENAI_COMPATIBLE_BASE_URL": "http://127.0.0.1:4000/v1",
+    }
+
+    # 1. An unrelated change saves even though the short key rides along untouched.
+    payload = _base_payload()
+    payload["OPENAI_COMPATIBLE_API_KEY"] = "ollama"
+    payload["OPENAI_COMPATIBLE_BASE_URL"] = "http://127.0.0.1:4000/v1"
+    payload["OPENAI_API_KEY"] = "sk-openai-1234567890"
+
+    prepared, error = prepare_onboarding_settings(payload, stored)
+
+    assert error is None
+    assert prepared["OPENAI_COMPATIBLE_API_KEY"] == "ollama"
+
+    # 2. The owner can replace the short key with a real one.
+    payload["OPENAI_COMPATIBLE_API_KEY"] = "sk-replacement-key-1234"
+
+    prepared, error = prepare_onboarding_settings(payload, stored)
+
+    assert error is None
+    assert prepared["OPENAI_COMPATIBLE_API_KEY"] == "sk-replacement-key-1234"
+
+
+def test_wizard_still_rejects_shortening_a_stored_key():
+    """Editing a stored key DOWN to a too-short value is authorship, not a prefill."""
+    stored = {"OPENAI_API_KEY": "sk-openai-1234567890"}
+    payload = _base_payload()
+    payload["OPENAI_API_KEY"] = "sk-short"
+
+    prepared, error = prepare_onboarding_settings(payload, stored)
+
+    assert prepared == {}
+    assert error == "OpenAI API key looks too short."

--- a/tests/test_onboarding_wizard.py
+++ b/tests/test_onboarding_wizard.py
@@ -640,10 +640,13 @@ def test_wizard_is_not_deadlocked_by_a_short_key_already_on_disk():
     untouched field posts the stored value back. Rejecting it discards the WHOLE
     payload — including the replacement typed in the same form — which makes the
     offending value the one value the wizard can never overwrite.
+
+    The stored fixture deliberately carries ONLY the short key: a stored
+    OPENAI_COMPATIBLE_BASE_URL would make has_startup_ready_provider() true and
+    the wizard would never open for this install in the first place.
     """
     stored = {
         "OPENAI_COMPATIBLE_API_KEY": "ollama",
-        "OPENAI_COMPATIBLE_BASE_URL": "http://127.0.0.1:4000/v1",
     }
 
     # 1. An unrelated change saves even though the short key rides along untouched.
@@ -676,3 +679,17 @@ def test_wizard_still_rejects_shortening_a_stored_key():
 
     assert prepared == {}
     assert error == "OpenAI API key looks too short."
+
+
+def test_onboarding_frontend_exempts_unchanged_prefilled_keys_from_length_check():
+    """The client-side mirror of the length check carries the same authorship rule.
+
+    validateProvidersStep() runs the identical <10 rule against state prefilled
+    from disk and blocks Next/Save BEFORE the payload reaches the server, so the
+    server-side exemption alone leaves the wizard deadlocked. The JS must skip
+    the length check for a value equal to its INITIAL_STATE prefill — and only
+    for that value, so a newly typed short key is still rejected client-side.
+    """
+    source = (REPO / "web/modules/onboarding_wizard.js").read_text(encoding="utf-8")
+
+    assert "value.length < 10 && value !== trim(INITIAL_STATE[field.stateKey])" in source

--- a/web/modules/onboarding_wizard.js
+++ b/web/modules/onboarding_wizard.js
@@ -224,7 +224,13 @@
             const keyValues = PROVIDER_FIELDS.map((field) => [field, trim(state[field.stateKey])]);
             const localSource = trim(state.localSource);
             const localFilename = trim(state.localFilename);
-            const shortKey = keyValues.find(([field, value]) => value && (field.inputType || 'password') === 'password' && value.length < 10);
+            // Only a credential the owner authored in THIS form is length-checked —
+            // the same authorship rule validate_setup_payload applies server-side.
+            // The wizard prefills every provider field from disk, so a stored value
+            // the owner never touched arrives here unchanged; rejecting it blocks
+            // Next/Save on the providers step and the offending value becomes the
+            // one value the wizard can never replace.
+            const shortKey = keyValues.find(([field, value]) => value && (field.inputType || 'password') === 'password' && value.length < 10 && value !== trim(INITIAL_STATE[field.stateKey]));
             if (shortKey) return `${shortKey[0].label.replace(' API Key', '')} API key looks too short.`;
             const hasRemote = keyValues.some(([field, value]) => value && !['OPENAI_COMPATIBLE_API_KEY', 'MINIMAX_REGION'].includes(field.settingKey));
             if (!hasRemote && !localSource) {


### PR DESCRIPTION
The wizard substitutes the values of all provider fields from the disk, so the untouched field is returned to the payload as it is. The minimum length check was also applied to such a substituted value, and a failure discards the payload entirely, along with the replacement entered in the same form. As a result, a too-short saved key became the only value that the wizard could no longer overwrite: any save failed with a message about the short length.

The length is now checked only for the value changed in the current request. The short key entered by the owner is still rejected, including when shortening the previously saved one.

<!--
Thank you for contributing to Ouroboros.

Open this PR against the `ouroboros` branch, not `main` or
`ouroboros-stable`. Keep review artifacts out of the git diff: attach or link
them in the Review evidence section instead.
-->

## Summary
The setup wizard prefills every provider field from disk, so an untouched field
comes back in the payload exactly as stored. The minimum-length check was applied
to that prefilled value as well, and a rejection discards the whole payload —
including the replacement key typed into the same form. A stored key shorter than
the minimum therefore became the one value the wizard could never overwrite: every
save failed with "… API key looks too short."

Observed in the field as an `OPENAI_COMPATIBLE_API_KEY` of `ollama` (6 chars): once
stored, the wizard refused every subsequent save, and the only way out was editing
`~/Ouroboros/data/settings.json` by hand.

The length check now applies only to a value changed in the current request. A short
key the owner actually typed is still rejected, including when an already stored key
is shortened.

## Scope

In scope:

- `ouroboros/settings_setup_contract.py`: in `validate_setup_payload`, skip the
  provider-field length check when the submitted value is identical to what is
  already in `current_settings` — that is, the prefilled value the owner never
  touched.
- `tests/test_onboarding_wizard.py`: three regression tests covering a newly typed
  short key (still rejected), a short key already on disk (no longer deadlocks, and
  can be replaced), and shortening a stored key (still rejected).

Non-goals:

- `build_initial_setup_state` prefills the wizard bootstrap with the stored secret
  itself rather than a placeholder. Unchanged here; it is a separate concern.
- Masked-placeholder round-trips through `/api/settings` are a separate defect and
  are not touched by this PR.
- No change to the length threshold itself, to `_PROVIDER_FIELDS`, or to any other
  validation rule.


## Verification

<!-- List exact commands and outcomes. Do not write only "tests pass". -->

- [x] Focused tests for the changed behavior pass.
- [x] The default local test suite passes, or the reason it was not run is below.
- [x] Lint/static checks relevant to this change pass.

Commands and results (all on the rebased head, base `742776cc`):

```text
$ .venv/bin/python -m ruff check . --select F
All checks passed!

$ .venv/bin/python -m pytest tests/test_onboarding_wizard.py
48 passed, 1 warning in 0.30s

The suite was run as the two-pass CI split described in CONTRIBUTING.md
("Mark non-parallel-safe tests serial") rather than as a single `make test`
invocation:

$ .venv/bin/python -m pytest -n auto \
    -m "not serial and not ui_browser and not ui_browser_docker and not skill_smoke"
2 failed, 7434 passed, 14 skipped, 41 warnings in 417.69s (0:06:57)
  FAILED tests/test_delegated_subagent_transport.py::test_an_unresolvable_write_root_is_a_typed_refusal_not_a_traceback
  FAILED tests/test_claude_code_gateway.py::TestReadGuard::test_confines_by_value_not_by_an_enumerated_field_name

  Both are pre-existing on the base and unrelated to this change. Reproduced on a
  clean worktree checked out at 742776cc with no changes applied:

  $ git worktree add <tmp> managed/ouroboros
  $ .venv/bin/python -m pytest \
      tests/test_delegated_subagent_transport.py::test_an_unresolvable_write_root_is_a_typed_refusal_not_a_traceback \
      "tests/test_claude_code_gateway.py::TestReadGuard::test_confines_by_value_not_by_an_enumerated_field_name"
  2 failed in 0.60s

  Neither touches onboarding, the setup contract, or provider validation.

$ .venv/bin/python -m pytest -m "serial"
366 passed, 7512 deselected, 1 warning in 139.01s (0:02:19)

Regression proof — source change reverted to the base version, new tests kept:
$ git checkout managed/ouroboros -- ouroboros/settings_setup_contract.py
$ .venv/bin/python -m pytest tests/test_onboarding_wizard.py -k deadlocked
FAILED tests/test_onboarding_wizard.py::test_wizard_is_not_deadlocked_by_a_short_key_already_on_disk
E   AssertionError: assert 'OpenAI-compatible API key looks too short.' is None
1 failed, 47 deselected in 0.04s

Not run: tests marked `skill_smoke` — they require OPENROUTER_API_KEY in the
environment and reach external network services. Also not run: `ui_browser` and
`ui_browser_docker`; this change has no rendered UI surface.
```

The three added tests are pure calls into `prepare_onboarding_settings`: no OS
process, no port, no module-level global or registry mutation. They are
parallel-safe and correctly carry no `serial` marker.

## Visual evidence

<!-- Check one. Visible UI changes need evidence from a real rendered flow. -->

- [x] Not applicable; this PR has no visible UI change.
- [ ] Before/after screenshots or other rendered-flow evidence are attached below.

Evidence: none. The wizard markup and field set are unchanged; only server-side
validation of the submitted payload differs.

## Governance and documentation

- [x] I followed `CONTRIBUTING.md` and checked the relevant guidance in
      `BIBLE.md`, `docs/ARCHITECTURE.md`, `docs/DEVELOPMENT.md`, and
      `docs/CHECKLISTS.md`.
- [x] I updated tests and documentation where behavior or architecture changed.
- [x] I did not include secrets, local settings, runtime state, logs, caches, or
      generated build/review artifacts in the commit.
- [x] I did **not** bump `VERSION` or release-only version carriers; maintainers
      assign the collision-free release version during final integration.

## Agent assistance (optional)

<!-- Disclosure is useful context, not a quality signal. Remove this section if unused. -->

- Agent/tool and model:
- Work performed by the agent:
- Human verification performed:

## Review evidence

<!--
Attach or link the final triad/scope review output when available. Evidence must
correspond to the current PR diff; rerun it after code changes or a rebase. If it
was not run, say why. Missing evidence does not prevent opening a PR, but it can
make maintainer integration slower.
-->

- [ ] Triad/scope review evidence is attached or linked below.
- [x] Review was not run; the reason is recorded below.

- Reviewed base SHA: `742776cc`
- Reviewed head/diff SHA: `880854d9`
- Review command/profile: n/a
- Triad verdict: n/a
- Scope verdict: n/a
- Run artifacts/link: n/a
- Known advisory findings or accepted tradeoffs: the equality check treats "value
  unchanged from what is stored" as "not authored in this request". An owner who
  retypes the exact same short value byte-for-byte is therefore not re-validated.
  That is the intended tradeoff: the alternative is the deadlock this PR fixes.
- If not run: `scripts/run_external_review.py --contributor` requires an
  `OPENROUTER_API_KEY` and an authorized `TOTAL_BUDGET`, which were not available
  for this run. The change is 10 added lines in one function, covered by three
  targeted regression tests plus the two-pass local suite recorded above.

## Final checklist

- [x] The PR base branch is `ouroboros`.
- [x] The branch is based on a current `ouroboros` revision (`742776cc`).
- [x] The PR is one coherent change and is ready to be squash-integrated.
- [x] The description explains any limitations, follow-up work, or compatibility impact.
