### PR TITLE
chore: add community and research trust metadata

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,50 @@
+name: Scorecard analysis workflow
+
+on:
+  push:
+    # Only the default branch is supported.
+    branches:
+      - main
+  schedule:
+    # Weekly on Saturdays.
+    - cron: "30 1 * * 6"
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed for Code scanning upload.
+      security-events: write
+      # Needed for GitHub OIDC token when publish_results is true.
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publishing makes the result available through the OpenSSF API.
+          publish_results: true
+
+      # Keep the SARIF result available from the Actions run.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Also publish the result in GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        with:
+          sarif_file: results.sarif

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,22 @@
+cff-version: 1.2.0
+message: "If you use Ouroboros in research, please cite it using the metadata below."
+title: "Ouroboros"
+type: software
+authors:
+  - family-names: "Razzhigaev"
+    given-names: "Anton"
+repository-code: "https://github.com/razzant/ouroboros"
+url: "https://ouroboros-agent.ai/"
+license: MIT
+abstract: >-
+  Ouroboros is an open-source, general-purpose AI agent with persistent
+  identity, durable memory, and a self-modifying codebase. It can work on
+  external projects, coordinate specialist agents, and evolve its
+  implementation through reviewed Git history. The Ouroboros agent contributed
+  to the design, implementation, and review of the software.
+keywords:
+  - artificial intelligence
+  - AI agents
+  - self-modifying systems
+  - persistent memory
+  - multi-agent systems

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant 3.0 Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, contact the Community Moderators at [https://t.me/abstractDL](https://t.me/abstractDL).
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1) Warning
+   1) Event: A violation involving a single incident or series of incidents.
+   2) Consequence: A private, written warning from the Community Moderators.
+   3) Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2) Temporarily Limited Activities
+   1) Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2) Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3) Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3) Temporary Suspension
+   1) Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   2) Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3) Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4) Permanent Ban
+   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2) Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3) Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
+
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -257,9 +257,13 @@ server.py (Starlette+uvicorn) ← HTTP + WebSocket on configurable host:port (de
       group-suicides when the parent dies. Panic layers (`_active_subprocesses`,
       port sweeps, Windows Job Objects) are unchanged complements.
 
-# Build & CI (not part of runtime)
+# Build, CI & public metadata (not part of runtime)
 .github/workflows/ci.yml     ← Five-tier CI (quick / full / integration / skill smoke / build+release)
 .github/workflows/claudexor-platform-gate.yml ← 3-OS delegated-execution gate: fixture lane (fake harness, offline, $0) + live lane on explicit API keys (subscription auth deliberately out of CI — verified by a live local run, D26)
+.github/workflows/scorecard.yml ← OpenSSF Scorecard on `main` pushes and weekly; full action SHA pins, read-only defaults, OIDC result publication, and SARIF artifact/code-scanning upload
+CODE_OF_CONDUCT.md            ← Contributor Covenant 3.0 community rules and private moderator contact
+CITATION.cff                  ← Machine-readable software citation; Anton is the cited author and Ouroboros's contribution is acknowledged
+docs/benchmarks/evidence.json ← Release-bound non-GAIA projection of public benchmark claims and immutable evidence links; README remains the claim SSOT
 scripts/claudexor_platform_smoke.py ← the platform gate's smoke runner (daemon boot, one delegated no-edit/edit task, containment report)
 scripts/fetch_claudexor_runtime.py  ← release-build fetcher for the pinned managed Claudexor runtime archive (claudexor_runtime_pin.json is the SSOT)
 build.sh                      ← macOS build (PyInstaller → .dmg)
@@ -1807,9 +1811,11 @@ Claude Runtime Status appears when an Anthropic key exists or when backend/runti
 
 The local `ouroboros-stable` ref also remains a recovery fallback maintained by explicit promotion; that local role does not select the official QA feed. Colab seeds it from the already validated shared Stable release when possible and otherwise from the selected validated channel, then leaves it pinned until promotion. Launcher metadata describes bootstrap provenance only. Runtime status, preflight, Colab bootstrap, and apply resolve the selected channel and exact fetched SHA themselves, so an older frozen launcher cannot silently redirect updates. Stable additionally requires the shared plain release tag; QA and Development do not use version comparison as an admission gate.
 
-CI has five roles: fork-safe quick checks with no provider secrets; the full cross-platform matrix; provider integration when secrets exist; official-skill install, preflight, review, dependency, and keyless execution smoke; and tag-triggered build/release. Secret-bearing skill review runs before any step that imports downloaded plugin code, and a missing required key is red rather than skipped. Release jobs build the three platform artifacts, verify final archives, produce checksums, SBOMs and source-bound attestations, and recheck the remote annotated tag against the event SHA before draft creation and publication.
+The main CI workflow has five roles: fork-safe quick checks with no provider secrets; the full cross-platform matrix; provider integration when secrets exist; official-skill install, preflight, review, dependency, and keyless execution smoke; and tag-triggered build/release. Secret-bearing skill review runs before any step that imports downloaded plugin code, and a missing required key is red rather than skipped. Release jobs build the three platform artifacts, verify final archives, produce checksums, SBOMs and source-bound attestations, and recheck the remote annotated tag against the event SHA before draft creation and publication.
 
 Quick pull-request jobs are read-only and never use `pull_request_target`. The live catalog skill lane is intentionally a release dependency: it proves that the published payloads still install on this runtime, while keeping provider credentials out of every process that imports payload code. This external-service dependency is an explicit owner trade-off rather than an accidental source of flaky authority.
+
+The separate Scorecard workflow runs on `main` pushes and weekly. It pins every action by full commit SHA, defaults permissions to read-only, and adds only `security-events: write` and `id-token: write` for SARIF upload and OpenSSF publication. `CODE_OF_CONDUCT.md` owns community rules and reporting; `CITATION.cff` owns citation metadata; `docs/benchmarks/evidence.json` is a historical, release-bound non-GAIA projection of public benchmark claims and immutable evidence links. README remains the claim SSOT.
 
 ### Build scripts
 

--- a/docs/benchmarks/evidence.json
+++ b/docs/benchmarks/evidence.json
@@ -1,0 +1,284 @@
+{
+  "schema_version": 1,
+  "snapshot": {
+    "repository": "https://github.com/razzant/ouroboros",
+    "version": "6.92.1",
+    "tag": "v6.92.1",
+    "commit": "d8087f42e4d369db393cbfb8318b8a82f9bb73b2",
+    "claims_source": "https://github.com/razzant/ouroboros/blob/d8087f42e4d369db393cbfb8318b8a82f9bb73b2/README.md#benchmarks"
+  },
+  "evidence_collection": "https://huggingface.co/collections/razzant/ouroboros-benchmark-evidence-6a6e7fec1cfdc2d8d93ed3a3",
+  "benchmarks": [
+    {
+      "id": "terminal-bench-2.1-claude-opus-5-high",
+      "benchmark": "Terminal-Bench 2.1",
+      "model": "Claude Opus-5 high",
+      "result": {
+        "value": 86.74,
+        "unit": "percent",
+        "raw_value": 86.97,
+        "adjustment": "One disclosed reward-hack trial was scored as zero."
+      },
+      "comparisons": [
+        {
+          "system": "Claude Code + Fable 5",
+          "value": 83.8,
+          "unit": "percent"
+        }
+      ],
+      "reporting": {
+        "self_reported": true,
+        "submission_status": "open",
+        "evidence_status": "public_run"
+      },
+      "evidence": [
+        {
+          "kind": "upstream_submission",
+          "url": "https://github.com/harbor-framework/terminal-bench-2-1/pull/175"
+        },
+        {
+          "kind": "public_run",
+          "url": "https://hub.harborframework.com/jobs/2b145543-edeb-4a3b-b46f-4800310f1182"
+        }
+      ]
+    },
+    {
+      "id": "terminal-bench-2.1-claude-opus-4.8-high",
+      "benchmark": "Terminal-Bench 2.1",
+      "model": "Claude Opus-4.8 high",
+      "result": {
+        "value": 80.22,
+        "unit": "percent"
+      },
+      "comparisons": [
+        {
+          "system": "Claude Code",
+          "value": 78.9,
+          "unit": "percent"
+        }
+      ],
+      "reporting": {
+        "self_reported": true,
+        "evidence_status": "public_run"
+      },
+      "evidence": [
+        {
+          "kind": "public_run",
+          "url": "https://hub.harborframework.com/jobs/4b8e244f-8ab0-4d28-8218-7cf346282faa"
+        }
+      ]
+    },
+    {
+      "id": "terminal-bench-2.1-gpt-5.5",
+      "benchmark": "Terminal-Bench 2.1",
+      "model": "GPT-5.5",
+      "result": {
+        "value": 84.3,
+        "unit": "percent",
+        "calculation": {
+          "self_reported_aggregation": "mean_over_tasks_of_per_task_pass_rate",
+          "self_reported_unrounded_value": 84.26966292134831,
+          "tasks": 89,
+          "scheduled_trials": 445,
+          "graded_trials": 444,
+          "passed_trials": 374,
+          "ungraded_trials_excluded": 1,
+          "ungraded_trial": {
+            "task": "mcmc-sampling-stan",
+            "graded_task_passes": 4,
+            "graded_task_trials": 4
+          },
+          "leaderboard_compatible": {
+            "aggregation": "passed_trials_over_scheduled_trials_with_errors_counted_as_zero",
+            "unrounded_value": 84.04494382022472,
+            "rounded_value": 84.04,
+            "display_value": 84.0
+          }
+        }
+      },
+      "comparisons": [
+        {
+          "system": "Codex CLI",
+          "value": 83.1,
+          "unit": "percent"
+        }
+      ],
+      "reporting": {
+        "self_reported": true,
+        "submission_status": "open",
+        "submission_validation": "failed_source_filter",
+        "evidence_status": "public_run"
+      },
+      "evidence": [
+        {
+          "kind": "upstream_submission",
+          "url": "https://github.com/harbor-framework/terminal-bench-2-1/pull/119"
+        },
+        {
+          "kind": "public_run",
+          "url": "https://hub.harborframework.com/jobs/f02fd019-23e1-495f-af0a-ebd9a65f3079"
+        }
+      ]
+    },
+    {
+      "id": "terminal-bench-2.1-grok-4.5",
+      "benchmark": "Terminal-Bench 2.1",
+      "model": "Grok-4.5",
+      "result": {
+        "value": 84.94,
+        "unit": "percent",
+        "adjustment": "The published result includes the reward-hack audit."
+      },
+      "comparisons": [
+        {
+          "system": "Cursor CLI",
+          "value": 79.3,
+          "unit": "percent"
+        },
+        {
+          "system": "Hermes",
+          "value": 77.53,
+          "unit": "percent"
+        }
+      ],
+      "reporting": {
+        "self_reported": true,
+        "submission_status": "open",
+        "evidence_status": "upstream_submission"
+      },
+      "evidence": [
+        {
+          "kind": "upstream_submission",
+          "url": "https://github.com/harbor-framework/terminal-bench-2-1/pull/146"
+        }
+      ]
+    },
+    {
+      "id": "osworld-verified-claude-opus-5",
+      "benchmark": "OSWorld-Verified",
+      "model": "Claude Opus-5",
+      "result": {
+        "value": 90.69,
+        "unit": "percent",
+        "score": 327.39,
+        "total": 361
+      },
+      "comparisons": [
+        {
+          "system": "Previous best on the public board",
+          "value": 90.19,
+          "unit": "percent"
+        }
+      ],
+      "reporting": {
+        "self_reported": true,
+        "evidence_status": "full_traces"
+      },
+      "evidence": [
+        {
+          "kind": "hugging_face_dataset",
+          "repository": "razzant/ouroboros-osworld-verified-opus5",
+          "revision": "f52ebf2248ce0ce0c496db18f5e6edce631304fa",
+          "url": "https://huggingface.co/datasets/razzant/ouroboros-osworld-verified-opus5/tree/f52ebf2248ce0ce0c496db18f5e6edce631304fa"
+        }
+      ]
+    },
+    {
+      "id": "osworld-verified-claude-sonnet-4.6",
+      "benchmark": "OSWorld-Verified",
+      "model": "Claude Sonnet-4.6",
+      "result": {
+        "value": 83.27,
+        "unit": "percent",
+        "score": 300.59,
+        "total": 361
+      },
+      "comparisons": [
+        {
+          "system": "Pointer",
+          "value": 81.45,
+          "unit": "percent"
+        }
+      ],
+      "reporting": {
+        "self_reported": true,
+        "evidence_status": "full_traces"
+      },
+      "evidence": [
+        {
+          "kind": "hugging_face_dataset",
+          "repository": "razzant/ouroboros-osworld-verified-sonnet46",
+          "revision": "0e8ad516a4eeaa586607ead400429885814e7633",
+          "url": "https://huggingface.co/datasets/razzant/ouroboros-osworld-verified-sonnet46/tree/0e8ad516a4eeaa586607ead400429885814e7633"
+        }
+      ]
+    },
+    {
+      "id": "cl-bench-claude-sonnet-4.6",
+      "benchmark": "CL-Bench",
+      "model": "Claude Sonnet-4.6",
+      "result": {
+        "value": 0.2301,
+        "unit": "normalized_reward",
+        "rank": 1
+      },
+      "comparisons": [
+        {
+          "system": "Previous top",
+          "value": 0.196,
+          "unit": "normalized_reward"
+        }
+      ],
+      "reporting": {
+        "self_reported": true,
+        "submission_status": "open",
+        "evidence_status": "full_traces"
+      },
+      "evidence": [
+        {
+          "kind": "upstream_submission",
+          "url": "https://github.com/pgasawa/continual-learning-bench/pull/10"
+        },
+        {
+          "kind": "hugging_face_dataset",
+          "repository": "razzant/ouroboros-clbench-traces",
+          "revision": "85958a21989ee7a52efaaf6d26d498f831835c70",
+          "url": "https://huggingface.co/datasets/razzant/ouroboros-clbench-traces/tree/85958a21989ee7a52efaaf6d26d498f831835c70"
+        }
+      ]
+    },
+    {
+      "id": "swe-bench-pro-gpt-5.6-luna",
+      "benchmark": "SWE-bench Pro",
+      "model": "GPT-5.6-luna",
+      "result": {
+        "value": 58.2,
+        "unit": "percent"
+      },
+      "comparisons": [
+        {
+          "system": "Codex CLI",
+          "value": 59.4,
+          "unit": "percent"
+        }
+      ],
+      "analysis": {
+        "test": "McNemar",
+        "p_value": 0.4,
+        "conclusion": "no_significant_difference"
+      },
+      "reporting": {
+        "self_reported": true,
+        "evidence_status": "matched_traces"
+      },
+      "evidence": [
+        {
+          "kind": "hugging_face_dataset",
+          "repository": "razzant/swepro-luna-matched-pair",
+          "revision": "62280378fd82ab9df0b7216745cd42e559ab3435",
+          "url": "https://huggingface.co/datasets/razzant/swepro-luna-matched-pair/tree/62280378fd82ab9df0b7216745cd42e559ab3435"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_trust_metadata.py
+++ b/tests/test_trust_metadata.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[1]
+RELEASE_VERSION = "6.92.1"
+RELEASE_TAG = f"v{RELEASE_VERSION}"
+RELEASE_COMMIT = "d8087f42e4d369db393cbfb8318b8a82f9bb73b2"
+
+
+def test_code_of_conduct_is_customized_contributor_covenant_3():
+    text = (REPO / "CODE_OF_CONDUCT.md").read_text(encoding="utf-8")
+
+    assert text.startswith("# Contributor Covenant 3.0 Code of Conduct\n")
+    assert "https://t.me/abstractDL" in text
+    assert "[NOTE:" not in text
+    assert "Contributor Covenant, version 3.0" in text
+    assert "CC BY-SA 4.0" in text
+
+
+def test_citation_metadata_has_the_approved_author_and_acknowledgment():
+    citation = yaml.safe_load((REPO / "CITATION.cff").read_text(encoding="utf-8"))
+
+    assert citation["cff-version"] == "1.2.0"
+    assert citation["title"] == "Ouroboros"
+    assert citation["type"] == "software"
+    assert citation["authors"] == [{"family-names": "Razzhigaev", "given-names": "Anton"}]
+    assert citation["repository-code"] == "https://github.com/razzant/ouroboros"
+    assert citation["url"] == "https://ouroboros-agent.ai/"
+    assert citation["license"] == "MIT"
+    assert "The Ouroboros agent contributed" in citation["abstract"]
+    forbidden = {"orcid", "affiliation", "version", "date-released", "doi"}
+    assert forbidden.isdisjoint(citation)
+    assert forbidden.isdisjoint(citation["authors"][0])
+
+
+def test_scorecard_workflow_is_fully_pinned_and_publishes_sarif():
+    path = REPO / ".github" / "workflows" / "scorecard.yml"
+    workflow = yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+    assert workflow["on"] == {
+        "push": {"branches": ["main"]},
+        "schedule": [{"cron": "30 1 * * 6"}],
+    }
+    assert workflow["permissions"] == "read-all"
+    job = workflow["jobs"]["analysis"]
+    assert job["runs-on"] == "ubuntu-latest"
+    assert job["permissions"] == {
+        "security-events": "write",
+        "id-token": "write",
+    }
+
+    ordered_steps = job["steps"]
+    assert [(step["name"], step["uses"]) for step in ordered_steps] == [
+        (
+            "Checkout code",
+            "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+        ),
+        (
+            "Run analysis",
+            "ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc",
+        ),
+        (
+            "Upload artifact",
+            "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+        ),
+        (
+            "Upload to code-scanning",
+            "github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38",
+        ),
+    ]
+    steps = {step["name"]: step for step in ordered_steps}
+
+    assert steps["Checkout code"]["with"] == {"persist-credentials": "false"}
+    scorecard = steps["Run analysis"]["with"]
+    assert scorecard == {
+        "results_file": "results.sarif",
+        "results_format": "sarif",
+        "publish_results": "true",
+    }
+    assert steps["Upload artifact"]["with"] == {
+        "name": "SARIF file",
+        "path": "results.sarif",
+        "retention-days": "5",
+    }
+    assert steps["Upload to code-scanning"]["with"] == {"sarif_file": "results.sarif"}
+
+
+def test_benchmark_evidence_is_release_bound_and_excludes_unready_evidence():
+    path = REPO / "docs" / "benchmarks" / "evidence.json"
+    raw = path.read_text(encoding="utf-8")
+    evidence = json.loads(raw)
+
+    assert "gaia" not in raw.lower()
+    assert evidence["schema_version"] == 1
+    assert evidence["snapshot"] == {
+        "repository": "https://github.com/razzant/ouroboros",
+        "version": RELEASE_VERSION,
+        "tag": RELEASE_TAG,
+        "commit": RELEASE_COMMIT,
+        "claims_source": (f"https://github.com/razzant/ouroboros/blob/{RELEASE_COMMIT}/README.md#benchmarks"),
+    }
+    rows = evidence["benchmarks"]
+    assert len(rows) == 8
+    assert len({row["id"] for row in rows}) == len(rows)
+    assert all(row["reporting"]["self_reported"] is True for row in rows)
+    assert all(row["reporting"]["evidence_status"] for row in rows)
+
+
+def test_benchmark_evidence_keeps_exact_scores_and_hugging_face_revisions():
+    evidence = json.loads((REPO / "docs" / "benchmarks" / "evidence.json").read_text(encoding="utf-8"))
+    rows = {row["id"]: row for row in evidence["benchmarks"]}
+
+    expected_scores = {
+        "terminal-bench-2.1-claude-opus-5-high": 86.74,
+        "terminal-bench-2.1-claude-opus-4.8-high": 80.22,
+        "terminal-bench-2.1-gpt-5.5": 84.3,
+        "terminal-bench-2.1-grok-4.5": 84.94,
+        "osworld-verified-claude-opus-5": 90.69,
+        "osworld-verified-claude-sonnet-4.6": 83.27,
+        "cl-bench-claude-sonnet-4.6": 0.2301,
+        "swe-bench-pro-gpt-5.6-luna": 58.2,
+    }
+    assert {key: row["result"]["value"] for key, row in rows.items()} == expected_scores
+    assert rows["terminal-bench-2.1-claude-opus-5-high"]["result"]["raw_value"] == 86.97
+    assert rows["terminal-bench-2.1-gpt-5.5"]["result"]["calculation"] == {
+        "self_reported_aggregation": "mean_over_tasks_of_per_task_pass_rate",
+        "self_reported_unrounded_value": 84.26966292134831,
+        "tasks": 89,
+        "scheduled_trials": 445,
+        "graded_trials": 444,
+        "passed_trials": 374,
+        "ungraded_trials_excluded": 1,
+        "ungraded_trial": {
+            "task": "mcmc-sampling-stan",
+            "graded_task_passes": 4,
+            "graded_task_trials": 4,
+        },
+        "leaderboard_compatible": {
+            "aggregation": "passed_trials_over_scheduled_trials_with_errors_counted_as_zero",
+            "unrounded_value": 84.04494382022472,
+            "rounded_value": 84.04,
+            "display_value": 84.0,
+        },
+    }
+    assert rows["terminal-bench-2.1-gpt-5.5"]["reporting"] == {
+        "self_reported": True,
+        "submission_status": "open",
+        "submission_validation": "failed_source_filter",
+        "evidence_status": "public_run",
+    }
+    assert rows["cl-bench-claude-sonnet-4.6"]["result"]["rank"] == 1
+    assert rows["swe-bench-pro-gpt-5.6-luna"]["analysis"] == {
+        "test": "McNemar",
+        "p_value": 0.4,
+        "conclusion": "no_significant_difference",
+    }
+
+    expected_revisions = {
+        "razzant/ouroboros-osworld-verified-opus5": ("f52ebf2248ce0ce0c496db18f5e6edce631304fa"),
+        "razzant/ouroboros-osworld-verified-sonnet46": ("0e8ad516a4eeaa586607ead400429885814e7633"),
+        "razzant/ouroboros-clbench-traces": ("85958a21989ee7a52efaaf6d26d498f831835c70"),
+        "razzant/swepro-luna-matched-pair": ("62280378fd82ab9df0b7216745cd42e559ab3435"),
+    }
+    found_revisions = {}
+    for row in rows.values():
+        for item in row["evidence"]:
+            assert item["url"].startswith("https://")
+            if item["kind"] == "hugging_face_dataset":
+                assert re.fullmatch(r"[0-9a-f]{40}", item["revision"])
+                assert item["url"].endswith(f"/tree/{item['revision']}")
+                found_revisions[item["repository"]] = item["revision"]
+    assert found_revisions == expected_revisions
+
+
+def test_architecture_registers_each_new_public_metadata_surface():
+    architecture = (REPO / "docs" / "ARCHITECTURE.md").read_text(encoding="utf-8")
+
+    for path in (
+        ".github/workflows/scorecard.yml",
+        "CODE_OF_CONDUCT.md",
+        "CITATION.cff",
+        "docs/benchmarks/evidence.json",
+    ):
+        assert path in architecture
+    assert "README remains the claim SSOT" in architecture


### PR DESCRIPTION
Adds a Contributor Covenant 3.0 Code of Conduct, CITATION.cff, an OpenSSF Scorecard workflow, and a release-bound benchmark evidence snapshot for v6.92.1. The workflow uses exact action SHAs, publishes to the OpenSSF API, retains SARIF, and uploads it to code scanning. The snapshot keeps README as the claim source, excludes GAIA for now, and records both the self-reported task-mean calculation behind GPT-5.5 84.3% and the leaderboard-compatible 84.04% value. No version files are changed.

Verified with 6 focused tests, Ruff, CFF/YAML/JSON validation, public URL checks, and git diff --check.