### PR TITLE
fix: the scope ladder must degrade what it may before what it may not

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2331,8 +2331,11 @@ row is recorded as `budget_omitted` naming the artifact and the reason, the pack
 status becomes `required_artifact_omitted`, and no consumer reviews the
 remainder — the ladder keeps shrinking the FIXED part and retries, so the
 refusal is a step, not the end (`budget_exceeded` is the sibling failure, when
-even the content-free manifest cannot fit); 4) the largest touched
-files degrade to diff-only — their full post-change snapshots are replaced by
+even the content-free manifest cannot fit); 4) touched files degrade to
+diff-only, FREELY DEGRADABLE ones first and largest-first within each tier — an
+artifact owed in full is reached only after rung 5, since degrading one is a
+typed assembly failure and can never buy a fitting pack — their full
+post-change snapshots are replaced by
 an explicit `TOUCHED FILE BUDGET DEGRADATION NOTE` while their complete
 changes remain visible in the staged diff, and the ladder DECLARES those paths
 to the atlas (`ReviewContextAtlasRequest.diff_only_included`, v6.87.15) so the

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -836,8 +836,9 @@ degradation ladder — full atlas → compact atlas (durable `context_manifest`
 keeps full per-file coverage) → a `required` artifact the atlas cannot fit is a
 FAILURE TO ASSEMBLE (typed `budget_omitted` row naming artifact and reason,
 `required_artifact_omitted` pack status, no review of the remainder), which the
