### PR TITLE
fix(cli): keep packaged installs user-local and migrate owned shims

### DIFF
--- a/ouroboros/packaged_cli_install.py
+++ b/ouroboros/packaged_cli_install.py
@@ -22,6 +22,8 @@ class InstallPlan:
     source: pathlib.Path
     action: str
     path_hint: str
+    obsolete_shims: tuple[pathlib.Path, ...] = ()
+    shadowing_commands: tuple[pathlib.Path, ...] = ()
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -80,11 +82,23 @@ def plan_posix_install(
     source = _packaged_wrapper_source(bundle_root, windows=False)
     if not source.is_file():
         raise PackagedCLIError(f"packaged wrapper is missing: {source}")
+    use_default_target = target_dir is None
     target_parent = target_dir or choose_posix_target_dir()
     target = target_parent / "ouroboros"
     action = _existing_action(target, source, force=force)
-    path_hint = _posix_path_hint(target_parent)
-    return InstallPlan(target=target, source=source, action=action, path_hint=path_hint)
+    obsolete_shims, shadowing_commands = _posix_shadowing_plan(
+        target,
+        migrate_owned=use_default_target,
+    )
+    path_hint = _posix_path_hint(target_parent, shadowing_commands=shadowing_commands)
+    return InstallPlan(
+        target=target,
+        source=source,
+        action=action,
+        path_hint=path_hint,
+        obsolete_shims=obsolete_shims,
+        shadowing_commands=shadowing_commands,
+    )
 
 
 def install_posix(plan: InstallPlan, *, force: bool = False) -> None:
@@ -93,31 +107,84 @@ def install_posix(plan: InstallPlan, *, force: bool = False) -> None:
     if plan.target.exists() or plan.target.is_symlink():
         plan.target.unlink()
     os.symlink(str(plan.source), str(plan.target))
+    for shim in plan.obsolete_shims:
+        if not _is_owned_posix_shim(shim):
+            raise PackagedCLIError(
+                f"installed {plan.target}, but refused to remove changed earlier command: {shim}"
+            )
+        try:
+            shim.unlink()
+        except OSError as exc:
+            raise PackagedCLIError(
+                f"installed {plan.target}, but could not remove older Ouroboros shim {shim}: {exc}"
+            ) from exc
 
 
 def choose_posix_target_dir() -> pathlib.Path:
+    return pathlib.Path.home().resolve() / ".local" / "bin"
+
+
+def _posix_shadowing_plan(
+    target: pathlib.Path,
+    *,
+    migrate_owned: bool,
+) -> tuple[tuple[pathlib.Path, ...], tuple[pathlib.Path, ...]]:
+    target_parent = _resolve_for_compare(target.parent)
     home = pathlib.Path.home().resolve()
+    obsolete: list[pathlib.Path] = []
+    shadowing: list[pathlib.Path] = []
+    seen: set[pathlib.Path] = set()
     for raw in os.environ.get("PATH", "").split(os.pathsep):
         if not raw:
             continue
-        path = pathlib.Path(raw).expanduser()
-        try:
-            resolved = path.resolve()
-        except OSError:
+        parent = _resolve_for_compare(pathlib.Path(raw).expanduser())
+        if parent == target_parent:
+            break
+        candidate = parent / "ouroboros"
+        if candidate in seen:
             continue
-        if home in (resolved, *resolved.parents) and resolved.is_dir() and os.access(resolved, os.W_OK):
-            return resolved
-    return home / ".local" / "bin"
+        seen.add(candidate)
+        if not candidate.exists() and not candidate.is_symlink():
+            continue
+        under_home = home in (parent, *parent.parents)
+        if migrate_owned and under_home and _is_owned_posix_shim(candidate):
+            obsolete.append(candidate)
+        else:
+            shadowing.append(candidate)
+    return tuple(obsolete), tuple(shadowing)
 
 
-def _posix_path_hint(target_dir: pathlib.Path) -> str:
+def _is_owned_posix_shim(path: pathlib.Path) -> bool:
+    if not path.is_symlink():
+        return False
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for _ in range(8):
+                line = handle.readline()
+                if not line:
+                    break
+                if line.rstrip("\r\n") == MARKER:
+                    return True
+    except OSError:
+        return False
+    return False
+
+
+def _posix_path_hint(
+    target_dir: pathlib.Path,
+    *,
+    shadowing_commands: tuple[pathlib.Path, ...] = (),
+) -> str:
     target_text = str(target_dir)
+    if shadowing_commands:
+        earlier_dir = shadowing_commands[0].parent
+        return f"Put {target_text} before {earlier_dir} in PATH, or remove the earlier command if it is obsolete."
     path_parts = [p for p in os.environ.get("PATH", "").split(os.pathsep) if p]
     if target_text in path_parts:
         return "Open a new terminal if your shell cached an older command path."
     shell = pathlib.Path(os.environ.get("SHELL", "")).name
     profile = "~/.zprofile" if shell == "zsh" else "~/.bash_profile"
-    return f'Add this to {profile} if needed: export PATH="$PATH:{target_text}"'
+    return f'Add this to {profile} if needed: export PATH="{target_text}:$PATH"'
 
 
 def plan_windows_install(
@@ -189,6 +256,14 @@ def _existing_action(target: pathlib.Path, source: pathlib.Path, *, force: bool)
 def _print_plan(plan: InstallPlan, *, dry_run: bool) -> None:
     prefix = "Would install" if dry_run else "Installed"
     print(f"{prefix} ouroboros CLI: {plan.target} -> {plan.source}")
+    cleanup_prefix = "Would remove" if dry_run else "Removed"
+    for shim in plan.obsolete_shims:
+        print(f"{cleanup_prefix} older Ouroboros CLI shim: {shim}")
+    for command in plan.shadowing_commands:
+        print(
+            f"Warning: earlier PATH command may shadow the installed CLI: {command}",
+            file=sys.stderr,
+        )
     print(plan.path_hint)
 
 

--- a/tests/test_packaged_cli.py
+++ b/tests/test_packaged_cli.py
@@ -277,6 +277,154 @@ def test_installer_plan_chooses_user_local_path_dir(tmp_path, monkeypatch):
     assert plan.source == root / "bin" / "ouroboros"
 
 
+def test_installer_plan_ignores_ambient_path_dirs(tmp_path, monkeypatch):
+    from ouroboros.packaged_cli_install import plan_posix_install
+
+    root = _make_bundle_root(tmp_path)
+    home = tmp_path / "home"
+    harness_dir = home / ".kimi-code" / "bin"
+    harness_dir.mkdir(parents=True)
+    system_dir = tmp_path / "system-bin"
+    system_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("PATH", os.pathsep.join([str(harness_dir), str(system_dir)]))
+
+    plan = plan_posix_install(root)
+
+    assert plan.target == home / ".local" / "bin" / "ouroboros"
+    assert plan.obsolete_shims == ()
+    assert plan.shadowing_commands == ()
+
+
+def test_installer_default_migrates_owned_shadowing_shim(tmp_path, monkeypatch, capsys):
+    from ouroboros.packaged_cli_install import _print_plan, install_posix, plan_posix_install
+
+    root = _make_bundle_root(tmp_path, root=tmp_path / "new-bundle")
+    old_root = _make_bundle_root(tmp_path, root=tmp_path / "old-bundle")
+    home = tmp_path / "home"
+    harness_dir = home / ".kimi-code" / "bin"
+    harness_dir.mkdir(parents=True)
+    target_dir = home / ".local" / "bin"
+    old_shim = harness_dir / "ouroboros"
+    os.chmod(root / "bin" / "ouroboros", 0o755)
+    os.chmod(old_root / "bin" / "ouroboros", 0o755)
+    os.symlink(old_root / "bin" / "ouroboros", old_shim)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("PATH", os.pathsep.join([str(harness_dir), str(target_dir)]))
+
+    plan = plan_posix_install(root)
+
+    assert plan.target == target_dir / "ouroboros"
+    assert plan.obsolete_shims == (old_shim,)
+    assert plan.shadowing_commands == ()
+
+    _print_plan(plan, dry_run=True)
+    assert f"Would remove older Ouroboros CLI shim: {old_shim}" in capsys.readouterr().out
+
+    install_posix(plan)
+
+    assert not old_shim.is_symlink()
+    assert plan.target.resolve() == (root / "bin" / "ouroboros").resolve()
+    assert shutil.which("ouroboros", path=os.environ["PATH"]) == str(plan.target)
+
+    reinstall = plan_posix_install(root)
+    assert reinstall.action == "refresh"
+    assert reinstall.obsolete_shims == ()
+    install_posix(reinstall)
+
+
+def test_installer_keeps_unowned_shadowing_command(tmp_path, monkeypatch, capsys):
+    from ouroboros.packaged_cli_install import _print_plan, install_posix, plan_posix_install
+
+    root = _make_bundle_root(tmp_path)
+    home = tmp_path / "home"
+    harness_dir = home / ".kimi-code" / "bin"
+    harness_dir.mkdir(parents=True)
+    target_dir = home / ".local" / "bin"
+    earlier_command = harness_dir / "ouroboros"
+    earlier_command.write_text("#!/bin/sh\necho foreign\n", encoding="utf-8")
+    os.chmod(earlier_command, 0o755)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("PATH", os.pathsep.join([str(harness_dir), str(target_dir)]))
+
+    plan = plan_posix_install(root)
+
+    assert plan.obsolete_shims == ()
+    assert plan.shadowing_commands == (earlier_command,)
+
+    install_posix(plan)
+    _print_plan(plan, dry_run=False)
+
+    captured = capsys.readouterr()
+    assert earlier_command.read_text(encoding="utf-8") == "#!/bin/sh\necho foreign\n"
+    assert f"earlier PATH command may shadow the installed CLI: {earlier_command}" in captured.err
+    assert f"Put {target_dir} before {harness_dir} in PATH" in captured.out
+
+
+def test_installer_explicit_target_does_not_migrate_owned_shadow(tmp_path, monkeypatch):
+    from ouroboros.packaged_cli_install import install_posix, plan_posix_install
+
+    root = _make_bundle_root(tmp_path, root=tmp_path / "new-bundle")
+    old_root = _make_bundle_root(tmp_path, root=tmp_path / "old-bundle")
+    home = tmp_path / "home"
+    harness_dir = home / ".kimi-code" / "bin"
+    harness_dir.mkdir(parents=True)
+    explicit_dir = home / "bin"
+    old_shim = harness_dir / "ouroboros"
+    os.symlink(old_root / "bin" / "ouroboros", old_shim)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("PATH", os.pathsep.join([str(harness_dir), str(explicit_dir)]))
+
+    plan = plan_posix_install(root, target_dir=explicit_dir)
+
+    assert plan.obsolete_shims == ()
+    assert plan.shadowing_commands == (old_shim,)
+
+    install_posix(plan)
+
+    assert old_shim.is_symlink()
+    assert plan.target.resolve() == (root / "bin" / "ouroboros").resolve()
+
+
+def test_installer_removes_old_shim_only_after_new_install_succeeds(tmp_path, monkeypatch):
+    from ouroboros import packaged_cli_install
+    from ouroboros.packaged_cli_install import install_posix, plan_posix_install
+
+    root = _make_bundle_root(tmp_path, root=tmp_path / "new-bundle")
+    old_root = _make_bundle_root(tmp_path, root=tmp_path / "old-bundle")
+    home = tmp_path / "home"
+    harness_dir = home / ".kimi-code" / "bin"
+    harness_dir.mkdir(parents=True)
+    target_dir = home / ".local" / "bin"
+    old_shim = harness_dir / "ouroboros"
+    os.symlink(old_root / "bin" / "ouroboros", old_shim)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("PATH", os.pathsep.join([str(harness_dir), str(target_dir)]))
+    plan = plan_posix_install(root)
+
+    def fail_install(_source, _target):
+        raise OSError("simulated install failure")
+
+    monkeypatch.setattr(packaged_cli_install.os, "symlink", fail_install)
+
+    with pytest.raises(OSError, match="simulated install failure"):
+        install_posix(plan)
+
+    assert old_shim.is_symlink()
+
+
+def test_posix_path_hint_prepends_target(tmp_path, monkeypatch):
+    from ouroboros.packaged_cli_install import _posix_path_hint
+
+    target_dir = tmp_path / "home" / ".local" / "bin"
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+
+    assert _posix_path_hint(target_dir) == (
+        f'Add this to ~/.zprofile if needed: export PATH="{target_dir}:$PATH"'
+    )
+
+
 def test_installer_plan_accepts_expected_wrapper_in_sibling_resources_dir(tmp_path, monkeypatch):
     from ouroboros.packaged_cli_install import plan_posix_install
 


### PR DESCRIPTION
The packaged POSIX installer previously chose the first writable directory under $HOME on PATH. That could place the ouroboros shim inside another tool's private directory, such as ~/.kimi-code/bin.

This update uses ~/.local/bin as the deterministic user-local default. On default installs, it also removes an earlier shadowing shim only when it is a symlink under the user's home and its resolved wrapper carries the exact Ouroboros marker. Foreign or unproven commands are preserved and reported, explicit --target-dir installs are left alone, and the PATH hint now prepends the install directory.

The new shim is installed before cleanup, and an old shim is revalidated immediately before removal. The branch is rebased onto ouroboros and keeps the repository's user-local, no-sudo install contract.

Verification: 9183 passed, 3 skipped, 82 deselected in the full suite; 99 focused and adjacent tests passed after the final base update; Ruff F and git diff checks passed.