### PR TITLE
fix: the pytest gate and spawned workers must not read the live repo's update transaction

### DIFF
--- a/supervisor/workers.py
+++ b/supervisor/workers.py
@@ -1191,6 +1191,32 @@ def _current_custody_session_id() -> str:
         return ""
 
 
+def _bind_worker_repo_root(repo_dir: str, drive_root: str = "") -> None:
+    """Point git_ops' roots at the repo and data dir this worker was told to serve.
+
+    ``git_ops.REPO_DIR`` is a module global with no env fallback, and ``git_ops.init()`` is never
+    called at boot, so a worker inherits the hardcoded ``~/Ouroboros/repo`` default. Under the
+    spawn start method (macOS/Windows) the child re-imports the module and gets that default even
+    when it serves a checkout somewhere else — and ``update_merge._update_tx_marker_path()``
+    resolves through it, so the worker's managed-update tool gate would read ANOTHER repo's
+    transaction. Bind it from the ``repo_dir`` this worker already receives.
+
+    ``DRIVE_ROOT`` moves with it: the same re-import leaves it on the default data dir, so a
+    worker serving a custom install would write git_ops' rescue snapshots and logs under an
+    unrelated home directory. Both values are handed to this process; the branch names and
+    REMOTE_URL are NOT, which is also why this is a direct assignment rather than
+    ``git_ops.init()`` — init() would overwrite them with its own defaults, silently retargeting
+    an install whose branches differ. They keep whatever the child imported.
+    """
+    import pathlib as _pl
+
+    from supervisor import git_ops as _git_ops
+
+    _git_ops.REPO_DIR = _pl.Path(repo_dir)
+    if drive_root:
+        _git_ops.DRIVE_ROOT = _pl.Path(drive_root)
+
+
 def _prepare_worker_task_runtime() -> None:
     """Load the managed-update authorization path before a live merge can conflict."""
     import supervisor.update_merge  # noqa: F401
