### PR TITLE
fix(settings): never persist a masked placeholder as a credential

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,6 +39,7 @@ server.py (Starlette+uvicorn) ← HTTP + WebSocket on configurable host:port (de
   │
   └── ouroboros/               ← Agent core (runs inside worker processes)
       ├── config.py            ← SSOT: paths, settings defaults, load/save, PID lock
+      ├── secret_masking.py    ← Exact Settings/MCP wire-placeholder emitters and recognizers, plus top-level known/custom secret repair before env overlay and persistence
       ├── update_channels.py   ← Closed Stable/QA/Development mapping and update-network defaults
       ├── colab_bootstrap.py   ← Google Colab source-mode bootstrap helpers: selected official update source, stable local `ouroboros` branch, Drive-backed settings/data, personal origin, no-UI server command, and native Telegram setup
       ├── cli.py               ← Source/headless CLI over gateway tasks, logs, settings, skills, marketplace, local-model, and MCP wrappers
@@ -1662,7 +1663,7 @@ Bundled native skills and editable marketplace/user payloads occupy separate pay
 
 ### MCP and browser-facing external tools
 
-`mcp_client.py` owns configured HTTP/SSE and local stdio MCP discovery and invocation. HTTP/SSE entries validate URLs and auth headers. Stdio entries pass one executable `command` and an exact string `args` list directly to the MCP SDK, without a shell, custom environment, or custom working directory; the SDK context owns process shutdown. Settings shows URL/auth fields for HTTP/SSE and command plus one-argument-per-line args for stdio. When MCP is enabled, successfully discovered tools join the selected initial capability envelope. Discovery failure produces an explicit capability omission through `list_available_tools`; it never silently removes an expected surface. Descriptions and results remain untrusted data, and every call still crosses registry, resource, safety, timeout, and result-handling policy.
+`mcp_client.py` owns configured HTTP/SSE and local stdio MCP discovery and invocation. HTTP/SSE entries validate URLs and auth headers. `secret_masking.py` owns the shared exact MCP token placeholder shapes used by status and Settings; load-time legacy repair remains intentionally limited to top-level Settings secrets and does not migrate pre-existing nested MCP values. Stdio entries pass one executable `command` and an exact string `args` list directly to the MCP SDK, without a shell, custom environment, or custom working directory; the SDK context owns process shutdown. Settings shows URL/auth fields for HTTP/SSE and command plus one-argument-per-line args for stdio. When MCP is enabled, successfully discovered tools join the selected initial capability envelope. Discovery failure produces an explicit capability omission through `list_available_tools`; it never silently removes an expected surface. Descriptions and results remain untrusted data, and every call still crosses registry, resource, safety, timeout, and result-handling policy.
 
 Browser tools are stateful and thread-sticky because Playwright sessions and greenlets have affinity; they cannot be scheduled as ordinary parallel stateless calls. Chromium is the default. WebKit and device descriptors are targeted tools for a real Safari/iOS risk, not a universal acceptance matrix and not a claim that a narrow Chromium viewport is Safari-equivalent. First-party PR helpers are normal built-ins, but their mutating operations remain subject to workspace, runtime-mode, local-readonly, heal-mode, credential, and reviewed-publication authority.
 
@@ -1707,6 +1708,12 @@ Single source of truth for:
   `acquire_pid_lock()`, `release_pid_lock()`
 
 Settings file: `~/Ouroboros/data/settings.json`. File-locked for concurrent access.
+`secret_masking.py` is the wire-placeholder authority for known and owner-defined
+top-level secrets. `load_settings()` repairs only recognized disk placeholders
+before environment precedence is resolved, so a real environment credential is
+never classified as a mask; `prepare_settings_for_persist()` applies the same
+top-level repair at the common writer boundary. Password, token, and MCP masks
+remain context-specific rather than sharing a suffix heuristic.
 
 ### LLM output token budgets
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1421,10 +1421,11 @@ host state, never in extension manifests.
 
 The base runtime is an optional client for trusted HTTP/SSE and local stdio MCP
 servers; it is not an MCP server. `ouroboros/mcp_client.py` owns server parsing,
-transport-specific validation, auth masking, provider-safe tool names,
-discovery, timeout, and result normalization. Settings carry only `MCP_ENABLED`,
-`MCP_TOOL_TIMEOUT_SEC`, and structured `MCP_SERVERS`; tokens never appear in
-status responses.
+transport-specific validation, provider-safe tool names, discovery, timeout,
+and result normalization. `ouroboros/secret_masking.py` owns the exact shared
+Settings/MCP auth-placeholder emitters and recognizers. Settings carry only
+`MCP_ENABLED`, `MCP_TOOL_TIMEOUT_SEC`, and structured `MCP_SERVERS`; tokens never
+appear in status responses.
 
 MCP descriptions/results are untrusted data, not policy. Enabled tools join the
 initial capability envelope, still pass runtime safety, and remain unavailable

--- a/ouroboros/config.py
+++ b/ouroboros/config.py
@@ -15,8 +15,8 @@ import time
 from typing import Any, Optional, Sequence
 
 from ouroboros.platform_layer import pid_lock_acquire as _compat_pid_lock_acquire, pid_lock_release as _compat_pid_lock_release
-from ouroboros.secret_masking import strip_masked_secrets
 from ouroboros.provider_models import compute_direct_review_models_fallback, local_only_review_route_env, migrate_model_value, review_model_uses_local as review_model_uses_local
+from ouroboros.secret_masking import strip_masked_secrets
 from ouroboros.update_channels import UPDATE_SETTINGS_DEFAULTS, normalize_update_channel
 
 
@@ -1145,7 +1145,7 @@ def prepare_settings_for_persist(settings: dict, *, authored_keys: Sequence[str]
         and str(v) == str(SETTINGS_DEFAULTS.get(k, "")))}
     _guard_context_mode_lowering(prepared, allow_context_lowering=allow_context_lowering)
     _guard_safety_mode_lowering(prepared, allow_safety_lowering=allow_safety_lowering)
-    return prepared
+    return strip_masked_secrets(prepared, known_setting_keys=SETTINGS_DEFAULTS)
 
 
 _SAFETY_MODE_RANK = {"full": 2, "light": 1, "off": 0}
@@ -1382,7 +1382,7 @@ def load_settings_lock_held() -> dict:
         loaded.pop(_retired, None)
     migrate_legacy_slot_keys(loaded)
     settings = dict(SETTINGS_DEFAULTS)
-    settings.update(loaded)
+    settings.update(strip_masked_secrets(loaded, known_setting_keys=SETTINGS_DEFAULTS))
     for key in SETTINGS_DEFAULTS:
         raw_env = os.environ.get(key)
         if raw_env is None or key in _DISK_AUTHORED_SETTINGS or key in ENDPOINT_AUTHORED_SETTINGS:  # DISK-authored
@@ -1395,7 +1395,7 @@ def load_settings_lock_held() -> dict:
         if key in loaded and settings.get(key) not in {None, ""}:
             continue
         settings[key] = _coerce_setting_value(key, raw_env)
