### PR TITLE
feat(skills): add typed bounded Iv ask client

### DIFF
--- a/data/skills/external/iv_ask/SKILL.md
+++ b/data/skills/external/iv_ask/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: iv_ask
+description: Ask the fixed Iv Hermes profile once and return only a bounded terminal result.
+version: 0.1.0
+type: extension
+entry: plugin.py
+runtime: python3
+permissions: [tool, net, read_settings]
+env_from_settings: [HERMES_API_KEY, HERMES_IV_ASK_ROOT_ID]
+timeout_sec: 135
+---
+
+# iv_ask — Stage 1C
+
+`iv_ask(text)` sends the original Lia text unchanged to the host-fixed Iv route.
+The extension supplies trusted root provenance from owner-granted host settings;
+the model cannot choose a profile, session, route, run ID, provenance, or URL.
+Hermes starts exactly one Runs API run and exposes only a capped, redacted
+terminal result (no reasoning, usage, events, or tool payloads).
+
+The future live payload path is exactly
+`/home/msheldyakov/ouroboros/data/skills/external/iv_ask/`.
+Review the payload, grant `HERMES_API_KEY` and `HERMES_IV_ASK_ROOT_ID`, enable
+`iv_ask`, then reload extensions. Hermes must already have the matching
+`gateway.api_server.lia_iv_ask.root_id` and fixed `model` configured.