@@ -1205,6 +1231,9 @@ def worker_main(wid: int, in_q: Any, out_q: Any, repo_dir: str, drive_root: str,
     # fork-safety guard (no _scproxy/SCDynamicStoreCopyProxies on the child side
     # of fork) and a clean default for spawned workers too.
     _os.environ["OUROBOROS_IN_WORKER"] = "1"
+    # Before ANY import that resolves the update-tx marker through git_ops (see
+    # _bind_worker_repo_root): a spawned child would otherwise gate on the hardcoded default repo.
+    _bind_worker_repo_root(repo_dir, drive_root)
     # Adopt the server's custody session id. Under the 'spawn' start method this
     # process re-imported process_custody and minted a fresh _SESSION_ID; without
     # adopting the server's id, every service/process this worker records looks

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,13 @@ def _bind_pytest_repo_root() -> None:
     git_ops.REPO_DIR.mkdir(parents=True, exist_ok=True)
 
 
+def git_ops_repo_root() -> pathlib.Path:
+    """The repo root this pytest session binds git_ops (and worker children) to."""
+    from supervisor import git_ops
+
+    return git_ops.REPO_DIR
+
+
 def _bind_pytest_runtime_roots() -> None:
     """Rebind modules that may have been imported before conftest set the env."""
     _bind_pytest_repo_root()
@@ -126,6 +133,10 @@ def _bind_pytest_runtime_roots() -> None:
     state.init(root, state.TOTAL_BUDGET_LIMIT)
     queue.init(root, queue.SOFT_TIMEOUT_SEC, queue.HARD_TIMEOUT_SEC)
     workers.DRIVE_ROOT = root
+    # spawn_workers hands str(workers.REPO_DIR) to every child, and the child binds git_ops to
+    # it — so leaving this at the live default would send workers started BY A TEST back at the
+    # operator's checkout, undoing the isolation above.
+    workers.REPO_DIR = git_ops_repo_root()
 
 
 def _mock_pollution_files(root: pathlib.Path) -> set[pathlib.Path]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,9 @@ import pytest
 
 
 _PYTEST_DATA_DIR = None
+# Repo root for a live-DATA run, which has no pytest data dir to hang it off. Created lazily
+# so the hermetic lane never leaves an unused temp dir behind (see pytest_sessionfinish).
+_PYTEST_REPO_FALLBACK = None
 if os.environ.get("OUROBOROS_ALLOW_LIVE_DATA_TESTS") != "1":
     _LIVE_DATA_ROOT = (
         os.environ.get("OUROBOROS_TEST_LIVE_DATA_ROOT")
@@ -84,8 +87,34 @@ def _restore_pytest_child_isolation() -> None:
         _PYTEST_POPEN_PATCHED = False
 
 
+def _bind_pytest_repo_root() -> None:
+    """Point git_ops.REPO_DIR away from the operator's live checkout.
+
+    Unbound, git_ops.REPO_DIR (no env fallback) sends
+    update_merge._update_tx_marker_path() at the LIVE repo's .git, so a staged managed merge
+    blocks the whole suite through the registry guard. An empty dir with no .git makes the
+    strict read `absent` — the honest allow. Direct assignment: init() would also rewrite
+    BRANCH_DEV/BRANCH_STABLE.
+
+    Keyed on the REPO opt-in (OUROBOROS_ALLOW_LIVE_REPO_TESTS, the same switch git_ops's own
+    destructive-git fuse reads), NOT on the DATA opt-in: they are separate switches, and a run
+    that opts into live DATA has not opted into reading the live repo's update transaction.
+    """
+    if os.environ.get("OUROBOROS_ALLOW_LIVE_REPO_TESTS") == "1":
+        return
+    from supervisor import git_ops
+
+    global _PYTEST_REPO_FALLBACK
+    if _PYTEST_DATA_DIR is None and _PYTEST_REPO_FALLBACK is None:
+        _PYTEST_REPO_FALLBACK = pathlib.Path(tempfile.mkdtemp(prefix="ouroboros-pytest-repo-"))
+    repo_root = (_PYTEST_DATA_DIR or _PYTEST_REPO_FALLBACK) / "repo"
+    git_ops.REPO_DIR = repo_root.resolve(strict=False)
+    git_ops.REPO_DIR.mkdir(parents=True, exist_ok=True)
+
+
 def _bind_pytest_runtime_roots() -> None:
     """Rebind modules that may have been imported before conftest set the env."""
+    _bind_pytest_repo_root()
     if _PYTEST_DATA_DIR is None:
         return
     root = _PYTEST_DATA_DIR.resolve(strict=False)
@@ -210,6 +239,8 @@ def pytest_sessionfinish(session, exitstatus):  # noqa: ARG001
     # Per-process temp data dir (unique mkdtemp per controller/worker) — clean on EVERY process.
     if _PYTEST_DATA_DIR is not None:
         shutil.rmtree(_PYTEST_DATA_DIR, ignore_errors=True)
+    if _PYTEST_REPO_FALLBACK is not None:
+        shutil.rmtree(_PYTEST_REPO_FALLBACK, ignore_errors=True)
 
 
 def pytest_unconfigure(config):  # noqa: ARG001

--- a/tests/test_pytest_repo_root_binding.py
+++ b/tests/test_pytest_repo_root_binding.py
@@ -1,0 +1,73 @@
+"""The pytest session must not resolve the update-tx marker through the LIVE repo.
+
+Unbound, ``git_ops.REPO_DIR`` sends ``update_merge._update_tx_marker_path()`` at the
+operator's real ``~/Ouroboros/repo/.git``, so a staged managed merge makes the registry
+guard block the whole suite.
+"""
+
+import os
+import pathlib
+
+import pytest
+
+import ouroboros.config as config
+import supervisor.git_ops as git_ops
+import supervisor.update_merge as update_merge
+
+
+_LIVE_REPO = (pathlib.Path.home() / "Ouroboros" / "repo").resolve(strict=False)
+
+# OUROBOROS_ALLOW_LIVE_REPO_TESTS=1 is the supported opt-in that deliberately KEEPS the live
+# repo root (git_ops's own destructive-git fuse reads the same switch), so these tests pin
+# behaviour that mode turns off by design.
+_LIVE_REPO_OPT_IN = os.environ.get("OUROBOROS_ALLOW_LIVE_REPO_TESTS") == "1"
+pytestmark = pytest.mark.skipif(_LIVE_REPO_OPT_IN, reason="live-repo opt-in keeps the live root")
+
+
+def test_pytest_session_repo_root_is_not_the_live_repo():
+    """Load-bearing: pins the conftest binding itself, independent of live state.
+
+    Holds in BOTH modes — the repo binding is keyed on the repo opt-in, not the data one, so a
+    live-DATA run still gets a throwaway repo root (its path is then a temp dir, not DATA_DIR).
+    """
+    bound = git_ops.REPO_DIR.resolve(strict=False)
+    assert bound != _LIVE_REPO
+    if os.environ.get("OUROBOROS_ALLOW_LIVE_DATA_TESTS") != "1":
+        assert bound == (config.DATA_DIR / "repo").resolve(strict=False)
+    marker = update_merge._update_tx_marker_path().resolve(strict=False)
+    assert marker == bound / ".git" / "ouroboros-update-tx.json"
+
+
+def test_ambient_tx_read_is_absent_in_pytest():
+    """The ambient (un-monkeypatched) strict read is the honest ``absent`` allow.
+
+    NOTE: with no live marker staged this also passes on the unfixed tree — it is a
+    behavioural statement, not evidence. The test above is the load-bearing one.
+    """
+    from ouroboros.tools.registry import _managed_update_code_tool_block
+
+    assert update_merge.read_update_tx_strict()[0] == "absent"
+    ctx = type("Ctx", (), {"task_id": "some-task", "task_metadata": None})()
+    assert _managed_update_code_tool_block(ctx, "write_file") == ""
+
+
+def test_guard_still_blocks_an_unauthorized_task_under_the_test_root(tmp_path, monkeypatch):
+    """The rebind must not weaken the gate: a real staged tx still blocks everyone else."""
+    from ouroboros.tools.registry import _managed_update_code_tool_block
+
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    monkeypatch.setattr(git_ops, "REPO_DIR", repo)
+    tx = {"phase": "assisted_resolution", "task_id": "owner-task"}
+    metadata = {
+        "managed_update": {
+            "authority_fingerprint": update_merge.assisted_authority_fingerprint(tx),
+        }
+    }
+    update_merge.write_update_tx(tx)
+
+    other = type("Ctx", (), {"task_id": "other-task", "task_metadata": metadata})()
+    assert "MANAGED_UPDATE_IN_PROGRESS" in _managed_update_code_tool_block(other, "write_file")
+
+    owner = type("Ctx", (), {"task_id": "owner-task", "task_metadata": metadata})()
+    assert _managed_update_code_tool_block(owner, "write_file") == ""

--- a/tests/test_worker_repo_root_binding.py
+++ b/tests/test_worker_repo_root_binding.py
@@ -1,0 +1,65 @@
+"""A spawned worker must gate on the repo it serves, not on git_ops' hardcoded default.
+
+``git_ops.REPO_DIR`` has no env fallback and ``git_ops.init()`` is never called at boot, so a
+spawn-started worker re-imports the module and inherits ``~/Ouroboros/repo``. Everything that
+resolves through ``git_ops._git_dir()`` — notably the managed-update transaction marker the
+repo-write tool gate reads — would then consult that repo instead of the worker's own.
+"""
+
+import pathlib
+
+import supervisor.git_ops as git_ops
+import supervisor.update_merge as update_merge
+import supervisor.workers as workers
+
+
+def test_worker_binds_the_repo_root_it_was_given(tmp_path, monkeypatch):
+    """The load-bearing assertion: the binding follows the worker's argument."""
+    served = tmp_path / "served-repo"
+    (served / ".git").mkdir(parents=True)
+    monkeypatch.setattr(git_ops, "REPO_DIR", pathlib.Path.home() / "Ouroboros" / "repo")
+
+    workers._bind_worker_repo_root(str(served), str(tmp_path / "data"))
+
+    assert git_ops.REPO_DIR == served
+    marker = update_merge._update_tx_marker_path()
+    assert marker == served / ".git" / "ouroboros-update-tx.json"
+
+
+def test_worker_binding_moves_both_roots_and_nothing_else(tmp_path, monkeypatch):
+    """Scope pin: the two roots the worker IS given move; the branch names and remote it is NOT
+    given keep whatever the child imported — git_ops.init() would overwrite them with defaults
+    and silently retarget an install whose branches differ."""
+    monkeypatch.setattr(git_ops, "REPO_DIR", pathlib.Path("/sentinel/repo"))
+    monkeypatch.setattr(git_ops, "DRIVE_ROOT", pathlib.Path("/sentinel/drive"))
+    monkeypatch.setattr(git_ops, "BRANCH_DEV", "sentinel-dev")
+    monkeypatch.setattr(git_ops, "REMOTE_URL", "sentinel-remote")
+
+    workers._bind_worker_repo_root(str(tmp_path / "served"), str(tmp_path / "data"))
+
+    assert git_ops.REPO_DIR == tmp_path / "served"
+    assert git_ops.DRIVE_ROOT == tmp_path / "data"
+    assert git_ops.BRANCH_DEV == "sentinel-dev"
+    assert git_ops.REMOTE_URL == "sentinel-remote"
+
+
+def test_worker_main_binds_before_it_can_read_a_transaction():
+    """Ordering pin. The bind must precede every import that resolves the marker; a bind placed
+    after the agent/update_merge imports would leave the very window this test exists to close."""
+    import inspect
+
+    source = inspect.getsource(workers.worker_main)
+    bind_at = source.index("_bind_worker_repo_root(repo_dir, drive_root)")
+    for later in ("_prepare_worker_task_runtime()", "make_agent("):
+        assert bind_at < source.index(later), f"{later} runs before the repo-root bind"
+
+
+def test_the_root_handed_to_spawned_children_is_isolated():
+    """spawn_workers passes ``str(workers.REPO_DIR)`` to every child (workers.py:1742,1946) and
+    the child binds git_ops to it, so an un-isolated value here would send workers started BY A
+    TEST back at the operator's checkout — and on fork it would overwrite the inherited binding.
+    Fails against the pre-fix tree: workers.REPO_DIR was the live path."""
+    live = (pathlib.Path.home() / "Ouroboros" / "repo").resolve(strict=False)
+    handed_to_children = pathlib.Path(str(workers.REPO_DIR)).resolve(strict=False)
+    assert handed_to_children != live
+    assert handed_to_children == git_ops.REPO_DIR.resolve(strict=False)


### PR DESCRIPTION
## The defect

`supervisor/git_ops.py` defines `REPO_DIR` as a module global with no env fallback, and
`git_ops.init()` is never called at boot — only `colab_bootstrap` and tests call it — so every
process runs on the hardcoded `~/Ouroboros/repo` default. `update_merge._update_tx_marker_path()`
resolves the managed-update transaction marker through that global.

Two consequences:

1. **The pre-commit pytest preflight cannot pass while a managed merge is staged.** Nothing in a
pytest process rebinds `git_ops.REPO_DIR`, so every test reads the operator's real
`~/Ouroboros/repo/.git/ouroboros-update-tx.json`. With a merge staged, the registry guard
(`_managed_update_code_tool_block`) returns `MANAGED_UPDATE_IN_PROGRESS` to every repo-mutating
tool call inside the suite, and tests asserting their own block string — 92 assertion sites across
14 files — fail en masse. Passing that preflight is a precondition for committing the merge, so
the gate is unpassable exactly when it is needed.

2. **A worker gates on the wrong repository.** `worker_main` receives `repo_dir` but never binds
`git_ops` to it. Under the spawn start method (macOS and Windows) the child re-imports the module
and gets the hardcoded default, so an install running from a checkout at any other path has its
workers consult the default repo's transaction instead of their own.

## The fix

**`tests/conftest.py` — bind the session's repo root.** `_bind_pytest_runtime_roots()` is the
function whose stated purpose is this class of leak; it already rebinds `config.DATA_DIR`,
`config.SETTINGS_PATH`, `state`, `queue` and `workers.DRIVE_ROOT`. Point `git_ops.REPO_DIR` at an
empty directory with no `.git`, so `read_update_tx_strict()` takes the honest `absent` branch
rather than `corrupt` (which fails closed). Direct assignment, not `git_ops.init()` — init() would
also rewrite `BRANCH_DEV`/`BRANCH_STABLE`.

The binding is keyed on the REPO opt-in (`OUROBOROS_ALLOW_LIVE_REPO_TESTS`, the same switch
git_ops' own destructive-git fuse reads), not on the DATA opt-in: they are separate switches, and
a run that opts into live data has not opted into reading the live repo's update transaction. The
tests that pin this behaviour skip under that opt-in, since it disables them by design.

`workers.REPO_DIR` is isolated too, because `spawn_workers`/`respawn_worker` hand
`str(workers.REPO_DIR)` to every child: leaving it at the live default would send workers started
by a test back at the operator's checkout.

**`supervisor/workers.py` — a worker binds the roots it was given.** `_bind_worker_repo_root()`
sets `git_ops.REPO_DIR` and `DRIVE_ROOT` from the two values `worker_main` already receives,
before any import that can resolve the marker: it sits immediately after the `OUROBOROS_IN_WORKER`
marker and ahead of both `make_agent` and `_prepare_worker_task_runtime`, whose whole purpose is
to preload `supervisor.update_merge`. `DRIVE_ROOT` moves with the repo root because the same
re-import otherwise leaves git_ops' rescue snapshots and logs under an unrelated home directory.
The branch names and `REMOTE_URL` are deliberately untouched: this process is not told them, and
`git_ops.init()` would overwrite them with its own defaults, silently retargeting an install whose
branches differ.

## No gate is weakened

A marker written under the test root still blocks a non-authorized task and still admits the
authorized one — pinned by a test. `tests/test_update_merge_assisted.py` (which asserts the block
legitimately) and `tests/test_live_mutation_fuses.py` (which re-points `REPO_DIR` at the live path
so the destructive-git fuse still fires) stay green. The rebind strictly reduces live exposure: an
accidental destructive caller now lands in a temp dir instead of the operator's checkout.

## Evidence

Every new test was run against the pre-fix tree first.

- `test_pytest_session_repo_root_is_not_the_live_repo` fails as a SEMANTIC difference —
  `assert PosixPath('/Users/andrew/Ouroboros/repo') != PosixPath('/Users/andrew/Ouroboros/repo')`
  — and passes afterwards in both isolation modes.
- The three worker tests fail as a missing symbol
  (`module 'supervisor.workers' has no attribute '_bind_worker_repo_root'`).
- `test_the_root_handed_to_spawned_children_is_isolated` fails against the pre-fix conftest with
  `assert PosixPath('/Users/andrew/Ouroboros/repo') != PosixPath('/Users/andrew/Ouroboros/repo')`,
  which is the concrete proof that children were being handed the live checkout.
- `test_ambient_tx_read_is_absent_in_pytest` passes on the unfixed tree too while no marker is
  staged; it is a behavioural statement, not evidence, and is labelled as such in the file.

Both suite lanes green (`-m "not serial" -n auto` and `-m serial`), including
`tests/test_worker_crash_retry.py`, which starts real workers. `ruff check . --select F` clean.
The four reds in `tests/test_skill_smoke_official.py` are Tier 6 skill reviews that need a live
provider key; they are red on this machine before and after, and touch none of this code.

## Not included

The second half of the deadlock — that an assisted merge's review pack is the union against local
HEAD rather than the resolver's delta — is not in this PR. An implementation exists, but review
established that diffing the index against the second parent yields the whole local divergence
rather than a subset of the union, with full file contents per path and no bound, so it can
produce a larger pack than the one it replaces. That needs a different design and its own
evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