-    return strip_masked_secrets(settings)
+    return settings
 
 
 def save_settings(

--- a/ouroboros/config.py
+++ b/ouroboros/config.py
@@ -14,8 +14,8 @@ import sys
 import time
 from typing import Any, Optional, Sequence
 
-from ouroboros.platform_layer import pid_lock_acquire as _compat_pid_lock_acquire
-from ouroboros.platform_layer import pid_lock_release as _compat_pid_lock_release
+from ouroboros.platform_layer import pid_lock_acquire as _compat_pid_lock_acquire, pid_lock_release as _compat_pid_lock_release
+from ouroboros.secret_masking import strip_masked_secrets
 from ouroboros.provider_models import compute_direct_review_models_fallback, local_only_review_route_env, migrate_model_value, review_model_uses_local as review_model_uses_local
 from ouroboros.update_channels import UPDATE_SETTINGS_DEFAULTS, normalize_update_channel
 
@@ -1395,7 +1395,7 @@ def load_settings_lock_held() -> dict:
         if key in loaded and settings.get(key) not in {None, ""}:
             continue
         settings[key] = _coerce_setting_value(key, raw_env)
-    return settings
+    return strip_masked_secrets(settings)
 
 
 def save_settings(

--- a/ouroboros/gateway/mcp.py
+++ b/ouroboros/gateway/mcp.py
@@ -14,10 +14,9 @@ from ouroboros.gateway._helpers import json_error, request_json_or
 from ouroboros.mcp_client import (
     canonical_server_id,
     get_manager,
-    looks_masked_secret,
     reconfigure_from_settings,
 )
-
+from ouroboros.secret_masking import looks_masked_mcp_secret
 
 log = logging.getLogger(__name__)
 
@@ -84,7 +83,7 @@ async def api_mcp_test(request: Request) -> JSONResponse:
                 # values from the saved config. The caller can also omit
                 # auth_token entirely to intentionally test without auth.
                 probe = dict(candidate)
-                if looks_masked_secret(probe.get("auth_token")):
+                if looks_masked_mcp_secret(probe.get("auth_token")):
                     probe["auth_token"] = str(target.get("auth_token") or "")
                 target = probe
             outcome = await asyncio.to_thread(manager.test_server, target)

--- a/ouroboros/gateway/settings.py
+++ b/ouroboros/gateway/settings.py
@@ -6,7 +6,6 @@ import asyncio
 import logging
 import os
 import pathlib
-import re
 import socket
 import sys
 from typing import Any, Dict, Optional
@@ -21,10 +20,6 @@ from ouroboros.config import (
     load_settings,
 )
 from ouroboros.config import ENDPOINT_AUTHORED_SETTINGS as _ENDPOINT_AUTHORED_SETTINGS
-from ouroboros.secret_masking import (
-    MASKED_SECRET_SETTING_KEYS,
-    looks_masked_secret as _looks_masked_secret,
-)
 from ouroboros.gateway._helpers import json_error, json_exception, request_drive_root
 from ouroboros.gateway.owner_settings import (
     CommitBoundary,
@@ -40,6 +35,13 @@ from ouroboros.gateway.owner_settings import (
 from ouroboros.onboarding_wizard import build_onboarding_html
 from ouroboros.platform_layer import is_container_env
 from ouroboros.provider_models import MINIMAX_REGION_ENDPOINTS, resolve_minimax_base_url
+from ouroboros.secret_masking import (
+    is_custom_secret_setting_key,
+    looks_masked_mcp_secret,
+    looks_masked_settings_secret,
+    mask_prefixed_secret,
+    mask_settings_secret,
+)
 from ouroboros.server_runtime import (
     apply_runtime_provider_defaults,
     classify_runtime_provider_change,
@@ -56,10 +58,6 @@ from ouroboros.utils import append_jsonl, utc_now_iso
 log = logging.getLogger(__name__)
 DEFAULT_PORT = int(os.environ.get("OUROBOROS_SERVER_PORT", "8765"))
 
-# The masker below and the read-side repair in config.load_settings must agree on
-# which keys are secrets, so the list has one home.
-_SECRET_SETTING_KEYS = MASKED_SECRET_SETTING_KEYS
-_CUSTOM_SECRET_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]{2,}$")
 
 def _get_lan_ip() -> str:
     """Return LAN IP via UDP socket trick; no packet is sent."""
@@ -127,25 +125,6 @@ def _build_network_meta(bind_host: str, bind_port: int) -> dict:
     }
 
 
-# Password-class secrets are usually short human-chosen strings: an 8-char
-# prefix can BE most of the password. They mask to a constant placeholder;
-# long machine-generated API keys keep the recognizable 8-char prefix.
-_PASSWORD_CLASS_KEYS = {
-    "OUROBOROS_NETWORK_PASSWORD",
-    "GIGACHAT_PASSWORD",
-    "GIGACHAT_CREDENTIALS",
-}
-
-
-def _mask_password_class(value: Any) -> str:
-    return "***set***" if str(value or "").strip() else ""
-
-
-def _mask_secret_value(value: Any) -> str:
-    text = str(value or "")
-    return text[:8] + "..." if len(text) > 8 else "***"
-
-
 def _mask_mcp_servers_payload(servers: Any) -> list:
     if not isinstance(servers, list):
         return []
@@ -162,7 +141,7 @@ def _mask_mcp_servers_payload(servers: Any) -> list:
             clone["id"] = _mcp_canonical_id(clone.get("id"))
         token = str(clone.get("auth_token") or "")
         if token:
-            clone["auth_token"] = _mask_secret_value(token)
+            clone["auth_token"] = mask_prefixed_secret(token, visible_chars=8)
             clone["auth_configured"] = True
         else:
             clone["auth_token"] = ""
@@ -194,7 +173,7 @@ def _rehydrate_mcp_servers_payload(incoming: Any, current: Any) -> list:
         if clone.get("id"):
             clone["id"] = _mcp_canonical_id(clone.get("id"))
         token = str(clone.get("auth_token") or "")
-        if _looks_masked_secret(token):
+        if looks_masked_mcp_secret(token):
             existing = current_by_id.get(_mcp_canonical_id(clone.get("id")))
             clone["auth_token"] = str((existing or {}).get("auth_token") or "")
         out.append(clone)
@@ -302,19 +281,18 @@ def _merge_settings_payload(current: Dict[str, Any], body: Dict[str, Any]) -> Di
         # A placeholder means "field untouched", never a new secret — and never a
         # credential worth persisting even when nothing is stored yet. Clearing
         # stays explicit: the UI sends "" for its Clear action.
-        if key in _SECRET_SETTING_KEYS and _looks_masked_secret(body[key]):
+        if key in SECRET_SETTING_KEYS and looks_masked_settings_secret(key, body[key]):
             continue
         merged[key] = body[key]
     for key, value in body.items():
         text_key = str(key or "").strip().upper()
         if text_key in _SETTINGS_DEFAULTS or text_key == "OUROBOROS_RUNTIME_MODE":
             continue
-        if not _CUSTOM_SECRET_KEY_RE.match(text_key):
+        if not is_custom_secret_setting_key(
+            text_key, known_setting_keys=_SETTINGS_DEFAULTS
+        ):
             continue
-        if text_key.startswith("OUROBOROS_"):
-            continue
-        # Same rule for owner-defined custom secret keys.
-        if _looks_masked_secret(value):
+        if looks_masked_settings_secret(text_key, value):
             continue
         merged[text_key] = value
     return merged
@@ -1112,17 +1090,15 @@ async def api_settings_get(request: Request) -> JSONResponse:
     safe = {k: v for k, v in settings.items()}
     for key in SECRET_SETTING_KEYS:
         if safe.get(key):
-            safe[key] = (
-                _mask_password_class(safe[key])
-                if key in _PASSWORD_CLASS_KEYS
-                else _mask_secret_value(safe[key])
-            )
+            safe[key] = mask_settings_secret(key, safe[key])
     safe["MCP_SERVERS"] = _mask_mcp_servers_payload(safe.get("MCP_SERVERS") or [])
     for key, value in list(safe.items()):
         if key in SECRET_SETTING_KEYS or key in _SETTINGS_DEFAULTS:
             continue
-        if _CUSTOM_SECRET_KEY_RE.match(str(key)) and value:
-            safe[key] = _mask_secret_value(value)
+        if is_custom_secret_setting_key(
+            key, known_setting_keys=_SETTINGS_DEFAULTS
+        ) and value:
+            safe[key] = mask_settings_secret(key, value)
     try:
         port = int(_port_file(request).read_text().strip()) if _port_file(request).exists() else _default_port(request)
     except (ValueError, OSError):
@@ -1132,7 +1108,7 @@ async def api_settings_get(request: Request) -> JSONResponse:
         key for key in settings
         if key not in SECRET_SETTING_KEYS
         and key not in _SETTINGS_DEFAULTS
-        and _CUSTOM_SECRET_KEY_RE.match(str(key))
+        and is_custom_secret_setting_key(key, known_setting_keys=_SETTINGS_DEFAULTS)
         and settings.get(key)
     )
     meta["setup_contract"] = build_setup_contract("web")

--- a/ouroboros/gateway/settings.py
+++ b/ouroboros/gateway/settings.py
@@ -21,6 +21,10 @@ from ouroboros.config import (
     load_settings,
 )
 from ouroboros.config import ENDPOINT_AUTHORED_SETTINGS as _ENDPOINT_AUTHORED_SETTINGS
+from ouroboros.secret_masking import (
+    MASKED_SECRET_SETTING_KEYS,
+    looks_masked_secret as _looks_masked_secret,
+)
 from ouroboros.gateway._helpers import json_error, json_exception, request_drive_root
 from ouroboros.gateway.owner_settings import (
     CommitBoundary,
@@ -52,6 +56,9 @@ from ouroboros.utils import append_jsonl, utc_now_iso
 log = logging.getLogger(__name__)
 DEFAULT_PORT = int(os.environ.get("OUROBOROS_SERVER_PORT", "8765"))
 
+# The masker below and the read-side repair in config.load_settings must agree on
+# which keys are secrets, so the list has one home.
+_SECRET_SETTING_KEYS = MASKED_SECRET_SETTING_KEYS
 _CUSTOM_SECRET_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]{2,}$")
 
 def _get_lan_ip() -> str:
@@ -137,9 +144,6 @@ def _mask_password_class(value: Any) -> str:
 def _mask_secret_value(value: Any) -> str:
     text = str(value or "")
     return text[:8] + "..." if len(text) > 8 else "***"
-
-
-from ouroboros.mcp_client import looks_masked_secret as _looks_masked_secret
 
 
 def _mask_mcp_servers_payload(servers: Any) -> list:
@@ -295,10 +299,10 @@ def _merge_settings_payload(current: Dict[str, Any], body: Dict[str, Any]) -> Di
             continue
         if key not in body:
             continue
-        # A mask means "keep the stored secret", so with nothing stored it is
-        # DROPPED: a client echoing back what it was served (the wizard does
-        # exactly that) must not be able to write the marker in as a credential.
-        if key in SECRET_SETTING_KEYS and _looks_masked_secret(body[key]):
+        # A placeholder means "field untouched", never a new secret — and never a
+        # credential worth persisting even when nothing is stored yet. Clearing
+        # stays explicit: the UI sends "" for its Clear action.
+        if key in _SECRET_SETTING_KEYS and _looks_masked_secret(body[key]):
             continue
         merged[key] = body[key]
     for key, value in body.items():

--- a/ouroboros/mcp_client.py
+++ b/ouroboros/mcp_client.py
@@ -23,6 +23,11 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
+from ouroboros.secret_masking import (
+    looks_masked_secret as looks_masked_secret,
+    mask_prefixed_secret,
+)
+
 log = logging.getLogger(__name__)
 
 
@@ -331,25 +336,12 @@ def redact_servers_for_status(configs: List[MCPServerConfig]) -> List[Dict[str, 
                 "transport": cfg.transport,
                 "url": cfg.url,
                 "auth_header": cfg.auth_header,
-                "auth_token": _mask_token(cfg.auth_token),
+                "auth_token": mask_prefixed_secret(cfg.auth_token, visible_chars=4),
                 "auth_configured": cfg.has_auth(),
                 "allowed_tools": list(cfg.allowed_tools),
             }
         )
     return out
-
-
-def _mask_token(value: str) -> str:
-    text = str(value or "")
-    if not text:
-        return ""
-    return text[:4] + "..." if len(text) > 4 else "***"
-
-
-# Re-exported so MCP callers and the Settings API share one mask contract; the
-# definition lives with the settings layer that produces the placeholder.
-from ouroboros.secret_masking import looks_masked_secret as looks_masked_secret  # noqa: E402
-
 
 def _redact_error_text(text: Any, cfg: Optional[MCPServerConfig] = None) -> str:
     """Redact MCP secrets before surfacing transport errors to UI/LLM/logs."""

--- a/ouroboros/mcp_client.py
+++ b/ouroboros/mcp_client.py
@@ -346,9 +346,9 @@ def _mask_token(value: str) -> str:
     return text[:4] + "..." if len(text) > 4 else "***"
 
 
-def looks_masked_secret(value: Any) -> bool:
-    text = str(value or "").strip()
-    return text in ("***", "***set***") or text.endswith("...")
+# Re-exported so MCP callers and the Settings API share one mask contract; the
+# definition lives with the settings layer that produces the placeholder.
+from ouroboros.secret_masking import looks_masked_secret as looks_masked_secret  # noqa: E402
 
 
 def _redact_error_text(text: Any, cfg: Optional[MCPServerConfig] = None) -> str:

--- a/ouroboros/secret_masking.py
+++ b/ouroboros/secret_masking.py
@@ -1,0 +1,59 @@
+"""One contract for masking settings secrets on the wire.
+
+The Settings API answers a GET with a placeholder instead of the stored
+credential, so any client can post that placeholder back — the UI does exactly
+that when the owner saves without touching a secret field. Producing the mask
+and recognizing it therefore have to live in the same file: once they drift, an
+unrecognized placeholder is persisted as the credential and every consumer
+(environment apply, provider catalogs, capability probes) sends it as an
+``Authorization`` value, which the provider rejects.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+# Credentials the Settings API answers a GET with a PLACEHOLDER instead of the
+# stored value. The same set gates the read-side repair in
+# ``config.load_settings`` and the write-side merge in
+# ``gateway.settings._merge_settings_payload``.
+MASKED_SECRET_SETTING_KEYS = frozenset({
+    "OPENROUTER_API_KEY",
+    "OPENAI_API_KEY",
+    "OPENAI_COMPATIBLE_API_KEY",
+    "CLOUDRU_FOUNDATION_MODELS_API_KEY",
+    "GIGACHAT_CREDENTIALS",
+    "GIGACHAT_PASSWORD",
+    "ANTHROPIC_API_KEY",
+    "MINIMAX_API_KEY",
+    "GITHUB_TOKEN",
+    "OUROBOROS_NETWORK_PASSWORD",
+})
+
+
+def looks_masked_secret(value: Any) -> bool:
+    """Whether ``value`` is a display placeholder rather than a real secret.
+
+    Deliberately narrow: only the shapes this codebase actually emits qualify,
+    so a short but genuine credential is never mistaken for a placeholder.
+    """
+    text = str(value or "").strip()
+    return text in ("***", "***set***") or text.endswith("...")
+
+
+def strip_masked_secrets(settings: Dict[str, Any]) -> Dict[str, Any]:
+    """Blank a stored placeholder so it can never be applied as a credential.
+
+    Read-side repair for an install an older round-trip already poisoned: the
+    placeholder is dropped on load, the Settings field reads as empty, and the
+    owner re-enters the real key instead of an endpoint seeing ``Bearer ***``.
+    Silent by design — ``load_settings`` runs on nearly every request, so a
+    warning here would be per-request noise; the emptied field is the
+    owner-facing signal.
+
+    Mutates and returns ``settings`` so a caller can wrap an existing return.
+    """
+    for key in MASKED_SECRET_SETTING_KEYS:
+        if looks_masked_secret(settings.get(key)):
+            settings[key] = ""
+    return settings

--- a/ouroboros/secret_masking.py
+++ b/ouroboros/secret_masking.py
@@ -1,48 +1,102 @@
-"""One contract for masking settings secrets on the wire.
+"""Wire placeholders for Settings and MCP secrets.
 
-The Settings API answers a GET with a placeholder instead of the stored
-credential, so any client can post that placeholder back — the UI does exactly
-that when the owner saves without touching a secret field. Producing the mask
-and recognizing it therefore have to live in the same file: once they drift, an
-unrecognized placeholder is persisted as the credential and every consumer
-(environment apply, provider catalogs, capability probes) sends it as an
-``Authorization`` value, which the provider rejects.
+Each reader recognizes only a shape emitted by its matching producer. Keeping
+the small mechanical contract here prevents a display placeholder from being
+persisted without treating arbitrary values ending in ``...`` as secrets to
+erase.
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict
+import re
+from typing import Any, Collection, Dict
 
 # Credentials the Settings API answers a GET with a PLACEHOLDER instead of the
 # stored value. The same set gates the read-side repair in
 # ``config.load_settings`` and the write-side merge in
 # ``gateway.settings._merge_settings_payload``.
-MASKED_SECRET_SETTING_KEYS = frozenset({
-    "OPENROUTER_API_KEY",
-    "OPENAI_API_KEY",
-    "OPENAI_COMPATIBLE_API_KEY",
-    "CLOUDRU_FOUNDATION_MODELS_API_KEY",
-    "GIGACHAT_CREDENTIALS",
-    "GIGACHAT_PASSWORD",
-    "ANTHROPIC_API_KEY",
-    "MINIMAX_API_KEY",
-    "GITHUB_TOKEN",
-    "OUROBOROS_NETWORK_PASSWORD",
-})
+MASKED_SECRET_SETTING_KEYS = frozenset(
+    {
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENAI_COMPATIBLE_API_KEY",
+        "CLOUDRU_FOUNDATION_MODELS_API_KEY",
+        "GIGACHAT_CREDENTIALS",
+        "GIGACHAT_PASSWORD",
+        "ANTHROPIC_API_KEY",
+        "MINIMAX_API_KEY",
+        "GITHUB_TOKEN",
+        "OUROBOROS_NETWORK_PASSWORD",
+    }
+)
+
+CONFIGURED_SECRET_PLACEHOLDER = "***set***"
+
+PASSWORD_SECRET_SETTING_KEYS = frozenset(
+    {
+        "OUROBOROS_NETWORK_PASSWORD",
+        "GIGACHAT_PASSWORD",
+        "GIGACHAT_CREDENTIALS",
+    }
+)
+
+_CUSTOM_SECRET_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]{2,}$")
+
+
+def is_custom_secret_setting_key(key: Any, *, known_setting_keys: Collection[str]) -> bool:
+    """Whether ``key`` is an owner-defined top-level Settings secret."""
+    text = str(key or "").strip()
+    return (
+        bool(_CUSTOM_SECRET_KEY_RE.fullmatch(text))
+        and text not in known_setting_keys
+        and not text.startswith("OUROBOROS_")
+    )
+
+
+def mask_prefixed_secret(value: Any, *, visible_chars: int) -> str:
+    """Mask a token, retaining the prefix used by its calling surface."""
+    text = str(value or "")
+    if not text:
+        return ""
+    return text[:visible_chars] + "..." if len(text) > visible_chars else "***"
+
+
+def mask_settings_secret(key: Any, value: Any) -> str:
+    """Return the Settings GET placeholder for one top-level secret."""
+    if str(key or "") in PASSWORD_SECRET_SETTING_KEYS:
+        return CONFIGURED_SECRET_PLACEHOLDER if str(value or "").strip() else ""
+    return mask_prefixed_secret(value, visible_chars=8)
+
+
+def _looks_prefixed_mask(value: Any, *, visible_chars: int) -> bool:
+    text = str(value or "").strip()
+    return len(text) == visible_chars + 3 and text.endswith("...")
+
+
+def looks_masked_settings_secret(key: Any, value: Any) -> bool:
+    """Recognize only the placeholder emitted for this Settings key class."""
+    text = str(value or "").strip()
+    if text == CONFIGURED_SECRET_PLACEHOLDER:
+        return True
+    if str(key or "") in PASSWORD_SECRET_SETTING_KEYS:
+        return False
+    return text == "***" or _looks_prefixed_mask(text, visible_chars=8)
+
+
+def looks_masked_mcp_secret(value: Any) -> bool:
+    """Recognize the short status and longer Settings MCP token masks."""
+    text = str(value or "").strip()
+    return text == "***" or _looks_prefixed_mask(text, visible_chars=4) or _looks_prefixed_mask(text, visible_chars=8)
 
 
 def looks_masked_secret(value: Any) -> bool:
-    """Whether ``value`` is a display placeholder rather than a real secret.
-
-    Deliberately narrow: only the shapes this codebase actually emits qualify,
-    so a short but genuine credential is never mistaken for a placeholder.
-    """
+    """Compatibility union of the exact placeholder shapes this module emits."""
     text = str(value or "").strip()
-    return text in ("***", "***set***") or text.endswith("...")
+    return text == CONFIGURED_SECRET_PLACEHOLDER or looks_masked_mcp_secret(text)
 
 
-def strip_masked_secrets(settings: Dict[str, Any]) -> Dict[str, Any]:
-    """Blank a stored placeholder so it can never be applied as a credential.
+def strip_masked_secrets(settings: Dict[str, Any], *, known_setting_keys: Collection[str]) -> Dict[str, Any]:
+    """Blank recognized top-level placeholders before read or persistence.
 
     Read-side repair for an install an older round-trip already poisoned: the
     placeholder is dropped on load, the Settings field reads as empty, and the
@@ -53,7 +107,13 @@ def strip_masked_secrets(settings: Dict[str, Any]) -> Dict[str, Any]:
 
     Mutates and returns ``settings`` so a caller can wrap an existing return.
     """
-    for key in MASKED_SECRET_SETTING_KEYS:
-        if looks_masked_secret(settings.get(key)):
+    for key, value in settings.items():
+        if key in MASKED_SECRET_SETTING_KEYS:
+            masked = looks_masked_settings_secret(key, value)
+        elif is_custom_secret_setting_key(key, known_setting_keys=known_setting_keys):
+            masked = looks_masked_settings_secret(key, value)
+        else:
+            masked = False
+        if masked:
             settings[key] = ""
     return settings

--- a/ouroboros/settings_setup_contract.py
+++ b/ouroboros/settings_setup_contract.py
@@ -13,6 +13,10 @@ from ouroboros.provider_models import (
     MINIMAX_REGION_ENDPOINTS,
     OPENAI_DIRECT_DEFAULTS,
 )
+from ouroboros.secret_masking import (
+    CONFIGURED_SECRET_PLACEHOLDER,
+    MASKED_SECRET_SETTING_KEYS as SECRET_SETTING_KEYS,
+)
 from ouroboros.task_pacing import COST_PLANNING_MARGIN_USD
 
 
@@ -75,30 +79,8 @@ _PROVIDER_FIELDS = _rows(("id", "stateKey", "settingKey", "settingsInputId", "la
     ("openai-compatible-key", "compatibleApiKey", "OPENAI_COMPATIBLE_API_KEY", "s-compatible-key", "OpenAI-compatible API Key", "Leave empty for no auth", "API key for the endpoint. Leave empty if your server does not require authentication.", "password", "more"),
 ))
 
-# Every settings key whose VALUE is a credential. ONE authority: /api/settings
-# masking, the generic settings merge, and the onboarding bootstrap all read it
-# from here, so a new provider cannot be secret on one surface and plaintext on
-# another. It lives in the setup contract because that is the lowest layer all
-# three already depend on.
-SECRET_SETTING_KEYS = frozenset({
-    "OPENROUTER_API_KEY",
-    "OPENAI_API_KEY",
-    "OPENAI_COMPATIBLE_API_KEY",
-    "CLOUDRU_FOUNDATION_MODELS_API_KEY",
-    "GIGACHAT_CREDENTIALS",
-    "GIGACHAT_PASSWORD",
-    "ANTHROPIC_API_KEY",
-    "MINIMAX_API_KEY",
-    "GITHUB_TOKEN",
-    "OUROBOROS_NETWORK_PASSWORD",
-})
-
-# What a configured credential looks like once it leaves the server. It is a
-# MARKER, not a redaction of the value: no prefix, no length, nothing that
-# narrows a guess. Deliberately the same token /api/settings already round-trips
-# for password-class secrets (``looks_masked_secret``), so every save path
-# rehydrates it through the rule it already has instead of a second one.
-CONFIGURED_SECRET_PLACEHOLDER = "***set***"
+# Secret-key membership and its configured marker are re-exported from the
+# leaf wire contract so onboarding, Settings, repair, and persistence cannot drift.
 
 _PROFILE_SPECS = {
     "openrouter": ("OpenRouter", "OpenRouter is present, so the next step keeps router-style defaults while still saving any extra direct keys you paste here.", "OpenRouter-style routing remains active. Unprefixed provider IDs like openai/gpt-5.6-terra or anthropic/claude-sonnet-5 continue to route through OpenRouter."),

--- a/tests/test_settings_secret_mask.py
+++ b/tests/test_settings_secret_mask.py
@@ -1,0 +1,225 @@
+"""A display placeholder must never be stored as a credential.
+
+The Settings API answers a GET with a placeholder instead of the stored secret,
+so any client can post that placeholder back. Persisting it replaces the working
+credential with a placeholder, and every consumer (env apply, provider catalogs,
+capability probes) then sends it as an ``Authorization`` value — which is what an
+OpenAI-compatible gateway rejects with "expected to start with 'sk-'".
+
+Values here are fixtures, never real credentials.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from ouroboros.secret_masking import looks_masked_secret
+
+REAL_KEY = "sk-original-secret"
+# Every placeholder shape this codebase emits.
+MASKS = ("***", "***set***", "sk-origi...")
+
+
+@pytest.fixture()
+def settings_client(tmp_path):
+    """TestClient over the real GET/POST settings endpoints with an in-memory disk."""
+    import server as srv
+
+    on_disk: Dict[str, Any] = {
+        "OPENAI_COMPATIBLE_API_KEY": REAL_KEY,
+        "OPENAI_COMPATIBLE_BASE_URL": "http://127.0.0.1:4000/v1",
+        "OPENROUTER_API_KEY": "sk-or-original",
+        "OPENAI_API_KEY": "sk-openai-original",
+        "ANTHROPIC_API_KEY": "sk-ant-original",
+        "GITHUB_TOKEN": "ghp-original",
+    }
+    saved: Dict[str, Any] = {}
+
+    def fake_load_settings():
+        return copy.deepcopy(on_disk)
+
+    def fake_save_settings(settings, *_a, **_k):
+        saved.clear()
+        saved.update(settings)
+        on_disk.update(settings)
+
+    patches = [
+        patch.object(srv, "_start_supervisor_if_needed", lambda *a, **k: None),
+        patch.object(srv, "_apply_settings_to_env", lambda *a, **k: None),
+        patch.object(srv, "apply_runtime_provider_defaults", lambda s: (dict(s), False, [])),
+        patch.object(srv, "load_settings", side_effect=fake_load_settings),
+        patch.object(srv, "save_settings", side_effect=fake_save_settings),
+        patch.object(srv._gateway_settings, "apply_runtime_provider_defaults", lambda s: (dict(s), False, [])),
+        patch.object(srv._gateway_settings, "_apply_max_context_auto_downgrade", lambda *a, **k: ("", "")),
+        patch.object(srv._gateway_settings, "_owner_read_settings_raw", side_effect=fake_load_settings),
+        patch.object(srv._gateway_settings, "_owner_write_settings", side_effect=fake_save_settings),
+        patch("ouroboros.server_auth.get_configured_network_password", return_value=""),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        app = Starlette(routes=[
+            Route("/api/settings", endpoint=srv.api_settings_get, methods=["GET"]),
+            Route("/api/settings", endpoint=srv.api_settings_post, methods=["POST"]),
+        ])
+        app.state.drive_root = tmp_path
+        app.state.repo_dir = tmp_path
+        with TestClient(app) as client:
+            yield client, on_disk, saved
+    finally:
+        for p in patches:
+            p.stop()
+
+
+def test_get_masks_the_stored_key(settings_client):
+    client, _on_disk, _saved = settings_client
+    resp = client.get("/api/settings")
+    assert resp.status_code == 200
+    assert REAL_KEY not in resp.text
+    assert looks_masked_secret(resp.json()["OPENAI_COMPATIBLE_API_KEY"])
+
+
+def test_reposting_the_served_mask_keeps_the_real_key(settings_client):
+    """The exact UI flow: load, then save without touching the field."""
+    client, on_disk, saved = settings_client
+    mask = client.get("/api/settings").json()["OPENAI_COMPATIBLE_API_KEY"]
+
+    resp = client.post("/api/settings", json={"OPENAI_COMPATIBLE_API_KEY": mask})
+
+    assert resp.status_code == 200, resp.text
+    assert saved["OPENAI_COMPATIBLE_API_KEY"] == REAL_KEY
+    assert on_disk["OPENAI_COMPATIBLE_API_KEY"] == REAL_KEY
+
+
+@pytest.mark.parametrize("mask", MASKS)
+def test_a_mask_is_never_persisted_even_with_nothing_stored(settings_client, mask):
+    """Without this, an empty field turns the placeholder into the credential."""
+    client, on_disk, saved = settings_client
+    on_disk["OPENAI_COMPATIBLE_API_KEY"] = ""
+
+    resp = client.post("/api/settings", json={"OPENAI_COMPATIBLE_API_KEY": mask})
+
+    assert resp.status_code == 200, resp.text
+    assert saved["OPENAI_COMPATIBLE_API_KEY"] == ""
+
+
+@pytest.mark.parametrize("mask", MASKS)
+def test_a_mask_is_never_persisted_as_a_custom_secret(settings_client, mask):
+    """Custom secret keys share the contract; they are masked by the same GET."""
+    client, _on_disk, saved = settings_client
+
+    resp = client.post("/api/settings", json={"MY_CUSTOM_TOKEN": mask})
+
+    assert resp.status_code == 200, resp.text
+    assert not saved.get("MY_CUSTOM_TOKEN")
+
+
+def test_a_new_key_replaces_the_old_one(settings_client):
+    client, on_disk, saved = settings_client
+
+    resp = client.post("/api/settings", json={"OPENAI_COMPATIBLE_API_KEY": "sk-new-secret"})
+
+    assert resp.status_code == 200, resp.text
+    assert saved["OPENAI_COMPATIBLE_API_KEY"] == "sk-new-secret"
+    assert on_disk["OPENAI_COMPATIBLE_API_KEY"] == "sk-new-secret"
+
+
+def test_explicit_clear_removes_the_key(settings_client):
+    """The Clear button posts an empty string; that must really delete it."""
+    client, on_disk, saved = settings_client
+
+    resp = client.post("/api/settings", json={"OPENAI_COMPATIBLE_API_KEY": ""})
+
+    assert resp.status_code == 200, resp.text
+    assert saved["OPENAI_COMPATIBLE_API_KEY"] == ""
+    assert on_disk["OPENAI_COMPATIBLE_API_KEY"] == ""
+
+
+def test_absent_key_keeps_the_stored_secret(settings_client):
+    client, _on_disk, saved = settings_client
+
+    resp = client.post("/api/settings", json={"OUROBOROS_MODEL": "openai-compatible::local-reason"})
+
+    assert resp.status_code == 200, resp.text
+    assert saved["OPENAI_COMPATIBLE_API_KEY"] == REAL_KEY
+
+
+@pytest.mark.parametrize("key", [
+    "OPENROUTER_API_KEY",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GITHUB_TOKEN",
+    "OPENAI_COMPATIBLE_API_KEY",
+])
+def test_every_provider_secret_round_trips(settings_client, key):
+    """One contract for all masked secrets, not a per-provider patch."""
+    client, on_disk, saved = settings_client
+    original = on_disk[key]
+    mask = client.get("/api/settings").json()[key]
+    assert looks_masked_secret(mask)
+
+    assert client.post("/api/settings", json={key: mask}).status_code == 200
+    assert saved[key] == original
+
+    assert client.post("/api/settings", json={key: "brand-new-value-123"}).status_code == 200
+    assert saved[key] == "brand-new-value-123"
+
+
+@pytest.mark.parametrize("mask", MASKS)
+def test_a_stored_mask_reads_back_as_unset(tmp_path, monkeypatch, mask):
+    """Repair for an install an older round-trip already poisoned."""
+    from ouroboros import config as cfg
+
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps({
+        "OPENAI_COMPATIBLE_API_KEY": mask,
+        "OPENAI_COMPATIBLE_BASE_URL": "http://127.0.0.1:4000/v1",
+    }), encoding="utf-8")
+    monkeypatch.setattr(cfg, "SETTINGS_PATH", settings_path)
+    monkeypatch.delenv("OPENAI_COMPATIBLE_API_KEY", raising=False)
+
+    loaded = cfg.load_settings()
+
+    assert loaded["OPENAI_COMPATIBLE_API_KEY"] == ""
+    assert loaded["OPENAI_COMPATIBLE_BASE_URL"] == "http://127.0.0.1:4000/v1"
+
+
+@pytest.mark.serial
+def test_a_stored_mask_never_reaches_the_environment(tmp_path, monkeypatch):
+    """apply_settings_to_env writes the real process env, so restore it after."""
+    from ouroboros import config as cfg
+
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps({
+        "OPENAI_COMPATIBLE_API_KEY": "***",
+        "OPENAI_COMPATIBLE_BASE_URL": "http://127.0.0.1:4000/v1",
+    }), encoding="utf-8")
+    monkeypatch.setattr(cfg, "SETTINGS_PATH", settings_path)
+    monkeypatch.delenv("OPENAI_COMPATIBLE_API_KEY", raising=False)
+
+    saved_env = dict(os.environ)
+    try:
+        cfg.apply_settings_to_env(cfg.load_settings())
+        assert os.environ.get("OPENAI_COMPATIBLE_API_KEY", "") == ""
+    finally:
+        os.environ.clear()
+        os.environ.update(saved_env)
+
+
+@pytest.mark.parametrize("value", ["***", "***set***", "sk-origi...", "abcd..."])
+def test_looks_masked_secret_accepts_every_placeholder(value):
+    assert looks_masked_secret(value) is True
+
+
+@pytest.mark.parametrize("value", ["", "sk-a", "*", "**", "sk-original-secret", "p@ssw0rd"])
+def test_looks_masked_secret_rejects_real_values(value):
+    assert looks_masked_secret(value) is False

--- a/tests/test_settings_secret_mask.py
+++ b/tests/test_settings_secret_mask.py
@@ -15,22 +15,24 @@ import copy
 import json
 import os
 from typing import Any, Dict
-from unittest.mock import patch
 
 import pytest
 from starlette.applications import Starlette
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
-from ouroboros.secret_masking import looks_masked_secret
+from ouroboros.secret_masking import (
+    looks_masked_mcp_secret,
+    looks_masked_secret,
+    looks_masked_settings_secret,
+)
 
 REAL_KEY = "sk-original-secret"
-# Every placeholder shape this codebase emits.
-MASKS = ("***", "***set***", "sk-origi...")
+TOKEN_MASKS = ("***", "***set***", "sk-origi...")
 
 
 @pytest.fixture()
-def settings_client(tmp_path):
+def settings_client(tmp_path, monkeypatch):
     """TestClient over the real GET/POST settings endpoints with an in-memory disk."""
     import server as srv
 
@@ -52,32 +54,39 @@ def settings_client(tmp_path):
         saved.update(settings)
         on_disk.update(settings)
 
-    patches = [
-        patch.object(srv, "_start_supervisor_if_needed", lambda *a, **k: None),
-        patch.object(srv, "_apply_settings_to_env", lambda *a, **k: None),
-        patch.object(srv, "apply_runtime_provider_defaults", lambda s: (dict(s), False, [])),
-        patch.object(srv, "load_settings", side_effect=fake_load_settings),
-        patch.object(srv, "save_settings", side_effect=fake_save_settings),
-        patch.object(srv._gateway_settings, "apply_runtime_provider_defaults", lambda s: (dict(s), False, [])),
-        patch.object(srv._gateway_settings, "_apply_max_context_auto_downgrade", lambda *a, **k: ("", "")),
-        patch.object(srv._gateway_settings, "_owner_read_settings_raw", side_effect=fake_load_settings),
-        patch.object(srv._gateway_settings, "_owner_write_settings", side_effect=fake_save_settings),
-        patch("ouroboros.server_auth.get_configured_network_password", return_value=""),
-    ]
-    for p in patches:
-        p.start()
-    try:
-        app = Starlette(routes=[
+    gateway = srv._gateway_settings
+
+    def provider_defaults(settings):
+        return dict(settings), False, []
+
+    monkeypatch.setattr(gateway, "load_settings", fake_load_settings)
+    # server's compatibility shim still assigns this retired module attribute.
+    # Record its absence so monkeypatch removes the temporary assignment again.
+    monkeypatch.setattr(gateway, "save_settings", fake_save_settings, raising=False)
+    monkeypatch.setattr(gateway, "_apply_settings_to_env", lambda *a, **k: None)
+    monkeypatch.setattr(gateway, "apply_runtime_provider_defaults", provider_defaults)
+    monkeypatch.setattr(gateway, "_apply_max_context_auto_downgrade", lambda *a, **k: ("", ""))
+    monkeypatch.setattr(gateway, "_owner_read_settings_raw", fake_load_settings)
+    monkeypatch.setattr(gateway, "_owner_write_settings", fake_save_settings)
+
+    # server's compatibility wrapper copies these four globals into the gateway
+    # on every request. Patch the gateway first so monkeypatch restores both
+    # modules to their real functions after the fixture.
+    monkeypatch.setattr(srv, "load_settings", fake_load_settings)
+    monkeypatch.setattr(srv, "save_settings", fake_save_settings)
+    monkeypatch.setattr(srv, "_apply_settings_to_env", lambda *a, **k: None)
+    monkeypatch.setattr(srv, "apply_runtime_provider_defaults", provider_defaults)
+
+    app = Starlette(
+        routes=[
             Route("/api/settings", endpoint=srv.api_settings_get, methods=["GET"]),
             Route("/api/settings", endpoint=srv.api_settings_post, methods=["POST"]),
-        ])
-        app.state.drive_root = tmp_path
-        app.state.repo_dir = tmp_path
-        with TestClient(app) as client:
-            yield client, on_disk, saved
-    finally:
-        for p in patches:
-            p.stop()
+        ]
+    )
+    app.state.drive_root = tmp_path
+    app.state.repo_dir = tmp_path
+    with TestClient(app) as client:
+        yield client, on_disk, saved
 
 
 def test_get_masks_the_stored_key(settings_client):
@@ -85,7 +94,7 @@ def test_get_masks_the_stored_key(settings_client):
     resp = client.get("/api/settings")
     assert resp.status_code == 200
     assert REAL_KEY not in resp.text
-    assert looks_masked_secret(resp.json()["OPENAI_COMPATIBLE_API_KEY"])
+    assert looks_masked_settings_secret("OPENAI_COMPATIBLE_API_KEY", resp.json()["OPENAI_COMPATIBLE_API_KEY"])
 
 
 def test_reposting_the_served_mask_keeps_the_real_key(settings_client):
@@ -100,7 +109,7 @@ def test_reposting_the_served_mask_keeps_the_real_key(settings_client):
     assert on_disk["OPENAI_COMPATIBLE_API_KEY"] == REAL_KEY
 
 
-@pytest.mark.parametrize("mask", MASKS)
+@pytest.mark.parametrize("mask", TOKEN_MASKS)
 def test_a_mask_is_never_persisted_even_with_nothing_stored(settings_client, mask):
     """Without this, an empty field turns the placeholder into the credential."""
     client, on_disk, saved = settings_client
@@ -112,7 +121,7 @@ def test_a_mask_is_never_persisted_even_with_nothing_stored(settings_client, mas
     assert saved["OPENAI_COMPATIBLE_API_KEY"] == ""
 
 
-@pytest.mark.parametrize("mask", MASKS)
+@pytest.mark.parametrize("mask", TOKEN_MASKS)
 def test_a_mask_is_never_persisted_as_a_custom_secret(settings_client, mask):
     """Custom secret keys share the contract; they are masked by the same GET."""
     client, _on_disk, saved = settings_client
@@ -121,6 +130,33 @@ def test_a_mask_is_never_persisted_as_a_custom_secret(settings_client, mask):
 
     assert resp.status_code == 200, resp.text
     assert not saved.get("MY_CUSTOM_TOKEN")
+
+
+def test_password_mask_is_never_persisted_with_nothing_stored(settings_client):
+    client, on_disk, saved = settings_client
+    on_disk["OUROBOROS_NETWORK_PASSWORD"] = ""
+
+    resp = client.post("/api/settings", json={"OUROBOROS_NETWORK_PASSWORD": "***set***"})
+
+    assert resp.status_code == 200, resp.text
+    assert saved["OUROBOROS_NETWORK_PASSWORD"] == ""
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("OUROBOROS_NETWORK_PASSWORD", "correct-horse..."),
+        ("MY_CUSTOM_TOKEN", "owner-chosen..."),
+    ],
+)
+def test_a_real_secret_ending_in_ellipsis_is_persisted(settings_client, key, value):
+    client, on_disk, saved = settings_client
+    on_disk[key] = ""
+
+    resp = client.post("/api/settings", json={key: value})
+
+    assert resp.status_code == 200, resp.text
+    assert saved[key] == value
 
 
 def test_a_new_key_replaces_the_old_one(settings_client):
@@ -153,19 +189,22 @@ def test_absent_key_keeps_the_stored_secret(settings_client):
     assert saved["OPENAI_COMPATIBLE_API_KEY"] == REAL_KEY
 
 
-@pytest.mark.parametrize("key", [
-    "OPENROUTER_API_KEY",
-    "OPENAI_API_KEY",
-    "ANTHROPIC_API_KEY",
-    "GITHUB_TOKEN",
-    "OPENAI_COMPATIBLE_API_KEY",
-])
+@pytest.mark.parametrize(
+    "key",
+    [
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GITHUB_TOKEN",
+        "OPENAI_COMPATIBLE_API_KEY",
+    ],
+)
 def test_every_provider_secret_round_trips(settings_client, key):
     """One contract for all masked secrets, not a per-provider patch."""
     client, on_disk, saved = settings_client
     original = on_disk[key]
     mask = client.get("/api/settings").json()[key]
-    assert looks_masked_secret(mask)
+    assert looks_masked_settings_secret(key, mask)
 
     assert client.post("/api/settings", json={key: mask}).status_code == 200
     assert saved[key] == original
@@ -174,16 +213,21 @@ def test_every_provider_secret_round_trips(settings_client, key):
     assert saved[key] == "brand-new-value-123"
 
 
-@pytest.mark.parametrize("mask", MASKS)
+@pytest.mark.parametrize("mask", TOKEN_MASKS)
 def test_a_stored_mask_reads_back_as_unset(tmp_path, monkeypatch, mask):
     """Repair for an install an older round-trip already poisoned."""
     from ouroboros import config as cfg
 
     settings_path = tmp_path / "settings.json"
-    settings_path.write_text(json.dumps({
-        "OPENAI_COMPATIBLE_API_KEY": mask,
-        "OPENAI_COMPATIBLE_BASE_URL": "http://127.0.0.1:4000/v1",
-    }), encoding="utf-8")
+    settings_path.write_text(
+        json.dumps(
+            {
+                "OPENAI_COMPATIBLE_API_KEY": mask,
+                "OPENAI_COMPATIBLE_BASE_URL": "http://127.0.0.1:4000/v1",
+            }
+        ),
+        encoding="utf-8",
+    )
     monkeypatch.setattr(cfg, "SETTINGS_PATH", settings_path)
     monkeypatch.delenv("OPENAI_COMPATIBLE_API_KEY", raising=False)
 
@@ -193,16 +237,106 @@ def test_a_stored_mask_reads_back_as_unset(tmp_path, monkeypatch, mask):
     assert loaded["OPENAI_COMPATIBLE_BASE_URL"] == "http://127.0.0.1:4000/v1"
 
 
+def test_a_stored_password_mask_reads_back_as_unset(tmp_path, monkeypatch):
+    from ouroboros import config as cfg
+
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps({"OUROBOROS_NETWORK_PASSWORD": "***set***"}), encoding="utf-8")
+    monkeypatch.setattr(cfg, "SETTINGS_PATH", settings_path)
+
+    assert cfg.load_settings()["OUROBOROS_NETWORK_PASSWORD"] == ""
+
+
+def test_disk_mask_does_not_block_a_real_environment_secret(tmp_path, monkeypatch):
+    from ouroboros import config as cfg
+
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps({"OPENAI_COMPATIBLE_API_KEY": "***"}), encoding="utf-8")
+    monkeypatch.setattr(cfg, "SETTINGS_PATH", settings_path)
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "sk-real-from-env")
+
+    assert cfg.load_settings()["OPENAI_COMPATIBLE_API_KEY"] == "sk-real-from-env"
+
+
+def test_environment_secret_ending_in_ellipsis_is_not_repaired(tmp_path, monkeypatch):
+    from ouroboros import config as cfg
+
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(cfg, "SETTINGS_PATH", settings_path)
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "sk-real-ending...")
+
+    assert cfg.load_settings()["OPENAI_COMPATIBLE_API_KEY"] == "sk-real-ending..."
+
+
+def test_real_stored_password_ending_in_ellipsis_is_not_repaired(tmp_path, monkeypatch):
+    from ouroboros import config as cfg
+
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps({"OUROBOROS_NETWORK_PASSWORD": "correct-horse..."}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cfg, "SETTINGS_PATH", settings_path)
+
+    assert cfg.load_settings()["OUROBOROS_NETWORK_PASSWORD"] == "correct-horse..."
+
+
+def test_custom_stored_masks_read_back_as_unset(tmp_path, monkeypatch):
+    from ouroboros import config as cfg
+
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "MY_CUSTOM_TOKEN": "***",
+                "TELEGRAM_BOT_TOKEN": "telegram...",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cfg, "SETTINGS_PATH", settings_path)
+
+    loaded = cfg.load_settings()
+
+    assert loaded["MY_CUSTOM_TOKEN"] == ""
+    assert loaded["TELEGRAM_BOT_TOKEN"] == ""
+
+
+def test_common_writer_blanks_top_level_masks(tmp_path, monkeypatch):
+    from ouroboros import config as cfg
+
+    settings_path = tmp_path / "settings.json"
+    monkeypatch.setattr(cfg, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(cfg, "SETTINGS_PATH", settings_path)
+
+    cfg.save_settings(
+        {
+            "OPENAI_COMPATIBLE_API_KEY": "sk-origi...",
+            "MY_CUSTOM_TOKEN": "my-token...",
+        }
+    )
+
+    raw = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert raw["OPENAI_COMPATIBLE_API_KEY"] == ""
+    assert raw["MY_CUSTOM_TOKEN"] == ""
+
+
 @pytest.mark.serial
 def test_a_stored_mask_never_reaches_the_environment(tmp_path, monkeypatch):
     """apply_settings_to_env writes the real process env, so restore it after."""
     from ouroboros import config as cfg
 
     settings_path = tmp_path / "settings.json"
-    settings_path.write_text(json.dumps({
-        "OPENAI_COMPATIBLE_API_KEY": "***",
-        "OPENAI_COMPATIBLE_BASE_URL": "http://127.0.0.1:4000/v1",
-    }), encoding="utf-8")
+    settings_path.write_text(
+        json.dumps(
+            {
+                "OPENAI_COMPATIBLE_API_KEY": "***",
+                "OPENAI_COMPATIBLE_BASE_URL": "http://127.0.0.1:4000/v1",
+            }
+        ),
+        encoding="utf-8",
+    )
     monkeypatch.setattr(cfg, "SETTINGS_PATH", settings_path)
     monkeypatch.delenv("OPENAI_COMPATIBLE_API_KEY", raising=False)
 
@@ -220,6 +354,34 @@ def test_looks_masked_secret_accepts_every_placeholder(value):
     assert looks_masked_secret(value) is True
 
 
-@pytest.mark.parametrize("value", ["", "sk-a", "*", "**", "sk-original-secret", "p@ssw0rd"])
+@pytest.mark.parametrize(
+    "value",
+    ["", "sk-a", "*", "**", "sk-original-secret", "p@ssw0rd", "correct-horse..."],
+)
 def test_looks_masked_secret_rejects_real_values(value):
     assert looks_masked_secret(value) is False
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "expected"),
+    [
+        ("OPENAI_API_KEY", "***", True),
+        ("OPENAI_API_KEY", "sk-origi...", True),
+        ("OPENAI_API_KEY", "***set***", True),
+        ("OUROBOROS_NETWORK_PASSWORD", "***set***", True),
+        ("OUROBOROS_NETWORK_PASSWORD", "***", False),
+        ("OUROBOROS_NETWORK_PASSWORD", "sk-origi...", False),
+    ],
+)
+def test_settings_masks_are_key_class_specific(key, value, expected):
+    assert looks_masked_settings_secret(key, value) is expected
+
+
+@pytest.mark.parametrize("value", ["***", "abcd...", "sk-origi..."])
+def test_mcp_recognizer_accepts_both_emitted_prefix_lengths(value):
+    assert looks_masked_mcp_secret(value) is True
+
+
+@pytest.mark.parametrize("value", ["***set***", "abcde...", "correct-horse..."])
+def test_mcp_recognizer_rejects_other_shapes(value):
+    assert looks_masked_mcp_secret(value) is False


### PR DESCRIPTION
API настроек отдаёт вместо сохранённого секрета отображаемую заглушку, поэтому клиент может вернуть её обратно. Если поле на диске пустое, заглушка записывалась как учётные данные и уходила в Authorization.

Заглушка больше не принимается на запись ни при каких условиях, а уже испорченная установка чинится на чтении: сохранённая заглушка отдаётся как пустое значение. Очистка остаётся явной — интерфейс шлёт пустую строку.

<!--
Thank you for contributing to Ouroboros.

Open this PR against the `ouroboros` branch, not `main` or
`ouroboros-stable`. Keep review artifacts out of the git diff: attach or link
them in the Review evidence section instead.
-->

## Summary

The Settings API answers a GET with a display placeholder instead of the stored
secret, so any client can post that placeholder back — the Settings UI does
exactly that when the owner saves without touching a secret field.

The write-side guard only ignored a placeholder when a value was **already
stored**: `_looks_masked_secret(body[key]) and merged.get(key)`. With the field
empty on disk, the placeholder was persisted as the credential, and nothing
downstream recovers it — `load_settings` returns it, `apply_settings_to_env`
exports it, and every consumer sends `Authorization: Bearer ***`. An
OpenAI-compatible gateway rejects that with "expected to start with 'sk-'".

Reproduced on the base revision before the change:

```text
_merge_settings_payload({"OPENAI_COMPATIBLE_API_KEY": ""},
                        {"OPENAI_COMPATIBLE_API_KEY": "***"})
  -> {"OPENAI_COMPATIBLE_API_KEY": "***"}        # placeholder stored as the key

settings.json = {"OPENAI_COMPATIBLE_API_KEY": "***"}
  load_settings() -> "***"
  os.environ     -> "***"                        # reaches the wire
```

A placeholder is now refused on write under all conditions, and an install a
previous round-trip already poisoned is repaired on read: the stored placeholder
loads as an empty value, the Settings field shows empty, and the owner re-enters
the real key instead of an endpoint seeing `Bearer ***`. Clearing stays explicit
— the UI sends an empty string for its Clear action.

## Scope

In scope:

- `ouroboros/secret_masking.py` (new): the mask contract in one place —
  `MASKED_SECRET_SETTING_KEYS`, `looks_masked_secret`, `strip_masked_secrets`.
  Producing the placeholder and recognizing it back must not drift apart. A new
  module rather than an addition to `config.py`, which is exactly at the
  1600-line ceiling enforced by
  `tests/test_smoke.py::test_no_oversized_modules`.
- `ouroboros/gateway/settings.py`: `_merge_settings_payload` drops the
  `and merged.get(...)` condition on both the known-secret and the custom-secret
  loop. `_SECRET_SETTING_KEYS` now aliases the shared set instead of repeating
  it, and the mask helper is imported from its new home.
- `ouroboros/config.py`: `load_settings` returns through
  `strip_masked_secrets`. To keep the module at its 1600-line ceiling this also
  folds the two adjacent `ouroboros.platform_layer` imports into one line — a
  one-line consolidation in the import block the change already touches, called
  out here because it is the only edit not strictly required by the fix.
- `ouroboros/mcp_client.py`: `looks_masked_secret` is re-exported from the new
  module instead of being defined a second time. Existing importers
  (`gateway/mcp.py`, `gateway/settings.py`) keep working unchanged.
- `tests/test_settings_secret_mask.py` (new): 30 tests over the real GET/POST
  settings endpoints and the load path.

Non-goals:

- `looks_masked_secret` stays exactly as narrow as it was: `***`, `***set***`,
  and the `prefix...` truncation. Widening it to shapes this codebase never
  emits (`**`, `********`) would risk reading a genuine human-chosen
  `OUROBOROS_NETWORK_PASSWORD` as a placeholder and silently unsetting it.
- `web/modules/settings.js` still posts the served placeholder back for short
  secrets — `collectSecretValue` filters only on `...`. Harmless once the server
  refuses it, and left for a separate frontend change.
- No change to which keys GET masks, to the masking format, or to the Clear
  flow.

## Verification

- [x] Focused tests for the changed behavior pass.
- [x] The default local test suite passes, or the reason it was not run is below.
- [x] Lint/static checks relevant to this change pass.

Commands and results:

```text
All commands on head 883fe687, base 089e1fe3.

$ .venv/bin/python -m ruff check . --select F
All checks passed!

$ .venv/bin/python -m pytest tests/test_settings_secret_mask.py tests/test_smoke.py
exit 0 — no failures. 30 tests in the new file; test_smoke.py included because
the change adds a module and touches config.py, which that file size-gates.

The suite was run as the two-pass CI split described in CONTRIBUTING.md
("Mark non-parallel-safe tests serial") rather than as a single `make test`:

$ .venv/bin/python -m pytest -n auto \
    -m "not serial and not ui_browser and not ui_browser_docker and not skill_smoke"
exit 1
  FAILED tests/test_delegated_subagent_transport.py::test_an_unresolvable_write_root_is_a_typed_refusal_not_a_traceback
  FAILED tests/test_claude_code_gateway.py::TestReadGuard::test_confines_by_value_not_by_an_enumerated_field_name

$ .venv/bin/python -m pytest -m "serial"
exit 1
  FAILED tests/test_process_custody.py::test_lifeline_kills_child_when_parent_dies

  No worker crash and no PARALLEL_WORKER_CRASH in either lane.

  All three failures are pre-existing on the base and unrelated to this change.
  Reproduced on a clean worktree at 089e1fe3 with nothing applied:

  $ git worktree add <tmp> 089e1fe3
  $ .venv/bin/python -m pytest \
      tests/test_process_custody.py::test_lifeline_kills_child_when_parent_dies \
      "tests/test_claude_code_gateway.py::TestReadGuard::test_confines_by_value_not_by_an_enumerated_field_name" \
      tests/test_delegated_subagent_transport.py::test_an_unresolvable_write_root_is_a_typed_refusal_not_a_traceback
  3 failed

  None of the three touches settings, secrets, or the gateway settings path.

Regression proof — both write-side guards restored to the base condition and the
read-side repair removed, new tests kept:

$ .venv/bin/python -m pytest tests/test_settings_secret_mask.py
10 failed
  test_a_mask_is_never_persisted_even_with_nothing_stored[***]
  test_a_mask_is_never_persisted_even_with_nothing_stored[***set***]
  test_a_mask_is_never_persisted_even_with_nothing_stored[sk-origi...]
  test_a_mask_is_never_persisted_as_a_custom_secret[***]
  test_a_mask_is_never_persisted_as_a_custom_secret[***set***]
  test_a_mask_is_never_persisted_as_a_custom_secret[sk-origi...]
  test_a_stored_mask_reads_back_as_unset[***]
  test_a_stored_mask_reads_back_as_unset[***set***]
  test_a_stored_mask_reads_back_as_unset[sk-origi...]
  test_a_stored_mask_never_reaches_the_environment

Not run: tests marked `skill_smoke` — they need OPENROUTER_API_KEY and reach
external network services. Also not run: `ui_browser` and `ui_browser_docker`;
this change has no rendered UI surface.
```

`test_a_stored_mask_never_reaches_the_environment` calls `apply_settings_to_env`,
which writes the real process environment, so it carries `@pytest.mark.serial`
and restores the environment afterwards. Every other test in the file is a pure
in-process call or a `TestClient` request over an in-memory settings dict with
module attributes patched and restored — no OS process, no port, no leaked
global — so they are parallel-safe and correctly unmarked.

Every secret value in the tests is a fixture.

## Visual evidence

- [x] Not applicable; this PR has no visible UI change.
- [ ] Before/after screenshots or other rendered-flow evidence are attached below.

Evidence: none. The Settings markup and field set are unchanged. The only
owner-visible difference is that a field holding a previously persisted
placeholder now reads as empty, which is the intended repair.

Evidence:

## Governance and documentation

- [x] I followed `CONTRIBUTING.md` and checked the relevant guidance in
      `BIBLE.md`, `docs/ARCHITECTURE.md`, `docs/DEVELOPMENT.md`, and
      `docs/CHECKLISTS.md`.
- [x] I updated tests and documentation where behavior or architecture changed.
- [x] I did not include secrets, local settings, runtime state, logs, caches, or
      generated build/review artifacts in the commit.
- [x] I did **not** bump `VERSION` or release-only version carriers; maintainers
      assign the collision-free release version during final integration.

## Agent assistance (optional)

<!-- Disclosure is useful context, not a quality signal. Remove this section if unused. -->

- Agent/tool and model:
- Work performed by the agent:
- Human verification performed:

## Review evidence

<!--
Attach or link the final triad/scope review output when available. Evidence must
correspond to the current PR diff; rerun it after code changes or a rebase. If it
was not run, say why. Missing evidence does not prevent opening a PR, but it can
make maintainer integration slower.
-->

- [ ] Triad/scope review evidence is attached or linked below.
- [x] Review was not run; the reason is recorded below.

- Reviewed base SHA: `089e1fe3`
- Reviewed head/diff SHA: `883fe687`
- Review command/profile: n/a
- Triad verdict: n/a
- Scope verdict: n/a
- Run artifacts/link: n/a
- Known advisory findings or accepted tradeoffs: a secret whose real value is
  literally `***`, `***set***`, or ends in `...` can no longer be saved, and is
  blanked if already on disk. That is unavoidable — such a value is
  indistinguishable from the placeholder the API itself emits — and the write
  path already rejected the first two shapes before this change. The new
  exposure is limited to the read-side repair. The read-side repair is silent by
  design: `load_settings` runs on nearly every request, so a warning there would
  be per-request noise; the emptied Settings field is the owner-facing signal.
- If not run, reason: `scripts/run_external_review.py --contributor` requires an
  `OPENROUTER_API_KEY` and an authorized `TOTAL_BUDGET`, neither of which was
  available for this run. The change is small and covered by the 30 targeted
  tests plus the two-pass local suite recorded above.

## Final checklist

- [x] The PR base branch is `ouroboros`.
- [x] The branch is based on a current `ouroboros` revision (`089e1fe3`).
- [x] The PR is one coherent change and is ready to be squash-integrated.
- [x] The description explains any limitations, follow-up work, or compatibility impact.