-ladder answers by shrinking the fixed part and retrying → the largest touched files degrade to
-diff-only with an explicit `TOUCHED FILE BUDGET DEGRADATION NOTE` (their full
+ladder answers by shrinking the fixed part and retrying → touched files degrade to
+diff-only, freely degradable ones first and largest-first within each tier (an artifact owed in
+full is reached only after the `-U0` rung), with an explicit `TOUCHED FILE BUDGET DEGRADATION NOTE` (their full
 changes stay visible in the staged diff, and those paths are DECLARED to the
 atlas via `diff_only_included`, so the durable coverage row records the dropped
 snapshot rather than claiming the file is fully in the prompt; legal only for

--- a/ouroboros/tools/review_context_atlas.py
+++ b/ouroboros/tools/review_context_atlas.py
@@ -495,7 +495,7 @@ def _build_file_facts(
     # BECAUSE it is touched, and its complete change-evidence is the staged
     # diff itself — so merely-touched files may legally degrade to diff-only
     # (the ladder's disclosed step), while these classes may not.
-    required_beyond_diff = force_include or is_canonical
+    required_beyond_diff = atlas_required_beyond_diff(rel)
     if rel in already_included or rel in diff_only_included:
         facts.disposition = "already_included"
         # The caller owns which snapshots actually survived in the fixed prompt;
@@ -775,6 +775,16 @@ def _is_force_include(rel: str) -> bool:
         or any(rel.startswith(prefix) for prefix in PROTECTED_RUNTIME_PATH_PREFIXES)
         or any(rel.startswith(prefix) for prefix in _FORCE_INCLUDE_PREFIXES)
     )
+
+
+def atlas_required_beyond_diff(rel: str) -> bool:
+    """True when the staged diff is never a substitute for this artifact.
+
+    The ONE definition of the class owed in full (BIBLE P3 scope floor), so the
+    ladder that chooses what to degrade and the assembler that refuses a
+    degraded required artifact cannot drift apart.
+    """
+    return _is_force_include(rel) or rel in _CANONICAL_CONTEXT_DOCS
 
 
 def _skip_by_dir(rel: str) -> bool:

--- a/ouroboros/tools/scope_review.py
+++ b/ouroboros/tools/scope_review.py
@@ -26,6 +26,7 @@ from ouroboros.tools.review_context_atlas import (
     atlas_assembly_failed,
     atlas_assembly_failure_reason,
     atlas_hard_budget_overflowed,
+    atlas_required_beyond_diff,
     atlas_unassembled_required,
     compile_review_context_atlas,
 )
@@ -554,7 +555,7 @@ def _render_touched_section(
         degrade_note = (
             "## TOUCHED FILE BUDGET DEGRADATION NOTE\n"
             "The full post-change snapshots of the following touched files were "
-            "OMITTED to fit the reviewer input budget (largest files first). "
+            "OMITTED to fit the budget (freely degradable first, largest per tier). "
             "Their complete changes are still visible in the staged diff below; "
             "treat this as an explicit, disclosed omission of unchanged "
             "surrounding context, not a hidden gap:\n"
@@ -761,17 +762,15 @@ def _build_scope_prompt(
         except OSError:
             return 0
 
-    # Guaranteed-fit ladder: 1) full atlas; 2) compact atlas; 3) degrade the
-    # largest touched files to diff-only (explicit disclosed note — their
-    # changes stay fully visible in the staged diff); 4) remove unchanged diff
-    # context while preserving every +/- line. Only an
-    # irreducible prompt still not fitting fails CLOSED (fixed_overflow).
+    # Guaranteed-fit ladder: 1) full atlas; 2) compact atlas; 3) degrade freely degradable touched
+    # files to diff-only, largest first (disclosed; changes stay visible in the staged diff);
+    # 4) drop unchanged diff context; 5) artifacts owed in full, last resort. Else fails CLOSED.
     input_limit = _effective_scope_input_limit(scope_model=scope_model)
     _atlas_min_allowance = 35_000  # manifest reserve + hard headroom, see review_context_atlas
     diff_only_paths: list = []
     degradable = sorted(
         current_context_paths,
-        key=lambda path: -_touched_token_estimate(path),
+        key=lambda path: (atlas_required_beyond_diff(path), -_touched_token_estimate(path)),
     )
     compact = False
     compact_diff_attempted = False
@@ -847,9 +846,11 @@ def _build_scope_prompt(
             # the fixed part enough to give the manifest its minimum room.
             deficit = max(50_000, fixed_prompt_tokens + _atlas_min_allowance - input_limit)
 
-        if not degradable:
-            if not compact_diff_attempted:
-                # Every staged +/- line without unchanged hunk context.
+        def can_degrade() -> bool:  # required tier only after -U0
+            return bool(degradable) and (compact_diff_attempted or not atlas_required_beyond_diff(degradable[0]))
+
+        if not can_degrade():
+            if not compact_diff_attempted:  # every +/- line, no unchanged context
                 compact_diff_attempted = True
                 try:
                     compact_diff = run_cmd(["git", "diff", "--cached", "-U0"], cwd=repo_dir)
@@ -857,6 +858,8 @@ def _build_scope_prompt(
                     compact_diff = ""
                 if compact_diff.strip() and compact_diff != diff_text:
                     diff_text = compact_diff
+                    continue
+                if can_degrade():  # -U0 gave nothing, but the required tier is open now
                     continue
             # Terminal pack status: >=1M authority is fixed_overflow; a sub-floor
             # pack is budget_exceeded here and the authority policy turns it into
@@ -874,7 +877,7 @@ def _build_scope_prompt(
                 atlas_overflowed=bool(atlas_overflowed),
             )
         freed = 0
-        while degradable and freed < deficit + 2_000:
+        while can_degrade() and freed < deficit + 2_000:
             path = degradable.pop(0)
             diff_only_paths.append(path)
             freed += _touched_token_estimate(path)

--- a/tests/test_review_context_atlas.py
+++ b/tests/test_review_context_atlas.py
@@ -626,3 +626,24 @@ def test_deep_self_review_refuses_a_pack_that_did_not_assemble(monkeypatch, tmp_
     assert pack_text == ""
     assert "ouroboros/llm.py" in stats["skipped"][0]
     assert stats["context_manifest"]["unassembled_required"][0]["path"] == "ouroboros/llm.py"
+
+
+def test_required_beyond_diff_is_one_public_definition_for_every_consumer():
+    """The class owed IN FULL is exported so the scope ladder (which chooses what
+    to degrade) and the assembler (which refuses a degraded required artifact)
+    read ONE definition. If they drift, the ladder degrades a path the assembler
+    can only refuse — a manufactured, unfixable budget deficit."""
+    from ouroboros.tools.review_context_atlas import atlas_required_beyond_diff
+
+    # force-include: prompts/, contracts/, protected runtime, review stack
+    assert atlas_required_beyond_diff("prompts/x.md")
+    assert atlas_required_beyond_diff("ouroboros/contracts/thing.py")
+    assert atlas_required_beyond_diff(".github/workflows/ci.yml")
+    assert atlas_required_beyond_diff("ouroboros/tools/scope_review.py")
+    # canonical context docs (the second clause — BIBLE.md is also force-include,
+    # so ARCHITECTURE.md is what proves the clause is not dead)
+    assert atlas_required_beyond_diff("BIBLE.md")
+    assert atlas_required_beyond_diff("docs/ARCHITECTURE.md")
+    # a merely-touched ordinary file may legally degrade to diff-only
+    assert not atlas_required_beyond_diff("module.py")
+    assert not atlas_required_beyond_diff("tests/test_thing.py")

--- a/tests/test_scope_review.py
+++ b/tests/test_scope_review.py
@@ -2811,6 +2811,81 @@ def test_ladder_cannot_degrade_a_required_beyond_diff_artifact_to_diff_only(
     assert rows["prompts/big_prompt.md"]["disposition"] == "budget_omitted"
     # An ORDINARY touched file may still ride the disclosed diff-only step
     # (pinned by test_diff_only_degradation_is_not_reported_as_fully_included).
+    # ORDERING: the tier sort only reorders, so the pop loop must also refuse to cross
+    # into the required tier until the zero-context rung has been tried — degrading a
+    # required artifact provably cannot buy a fitting pack, while -U0 still might. Every
+    # recorded step that already shows the artifact degraded must show -U0 attempted.
+    for step in steps:
+        if step.get("unassembled_required") and step.get("diff_only_files"):
+            assert step["zero_context_diff"] is True, step
+    assert any(step.get("zero_context_diff") for step in steps), steps
+
+
+def test_ladder_degrades_ordinary_files_before_a_required_artifact(tmp_path, monkeypatch):
+    """Defect B. The ladder sorted ALL touched paths by size with no requiredness
+    filter, so the LARGEST file was degraded first even when it was an artifact
+    owed in full. Degrading one of those can never buy a fitting pack — the atlas
+    turns it into an assembly refusal (`required_artifact_omitted`), which the
+    ladder then reads as a further deficit and degrades further. The deficit was
+    manufactured: the ordinary files alone covered it.
+
+    The fixture is deliberately shaped so a size-only sort CANNOT pass it: the
+    required artifact is the LARGEST touched file (~40K tokens), while the three
+    ordinary files are individually smaller (~20K each) but collectively cover
+    the deficit. Pre-fix this reaches the terminal with
+    `status == "fixed_overflow"` and `unassembled_required ==
+    ["prompts/large_prompt.md"]`; post-fix the three ordinary files degrade, the
+    prompt's full snapshot survives, and the pack assembles."""
+    import subprocess
+
+    from ouroboros.tools import scope_review as sr
+
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "CHECKLISTS.md").write_text(
+        "## Intent / Scope Review Checklist\n\nplaceholder\n", encoding="utf-8",
+    )
+    (tmp_path / "prompts").mkdir()
+    # ~40K touched tokens: the LARGEST touched file, and owed in full.
+    (tmp_path / "prompts" / "large_prompt.md").write_text(
+        "word here\n" * 16_000, encoding="utf-8",
+    )
+    ordinary = ["a_mod.py", "b_mod.py", "c_mod.py"]
+    for name in ordinary:
+        # ~20K touched tokens each: individually smaller than the artifact,
+        # together (~60K) more than the ~50K deficit.
+        (tmp_path / name).write_text("y = 1\n" * 13_334, encoding="utf-8")
+    subprocess.run(["git", "init"], cwd=str(tmp_path), capture_output=True)
+    subprocess.run(["git", "add", "."], cwd=str(tmp_path), capture_output=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=T", "commit", "-m", "init"],
+        cwd=str(tmp_path), capture_output=True,
+    )
+    # Tiny changes inside big files: the diff fits, the snapshots do not.
+    (tmp_path / "prompts" / "large_prompt.md").write_text(
+        "CHANGED\n" + "word here\n" * 15_999, encoding="utf-8",
+    )
+    for name in ordinary:
+        (tmp_path / name).write_text("z = 0\n" + "y = 1\n" * 13_333, encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=str(tmp_path), capture_output=True)
+
+    monkeypatch.setattr(sr, "_effective_scope_input_limit", lambda **_kw: 90_000)
+    monkeypatch.setattr(sr, "_scope_window",
+                        lambda _m, **_k: sr.ReviewerWindow(window_tokens=1_000_000, status="confirmed"))
+
+    prompt, status = sr._build_scope_prompt(tmp_path, "test commit")
+
+    # The pack assembles: the deficit was always coverable by optional content.
+    assert status is None, getattr(status, "unassembled_required", status)
+    assert prompt
+    # The required artifact keeps its full snapshot in the fixed part…
+    assert "### prompts/large_prompt.md" in prompt
+    # …and the disclosed degradation names the ordinary files, and only those.
+    note = prompt.split("## TOUCHED FILE BUDGET DEGRADATION NOTE", 1)[1].split("\n\n", 1)[0]
+    for name in ordinary:
+        assert f"- {name}" in note, note
+    assert "prompts/large_prompt.md" not in note, note
+    rows = {r["path"]: r for r in sr._current_scope_context_manifest()["coverage"]}
+    assert rows["prompts/large_prompt.md"]["disposition"] == "already_included"
 
 
 def test_cold_start_sizes_down_and_passes_instead_of_400ing(tmp_path, monkeypatch):


### PR DESCRIPTION
## The defect

The guaranteed-fit ladder sorted every touched path by size alone and degraded the largest to
diff-only. Nothing in that ordering knew about requiredness, so on a change touching a large
force-include or canonical artifact the ladder reached for that artifact **first** — and degrading
one is unconditionally futile: the assembler marks it `budget_omitted`, the pack terminates as
`required_artifact_omitted`, and the caller reads that refusal as a further budget deficit and
degrades again. A pack that would have fit is refused, and the refusal names an artifact the ladder
itself removed.

Measured on a real assisted release merge (6.89.6 → 6.90.1, 8 conflicts, resolved):

```
assembled                786,933 tokens
limit                    795,000        (headroom 8,067)
required artifacts       60,353         (7 force-include files, reported unassembled)
shortfall                52,286
atlas_overflowed = False
```

`atlas_overflowed=False` is the tell: the atlas fit. Its budget had gone to optional content while
the artifacts owed in full were degraded out of it. Every path in the review stack is
required-beyond-diff, so an ordinary large review-stack commit reaches the same path — this is not
an update-specific bug.

## The fix — two changes, both about order

- **Tier the sort.** Two tiers, each largest-first: freely degradable paths, then the artifacts owed
  in full. The required tier stays in the list rather than being removed, because reaching it is the
  honest last resort and an empty list would fire the terminal with no `unassembled_required` rows,
  destroying the disclosure that names the artifact.
- **Gate the crossing on the `-U0` rung.** A sort alone only reorders; the pop loop drained the whole
  list, so the ladder spent its irreversible step — which provably cannot produce a fitting pack —
  before the zero-context diff step that still could. Any pack whose deficit `git diff --cached -U0`
  would have covered failed closed instead.

`atlas_required_beyond_diff()` becomes the single definition of that class, so the ladder choosing
what to degrade and the assembler refusing a degraded required artifact cannot drift apart; the
atlas's own `required_beyond_diff` now routes through it.

## Nothing about the gate moves

No token limit, no output margin, no change to `required_artifact_omitted`,
`_unassembled_required`, `ATLAS_ASSEMBLY_FAILURE_STATUSES` or either remedy string; no escape hatch
and no assisted-merge special case. `BIBLE.md`'s scope floor is untouched: a required artifact that
genuinely cannot fit is still a failure to assemble, and the pin proving a required artifact can
still be degraded only as the true last resort — so the terminal still names it — stays green.
The reviewer-facing degradation note now states the real rule instead of "largest files first", and
both architecture docs are corrected to the real rung order.

## Evidence

- `atlas_required_beyond_diff` test fails pre-fix as a missing symbol.
- The ladder test fails pre-fix semantically: `unassembled_required=['prompts/large_prompt.md']`,
  status `fixed_overflow`. Its fixture makes the required artifact the **largest** touched file with
  ordinary files individually smaller but collectively covering the deficit — the obvious "medium
  required file, larger ordinary files" fixture passes pre-fix and proves nothing.
- The ordering assertions added to the existing irreducible-pack pin fail pre-fix on a recorded
  ladder step that degraded the artifact with `zero_context_diff: False`.
- Both suite lanes green (`-m "not serial" -n auto` and `-m serial`); `ruff check --select F` clean;
  `ouroboros/tools/scope_review.py` stays exactly at the 1600-line module cap.

The four reds in `tests/test_skill_smoke_official.py` are Tier 6 skill reviews needing a live
provider key; they are red on this machine before and after and touch none of this code.

## Deliberately not included

- Suppressing further degradation when a refusal is artifact-missing-only. Correct in principle,
  risks the mixed-cause pins, and belongs in its own change with its own evidence.
- Touched tests are excluded from `current_context_paths` and therefore from the degradable list,
  yet the atlas still treats them as anchors. That is pre-existing — this change only alters the
  sort key — and is filed separately.
- Shrinking `docs/ARCHITECTURE.md`, which is loaded unconditionally into every scope prompt at
  ~127K tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