--- a/data/skills/external/iv_ask/plugin.py
+++ b/data/skills/external/iv_ask/plugin.py
@@ -1,0 +1,109 @@
+"""Typed Ouroboros client for the narrow Hermes iv_ask projection."""
+from __future__ import annotations
+
+import json
+import re
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+_BASE_URL = "http://127.0.0.1:8642"
+_START_PATH = "/api/lia/iv-ask/runs"
+_MAX_HTTP_BYTES = 16 * 1024
+_MAX_TEXT_CHARS = 8000
+_POLL_SECONDS = 0.05
+_DEADLINE_SECONDS = 120.0
+_RUN_ID_RE = re.compile(r"^run_[0-9a-f]{32}$")
+
+
+def _compact(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def _error(code: str, message: str) -> str:
+    return _compact({"error": {"code": code, "message": message}})
+
+
+def _http_json(method: str, path: str, key: str, body: Any = None) -> tuple[int, Any]:
+    data = None if body is None else json.dumps(body, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    request = urllib.request.Request(
+        _BASE_URL + path,
+        data=data,
+        headers={"Authorization": f"Bearer {key}", "Accept": "application/json", "Content-Type": "application/json"},
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            raw = response.read(_MAX_HTTP_BYTES + 1)
+            status = int(response.status)
+    except urllib.error.HTTPError as exc:
+        raw = exc.read(_MAX_HTTP_BYTES + 1)
+        status = int(exc.code)
+    if len(raw) > _MAX_HTTP_BYTES:
+        raise ValueError("response_too_large")
+    payload = json.loads(raw.decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("invalid_response")
+    return status, payload
+
+
+def register(api: Any) -> None:
+    def iv_ask(text: str) -> str:
+        if not isinstance(text, str) or not text or len(text) > _MAX_TEXT_CHARS:
+            return _error("invalid_input", f"text must be 1..{_MAX_TEXT_CHARS} characters")
+        settings = api.get_settings(["HERMES_API_KEY", "HERMES_IV_ASK_ROOT_ID"])
+        key = str(settings.get("HERMES_API_KEY") or "").strip()
+        root_id = str(settings.get("HERMES_IV_ASK_ROOT_ID") or "").strip()
+        if not key or not root_id:
+            return _error("not_configured", "Hermes iv_ask credential or trusted root is not granted")
+        provenance = {
+            "actor": "lia",
+            "operation": "iv_ask",
+            "root": {"type": "ouroboros_host", "id": root_id, "trusted": True},
+        }
+        try:
+            status, started = _http_json("POST", _START_PATH, key, {"input": text, "provenance": provenance})
+            if status != 202:
+                return _error("hermes_rejected", "Hermes rejected iv_ask")
+            run_id = str(started.get("run_id") or "")
+            if not _RUN_ID_RE.fullmatch(run_id):
+                return _error("invalid_run_id", "Hermes returned an invalid linked run ID")
+            deadline = time.monotonic() + _DEADLINE_SECONDS
+            while time.monotonic() < deadline:
+                status, payload = _http_json("GET", f"{_START_PATH}/{run_id}", key)
+                if status != 200:
+                    return _error("hermes_status_error", "Hermes iv_ask status failed")
+                state = payload.get("status")
+                if state in {"completed", "failed", "cancelled"}:
+                    allowed = {"run_id", "status", "result", "error"}
+                    if set(payload) - allowed:
+                        return _error("invalid_terminal_result", "Hermes terminal result contained unexpected fields")
+                    return _compact(payload)
+                if state not in {"started", "queued", "running"}:
+                    return _error("nonterminal_status", "Hermes returned an unsupported nonterminal status")
+                time.sleep(_POLL_SECONDS)
+            try:
+                _http_json("POST", f"/v1/runs/{run_id}/stop", key, {})
+            except Exception:
+                pass
+            return _error("timeout", "Hermes iv_ask did not reach a terminal state before the fixed deadline")
+        except ValueError as exc:
+            code = str(exc) if str(exc) in {"response_too_large", "invalid_response"} else "invalid_response"
+            return _error(code, "Hermes iv_ask returned an invalid bounded response")
+        except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError):
+            api.log("warning", "Hermes iv_ask unavailable")
+            return _error("hermes_unavailable", "Hermes iv_ask is unavailable")
+
+    api.register_tool(
+        "iv_ask",
+        iv_ask,
+        description="Ask the fixed Iv profile once with Lia's exact text; returns only a bounded terminal result.",
+        schema={
+            "type": "object",
+            "properties": {"text": {"type": "string", "minLength": 1, "maxLength": _MAX_TEXT_CHARS}},
+            "required": ["text"],
+            "additionalProperties": False,
+        },
+        timeout_sec=130,
+    )

--- a/tests/test_iv_ask_skill.py
+++ b/tests/test_iv_ask_skill.py
@@ -1,0 +1,90 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+PLUGIN = Path(__file__).resolve().parents[1] / "data" / "skills" / "external" / "iv_ask" / "plugin.py"
+spec = importlib.util.spec_from_file_location("iv_ask_stage1c_plugin", PLUGIN)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+class API:
+    def __init__(self, settings=None):
+        self.settings = settings or {"HERMES_API_KEY": "secret", "HERMES_IV_ASK_ROOT_ID": "lia-project-root"}
+        self.tools = {}
+        self.logs = []
+
+    def get_settings(self, keys):
+        return {key: self.settings.get(key) for key in keys}
+
+    def register_tool(self, name, handler, **kwargs):
+        self.tools[name] = (handler, kwargs)
+
+    def log(self, *args, **kwargs):
+        self.logs.append((args, kwargs))
+
+
+def _tool(api=None):
+    api = api or API()
+    mod.register(api)
+    return api, api.tools["iv_ask"][0]
+
+
+def test_schema_exposes_only_typed_text():
+    api, _ = _tool()
+    schema = api.tools["iv_ask"][1]["schema"]
+    assert schema["required"] == ["text"]
+    assert set(schema["properties"]) == {"text"}
+    assert schema["additionalProperties"] is False
+
+
+def test_one_linked_run_exact_text_structured_provenance_and_bounded_terminal(monkeypatch):
+    calls = []
+    responses = iter([
+        (202, {"run_id": "run_" + "a" * 32, "status": "started"}),
+        (200, {"run_id": "run_" + "a" * 32, "status": "running"}),
+        (200, {"run_id": "run_" + "a" * 32, "status": "completed", "result": "Итог"}),
+    ])
+    def fake(method, path, key, body=None):
+        calls.append((method, path, key, body))
+        return next(responses)
+    monkeypatch.setattr(mod, "_http_json", fake)
+    monkeypatch.setattr(mod.time, "sleep", lambda _: None)
+    _, tool = _tool()
+    text = "  исходная формулировка Лии  "
+    result = json.loads(tool(text))
+    assert result["result"] == "Итог"
+    starts = [call for call in calls if call[0] == "POST" and call[1] == mod._START_PATH]
+    assert len(starts) == 1
+    assert starts[0][3]["input"] == text
+    assert starts[0][3]["provenance"] == {"actor": "lia", "operation": "iv_ask", "root": {
+        "type": "ouroboros_host", "id": "lia-project-root", "trusted": True,
+    }}
+    assert "profile" not in starts[0][3] and "session_id" not in starts[0][3] and "model" not in starts[0][3]
+
+
+def test_auth_rejection_nonterminal_timeout_and_oversize_fail_closed(monkeypatch):
+    _, tool = _tool()
+    monkeypatch.setattr(mod, "_http_json", lambda *a, **k: (401, {"error": {"message": "secret detail"}}))
+    assert json.loads(tool("x"))["error"]["code"] == "hermes_rejected"
+
+    seq = iter([(202, {"run_id": "run_" + "b" * 32}), (200, {"status": "waiting_for_approval"})])
+    monkeypatch.setattr(mod, "_http_json", lambda *a, **k: next(seq))
+    assert json.loads(tool("x"))["error"]["code"] == "nonterminal_status"
+
+    calls = []
+    def timeout_http(method, path, key, body=None):
+        calls.append((method, path))
+        if path == mod._START_PATH:
+            return 202, {"run_id": "run_" + "c" * 32}
+        return 200, {"status": "stopping"}
+    monkeypatch.setattr(mod, "_http_json", timeout_http)
+    monkeypatch.setattr(mod, "_DEADLINE_SECONDS", 0)
+    assert json.loads(tool("x"))["error"]["code"] == "timeout"
+    assert calls == [("POST", mod._START_PATH), ("POST", "/v1/runs/run_" + "c" * 32 + "/stop")]
+
+    def too_large(*args, **kwargs):
+        raise ValueError("response_too_large")
+    monkeypatch.setattr(mod, "_http_json", too_large)
+    assert json.loads(tool("x"))["error"]["code"] == "response_too_large"


### PR DESCRIPTION
## Summary
- add external `iv_ask(text)` extension payload at the future live path shape
- keep Hermes URL, trusted root, profile/route and run IDs outside the model schema
- start exactly one narrow authenticated run and poll only its bounded terminal projection
- fail closed on auth/protocol/nonterminal/timeout/oversize failures

## Verification
- `python3 -m pytest tests/test_iv_ask_skill.py tests/test_skill_loader.py tests/test_skill_manifest_v11.py -q` (68 passed)
- direct local skill -> HTTP auth -> intercepted Hermes Runs backend smoke passed; no model/live message used

Hermes-side narrow projection is a separate local candidate commit because that source snapshot has no remote.