### PR TITLE
Add technical report page and citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,3 +20,23 @@ keywords:
   - self-modifying systems
   - persistent memory
   - multi-agent systems
+preferred-citation:
+  type: article
+  title: "Ouroboros: A Self-Developing Frontier Coding Agent with Reviewed Core Evolution"
+  authors:
+    - family-names: "Razzhigaev"
+      given-names: "Anton"
+    - family-names: "Gritsaev"
+      given-names: "Andrei"
+    - family-names: "Kaznacheev"
+      given-names: "Andrei"
+    - family-names: "Dragunov"
+      given-names: "Nikita"
+    - family-names: "Yampolskiy"
+      given-names: "Roman"
+    - family-names: "Kuznetsov"
+      given-names: "Andrei"
+  journal: "arXiv"
+  year: 2026
+  doi: "10.48550/arXiv.2608.08311"
+  url: "https://arxiv.org/abs/2608.08311"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/razzant/ouroboros?style=flat&logo=github)](https://github.com/razzant/ouroboros/stargazers)
 [![Downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frazzant%2Fouroboros%2Fbadges%2Fdownloads.json)](https://github.com/razzant/ouroboros/releases)
 [![Website](https://img.shields.io/badge/website-ouroboros--agent.ai-c93545.svg)](https://ouroboros-agent.ai/)
+[![Technical report](https://img.shields.io/badge/technical_report-arXiv%3A2608.08311-b31b1b.svg)](https://arxiv.org/abs/2608.08311)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![macOS 12+](https://img.shields.io/badge/macOS-12%2B-black.svg)](https://github.com/razzant/ouroboros/releases)
@@ -14,6 +15,8 @@
 Ouroboros is an open-source, general-purpose AI agent whose identity, durable memory, and history continue across tasks and restarts. It works on external projects, coordinates a live swarm of specialist agents, and can rewrite the implementation it runs on, including its code, architecture, prompts, tools, and dependencies. Reflection can also change how it understands itself without severing that continuity.
 
 It runs as a native desktop app or through a headless CLI. The runtime keeps its repository, durable memory, history, and interface on your machine, while model inference can use remote APIs you configure or a local GGUF model.
+
+The technical report, [Ouroboros: A Self-Developing Frontier Coding Agent with Reviewed Core Evolution](https://arxiv.org/abs/2608.08311), describes the reviewed core-evolution system, the 161-day Hope deployment, and the benchmark campaigns summarized below. [Paper page](https://ouroboros-agent.ai/paper/) · [Hugging Face](https://huggingface.co/papers/2608.08311)
 
 The charts below are self-reported results on Terminal-Bench 2.1, OSWorld-Verified, and CL-Bench, measured against Codex, Claude Code, Cursor, and Hermes — on the same model where a matched pair was run, and against the public leaderboard where it was not.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -267,8 +267,9 @@ server.py (Starlette+uvicorn) ← HTTP + WebSocket on configurable host:port (de
 .github/workflows/claudexor-platform-gate.yml ← 3-OS delegated-execution gate: fixture lane (fake harness, offline, $0) + live lane on explicit API keys (subscription auth deliberately out of CI — verified by a live local run, D26)
 .github/workflows/scorecard.yml ← OpenSSF Scorecard on `main` pushes and weekly; full action SHA pins, read-only defaults, OIDC result publication, and SARIF artifact/code-scanning upload
 CODE_OF_CONDUCT.md            ← Contributor Covenant 3.0 community rules and private moderator contact
-CITATION.cff                  ← Machine-readable software citation; Anton is the cited author and Ouroboros's contribution is acknowledged
+CITATION.cff                  ← Machine-readable software citation plus the preferred six-author technical-report citation; no institutional affiliation is inferred
 docs/benchmarks/evidence.json ← Release-bound non-GAIA projection of public benchmark claims and immutable evidence links; README remains the claim SSOT
+site/paper/index.html         ← Canonical technical-report landing page with author/citation metadata, `ScholarlyArticle` JSON-LD, paper links, and evidence navigation
 scripts/claudexor_platform_smoke.py ← the platform gate's smoke runner (daemon boot, one delegated no-edit/edit task, containment report)
 scripts/fetch_claudexor_runtime.py  ← release-build fetcher for the pinned managed Claudexor runtime archive (claudexor_runtime_pin.json is the SSOT)
 build.sh                      ← macOS build (PyInstaller → .dmg)
@@ -286,7 +287,7 @@ skills/telegram/            ← Bundled owner-only Telegram text/photo bridge pl
 skills/unix_computer_use/   ← Bundled extension skill for supervised desktop observation and input, including explicitly configured remote connections stored in skill state. A disabled or missing active connection fails closed instead of falling back to the local desktop; unavailable platform backends report that fact rather than guessing.
 packaging/cli/                ← Packaged CLI shell/cmd wrappers and user-local installer launchers copied into desktop artifacts
 Dockerfile                    ← Docker image (web UI runtime)
-site/                         ← Public GitHub Pages source (Vite). `site/scripts/sync-assets.mjs` copies canonical `assets/` images into gitignored `site/public/assets/`, and `pnpm build` renders committed `docs/`. Text-first product and install routes, `/llms.txt`, `/install.json`, and the sitemap share the same build; `tests/test_public_site_metadata.py` guards canonical URLs, structured metadata, install data, asset hashes, and source-to-Pages sync.
+site/                         ← Public GitHub Pages source (Vite). `site/scripts/sync-assets.mjs` copies canonical `assets/` images into gitignored `site/public/assets/`, and `pnpm build` renders committed `docs/`. Text-first product, paper, and install routes, `/llms.txt`, `/install.json`, and the sitemap share the same build; `tests/test_public_site_metadata.py` guards canonical URLs, structured metadata, paper citations, install data, asset hashes, and source-to-Pages sync.
 devtools/                     ← Tracked operator tooling outside runtime and package discovery; domain-specific architecture and methodology stay with the relevant devtool.
 ```
 
@@ -1953,7 +1954,7 @@ The main CI workflow has five roles: fork-safe quick checks with no provider sec
 
 Quick pull-request jobs are read-only and never use `pull_request_target`. The live catalog skill lane is intentionally a release dependency: it proves that the published payloads still install on this runtime, while keeping provider credentials out of every process that imports payload code. This external-service dependency is an explicit owner trade-off rather than an accidental source of flaky authority.
 
-The separate Scorecard workflow runs on `main` pushes and weekly. It pins every action by full commit SHA, defaults permissions to read-only, and adds only `security-events: write` and `id-token: write` for SARIF upload and OpenSSF publication. `CODE_OF_CONDUCT.md` owns community rules and reporting; `CITATION.cff` owns citation metadata; `docs/benchmarks/evidence.json` is a historical, release-bound non-GAIA projection of public benchmark claims and immutable evidence links. README remains the claim SSOT.
+The separate Scorecard workflow runs on `main` pushes and weekly. It pins every action by full commit SHA, defaults permissions to read-only, and adds only `security-events: write` and `id-token: write` for SARIF upload and OpenSSF publication. `CODE_OF_CONDUCT.md` owns community rules and reporting; `CITATION.cff` owns the software citation and preferred technical-report citation; `site/paper/index.html` owns the canonical human- and machine-readable paper landing page; `docs/benchmarks/evidence.json` is a historical, release-bound non-GAIA projection of public benchmark claims and immutable evidence links. README remains the claim SSOT.
 
 ### Build scripts
 

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -22,7 +22,7 @@
 </head>
 <body class="text-page">
   <div class="ambient" aria-hidden="true"></div>
-  <header class="text-nav"><a class="brand" href="/" aria-label="Ouroboros home"><img src="/assets/icon_1024.png" alt=""><span>Ouroboros</span></a><nav aria-label="Text pages"><a href="/install/">Install</a><a href="/benchmarks/">Benchmarks</a><a href="https://github.com/razzant/ouroboros">GitHub</a></nav></header>
+  <header class="text-nav"><a class="brand" href="/" aria-label="Ouroboros home"><img src="/assets/icon_1024.png" alt=""><span>Ouroboros</span></a><nav aria-label="Text pages"><a href="/paper/">Paper</a><a href="/install/">Install</a><a href="/benchmarks/">Benchmarks</a><a href="https://github.com/razzant/ouroboros">GitHub</a></nav></header>
   <main class="text-document">
     <p class="chapter-index">ABOUT / PLAIN TEXT</p>
     <h1>Ouroboros is an AI agent with a continuing identity and an editable implementation.</h1>
@@ -50,6 +50,6 @@
       <li><a href="/history/first-48-hours/">The first 48 hours</a> preserve the original generation as an archive.</li>
     </ul>
   </main>
-  <footer class="text-footer"><a href="/">Home</a><a href="/install/">Install</a><a href="/benchmarks/">Benchmarks</a><a href="/llms.txt">llms.txt</a></footer>
+  <footer class="text-footer"><a href="/">Home</a><a href="/paper/">Paper</a><a href="/install/">Install</a><a href="/benchmarks/">Benchmarks</a><a href="/llms.txt">llms.txt</a></footer>
 </body>
 </html>

--- a/docs/benchmarks/index.html
+++ b/docs/benchmarks/index.html
@@ -32,7 +32,7 @@
 </head>
 <body class="text-page">
   <div class="ambient" aria-hidden="true"></div>
-  <header class="text-nav"><a class="brand" href="/" aria-label="Ouroboros home"><img src="/assets/icon_1024.png" alt=""><span>Ouroboros</span></a><nav aria-label="Text pages"><a href="/about/">About</a><a href="/install/">Install</a><a href="https://github.com/razzant/ouroboros/tree/ouroboros/devtools/benchmarks">Harness code</a></nav></header>
+  <header class="text-nav"><a class="brand" href="/" aria-label="Ouroboros home"><img src="/assets/icon_1024.png" alt=""><span>Ouroboros</span></a><nav aria-label="Text pages"><a href="/paper/">Paper</a><a href="/about/">About</a><a href="/install/">Install</a><a href="https://github.com/razzant/ouroboros/tree/ouroboros/devtools/benchmarks">Harness code</a></nav></header>
   <main class="text-document text-document-wide">
     <p class="chapter-index">BENCHMARKS / PUBLIC EVIDENCE</p>
     <h1>Scores, status, and evidence.</h1>
@@ -56,6 +56,6 @@
     <h2>How to read the table</h2>
     <p>Each comparison binds a model to a harness. A model score from one harness does not describe the same system as the score from another harness. The repository keeps adapters and methods under <a href="https://github.com/razzant/ouroboros/tree/ouroboros/devtools/benchmarks">devtools/benchmarks</a>.</p>
   </main>
-  <footer class="text-footer"><a href="/">Home</a><a href="/about/">About</a><a href="/install/">Install</a><a href="https://habr.com/ru/companies/airi/articles/1065428/">Launch write-up</a></footer>
+  <footer class="text-footer"><a href="/">Home</a><a href="/paper/">Paper</a><a href="/about/">About</a><a href="/install/">Install</a><a href="https://habr.com/ru/companies/airi/articles/1065428/">Launch write-up</a></footer>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -49,7 +49,7 @@
   <div class="site-shell">
     <nav class="site-nav" aria-label="Primary navigation">
       <a class="brand" href="#top" aria-label="Ouroboros home"><img src="/assets/icon_1024.png" alt=""><span>Ouroboros</span></a>
-      <div class="nav-links"><a href="#work">Work</a><a href="/benchmarks/">Benchmarks</a><a href="/install/">Install</a><a href="#evolution">Evolution</a><a href="/about/">About</a></div>
+      <div class="nav-links"><a href="#work">Work</a><a href="/paper/">Paper</a><a href="/benchmarks/">Benchmarks</a><a href="/install/">Install</a><a href="#evolution">Evolution</a><a href="/about/">About</a></div>
       <div class="nav-actions"><a class="btn btn-quiet" href="https://github.com/razzant/ouroboros">GitHub</a><a class="btn btn-primary" href="https://github.com/razzant/ouroboros/releases/latest">Download</a></div>
     </nav>
 
@@ -100,7 +100,7 @@
           <figure class="media-panel reveal"><img src="/assets/bench-osworld.svg?v=26e6cdc7db" alt="Self-reported OSWorld-Verified results: Ouroboros 90.69% with Claude Opus-5 and 83.27% with Claude Sonnet-4.6" loading="lazy" width="1800" height="1000"><figcaption><span>OSWorld-Verified · 90.69% · self-reported</span><span><a href="https://huggingface.co/datasets/razzant/ouroboros-osworld-verified-opus5">Full traces</a></span></figcaption></figure>
           <figure class="media-panel reveal"><img src="/assets/bench-cl-bench.svg?v=633474d172" alt="Self-reported CL-Bench result: Ouroboros normalized reward 0.2301 with Claude Sonnet-4.6, rank 1" loading="lazy" width="1800" height="760"><figcaption><span>CL-Bench · 0.2301 · self-reported rank #1</span><span><a href="https://github.com/pgasawa/continual-learning-bench/pull/10">Open submission</a> · <a href="https://huggingface.co/datasets/razzant/ouroboros-clbench-traces">Full traces</a></span></figcaption></figure>
         </div>
-        <p class="bench-note reveal">The <a href="https://huggingface.co/datasets/razzant/swepro-luna-matched-pair">SWE-bench Pro matched-pair traces</a> support the statistical comparison with Codex CLI. A separate GAIA campaign reports 129/165 for Ouroboros and 131/165 for Claude Code, with strict pass@1 at 128/165 for both; its scrubbed trace capsule is still pending. Adapters, run scripts, and per-benchmark methodology live in <a href="https://github.com/razzant/ouroboros/tree/ouroboros/devtools/benchmarks">devtools/benchmarks</a>, and the full story with audits is in the <a href="https://habr.com/ru/companies/airi/articles/1065428/">launch write-up</a>.</p>
+        <p class="bench-note reveal">The <a href="https://huggingface.co/datasets/razzant/swepro-luna-matched-pair">SWE-bench Pro matched-pair traces</a> support the statistical comparison with Codex CLI. A separate GAIA campaign reports 129/165 for Ouroboros and 131/165 for Claude Code, with strict pass@1 at 128/165 for both; its scrubbed trace capsule is still pending. Adapters, run scripts, and per-benchmark methodology live in <a href="https://github.com/razzant/ouroboros/tree/ouroboros/devtools/benchmarks">devtools/benchmarks</a>. The <a href="/paper/">technical report</a> describes the system, campaigns, corrections, and limitations.</p>
       </section>
 
       <section class="chapter run-chapter" id="run" aria-labelledby="run-title">
@@ -162,7 +162,7 @@
       </section>
     </main>
 
-    <footer class="site-footer"><span>Ouroboros · open source</span><span><a href="/about/">About</a> · <a href="/install/">Install</a> · <a href="/benchmarks/">Benchmarks</a> · <a href="/llms.txt">llms.txt</a> · <a href="https://github.com/razzant/ouroboros/releases">Releases</a> · <a href="https://github.com/razzant/ouroboros/blob/ouroboros/CONTRIBUTING.md">Contributing</a> · <a href="/history/first-48-hours/">First 48 hours</a></span></footer>
+    <footer class="site-footer"><span>Ouroboros · open source</span><span><a href="/paper/">Paper</a> · <a href="/about/">About</a> · <a href="/install/">Install</a> · <a href="/benchmarks/">Benchmarks</a> · <a href="/llms.txt">llms.txt</a> · <a href="https://github.com/razzant/ouroboros/releases">Releases</a> · <a href="https://github.com/razzant/ouroboros/blob/ouroboros/CONTRIBUTING.md">Contributing</a> · <a href="/history/first-48-hours/">First 48 hours</a></span></footer>
   </div>
   <button class="motion-toggle" type="button" aria-label="Pause motion" aria-pressed="false"><span aria-hidden="true">Ⅱ</span><span class="motion-label">Pause motion</span></button>
 </body>

--- a/docs/install/index.html
+++ b/docs/install/index.html
@@ -36,7 +36,7 @@
 </head>
 <body class="text-page">
   <div class="ambient" aria-hidden="true"></div>
-  <header class="text-nav"><a class="brand" href="/" aria-label="Ouroboros home"><img src="/assets/icon_1024.png" alt=""><span>Ouroboros</span></a><nav aria-label="Text pages"><a href="/about/">About</a><a href="/benchmarks/">Benchmarks</a><a href="https://github.com/razzant/ouroboros/releases/latest">Releases</a></nav></header>
+  <header class="text-nav"><a class="brand" href="/" aria-label="Ouroboros home"><img src="/assets/icon_1024.png" alt=""><span>Ouroboros</span></a><nav aria-label="Text pages"><a href="/paper/">Paper</a><a href="/about/">About</a><a href="/benchmarks/">Benchmarks</a><a href="https://github.com/razzant/ouroboros/releases/latest">Releases</a></nav></header>
   <main class="text-document">
     <p class="chapter-index">INSTALL / STABLE RELEASE</p>
     <h1>Install Ouroboros.</h1>
@@ -87,6 +87,6 @@ ouroboros server</code></pre>
     <h2>Verify the download</h2>
     <p>Proof files vary by release. Check the selected release for its checksums and evidence file, if present. Releases built by the current workflow also include CycloneDX SBOMs, packaged smoke receipts, and GitHub attestations. <a href="/install.json">install.json</a> gives machine-readable release discovery, artifact name templates, and accepted proof filenames.</p>
   </main>
-  <footer class="text-footer"><a href="/">Home</a><a href="/about/">About</a><a href="/benchmarks/">Benchmarks</a><a href="/install.json">install.json</a></footer>
+  <footer class="text-footer"><a href="/">Home</a><a href="/paper/">Paper</a><a href="/about/">About</a><a href="/benchmarks/">Benchmarks</a><a href="/install.json">install.json</a></footer>
 </body>
 </html>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10,6 +10,7 @@ Ouroboros publishes self-reported benchmark results with status labels and links
 
 ## Start here
 
+- [Technical report](https://ouroboros-agent.ai/paper/): Paper metadata, authors, citation, code, and public evidence links.
 - [About](https://ouroboros-agent.ai/about/): What Ouroboros is and how it works.
 - [Install](https://ouroboros-agent.ai/install/): Packaged downloads and source setup.
 - [Benchmark evidence](https://ouroboros-agent.ai/benchmarks/): Scores, publication status, runs, traces, and methodology.

--- a/docs/paper/index.html
+++ b/docs/paper/index.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Technical report for Ouroboros, a self-developing frontier coding agent with reviewed core evolution, persistent identity, and public benchmark evidence.">
+  <meta name="robots" content="index, follow, max-image-preview:large">
+  <link rel="canonical" href="https://ouroboros-agent.ai/paper/">
+  <link rel="alternate" type="application/pdf" href="https://arxiv.org/pdf/2608.08311">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="Ouroboros">
+  <meta property="og:title" content="Ouroboros: A Self-Developing Frontier Coding Agent with Reviewed Core Evolution">
+  <meta property="og:description" content="Technical report on reviewed core evolution, the 161-day Hope deployment, and the benchmark campaigns behind Ouroboros.">
+  <meta property="og:url" content="https://ouroboros-agent.ai/paper/">
+  <meta property="og:image" content="https://ouroboros-agent.ai/assets/og-preview.png?v=44a9e298f8">
+  <meta property="og:image:alt" content="Ouroboros, a self-developing frontier coding agent with reviewed core evolution">
+  <meta property="article:published_time" content="2026-08-08">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Ouroboros: A Self-Developing Frontier Coding Agent">
+  <meta name="twitter:description" content="Technical report on reviewed core evolution, the Hope deployment, and public benchmark campaigns.">
+  <meta name="twitter:image" content="https://ouroboros-agent.ai/assets/og-preview.png?v=44a9e298f8">
+  <meta name="twitter:image:alt" content="Ouroboros, a self-developing frontier coding agent with reviewed core evolution">
+  <meta name="citation_title" content="Ouroboros: A Self-Developing Frontier Coding Agent with Reviewed Core Evolution">
+  <meta name="citation_author" content="Anton Razzhigaev">
+  <meta name="citation_author" content="Andrei Gritsaev">
+  <meta name="citation_author" content="Andrei Kaznacheev">
+  <meta name="citation_author" content="Nikita Dragunov">
+  <meta name="citation_author" content="Roman Yampolskiy">
+  <meta name="citation_author" content="Andrei Kuznetsov">
+  <meta name="citation_publication_date" content="2026/08/08">
+  <meta name="citation_arxiv_id" content="2608.08311">
+  <meta name="citation_doi" content="10.48550/arXiv.2608.08311">
+  <meta name="citation_abstract_html_url" content="https://arxiv.org/abs/2608.08311">
+  <meta name="citation_pdf_url" content="https://arxiv.org/pdf/2608.08311">
+  <title>Ouroboros technical report</title>
+  <link rel="icon" href="/assets/icon_1024.png" type="image/png">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ScholarlyArticle",
+      "headline": "Ouroboros: A Self-Developing Frontier Coding Agent with Reviewed Core Evolution",
+      "name": "Ouroboros: A Self-Developing Frontier Coding Agent with Reviewed Core Evolution",
+      "description": "Technical report on reviewed core evolution, the 161-day Hope deployment, and the benchmark campaigns behind Ouroboros.",
+      "datePublished": "2026-08-08",
+      "url": "https://ouroboros-agent.ai/paper/",
+      "mainEntityOfPage": "https://ouroboros-agent.ai/paper/",
+      "sameAs": [
+        "https://arxiv.org/abs/2608.08311",
+        "https://huggingface.co/papers/2608.08311",
+        "https://doi.org/10.48550/arXiv.2608.08311"
+      ],
+      "identifier": [
+        {"@type": "PropertyValue", "propertyID": "arXiv", "value": "2608.08311"},
+        {"@type": "PropertyValue", "propertyID": "DOI", "value": "10.48550/arXiv.2608.08311"}
+      ],
+      "author": [
+        {"@type": "Person", "name": "Anton Razzhigaev"},
+        {"@type": "Person", "name": "Andrei Gritsaev"},
+        {"@type": "Person", "name": "Andrei Kaznacheev"},
+        {"@type": "Person", "name": "Nikita Dragunov"},
+        {"@type": "Person", "name": "Roman Yampolskiy"},
+        {"@type": "Person", "name": "Andrei Kuznetsov"}
+      ],
+      "encoding": {
+        "@type": "MediaObject",
+        "contentUrl": "https://arxiv.org/pdf/2608.08311",
+        "encodingFormat": "application/pdf"
+      },
+      "about": {
+        "@type": "SoftwareApplication",
+        "name": "Ouroboros",
+        "url": "https://ouroboros-agent.ai/",
+        "codeRepository": "https://github.com/razzant/ouroboros"
+      }
+    }
+  </script>
+  <link rel="stylesheet" crossorigin href="/assets/ouroboros-BMqX6MjG.css">
+</head>
+<body class="text-page">
+  <div class="ambient" aria-hidden="true"></div>
+  <header class="text-nav"><a class="brand" href="/" aria-label="Ouroboros home"><img src="/assets/icon_1024.png" alt=""><span>Ouroboros</span></a><nav aria-label="Text pages"><a href="/about/">About</a><a href="/benchmarks/">Benchmarks</a><a href="https://github.com/razzant/ouroboros">GitHub</a></nav></header>
+  <main class="text-document">
+    <p class="chapter-index">TECHNICAL REPORT / 2026</p>
+    <h1>Ouroboros: A Self-Developing Frontier Coding Agent with Reviewed Core Evolution</h1>
+    <p class="text-lede">The report describes how Ouroboros changes its own runtime through reviewed Git history, preserves identity and memory across releases, and turns experience from ordinary work into structural improvements.</p>
+    <p>Anton Razzhigaev, Andrei Gritsaev, Andrei Kaznacheev, Nikita Dragunov, Roman Yampolskiy, and Andrei Kuznetsov.</p>
+    <div class="hero-actions"><a class="btn btn-primary" href="https://arxiv.org/abs/2608.08311">Read on arXiv</a><a class="btn btn-quiet" href="https://arxiv.org/pdf/2608.08311">PDF</a><a class="btn btn-quiet" href="https://huggingface.co/papers/2608.08311">Hugging Face</a></div>
+
+    <h2>What the report covers</h2>
+    <ul>
+      <li>Reviewed core evolution across code, prompts, tools, context assembly, architecture, and dependencies.</li>
+      <li>Hope, a 161-day deployment in which ordinary work and human interaction continually expose new problems and improvement opportunities.</li>
+      <li>Benchmark campaigns on Terminal-Bench 2.1, OSWorld-Verified, CL-Bench, SWE-bench Pro, and GAIA, including limitations and audit corrections.</li>
+      <li>The operational controls used to keep self-modification attributable, reviewable, and recoverable.</li>
+    </ul>
+
+    <h2>Paper and evidence</h2>
+    <ul class="link-list">
+      <li><a href="https://arxiv.org/abs/2608.08311">arXiv 2608.08311</a> is the canonical preprint record.</li>
+      <li><a href="https://huggingface.co/papers/2608.08311">Hugging Face Papers</a> carries the community discussion and linked artifacts.</li>
+      <li><a href="https://huggingface.co/collections/razzant/ouroboros-benchmark-evidence-6a6e7fec1cfdc2d8d93ed3a3">Benchmark evidence collection</a> groups the public datasets and explorer.</li>
+      <li><a href="https://huggingface.co/spaces/razzant/ouroboros-benchmark-explorer">Benchmark Explorer</a> provides a no-key view of the released evidence.</li>
+      <li><a href="https://github.com/razzant/ouroboros">Source repository</a> contains the implementation, history, benchmark adapters, and methodology.</li>
+    </ul>
+
+    <h2>Citation</h2>
+    <pre><code>@techreport{razzhigaev2026ouroboros,
+  title        = {Ouroboros: A Self-Developing Frontier Coding Agent with Reviewed Core Evolution},
+  author       = {Anton Razzhigaev and Andrei Gritsaev and Andrei Kaznacheev and Nikita Dragunov and Roman Yampolskiy and Andrei Kuznetsov},
+  year         = {2026},
+  eprint       = {2608.08311},
+  archivePrefix = {arXiv},
+  primaryClass = {cs.SE},
+  doi          = {10.48550/arXiv.2608.08311},
+  url          = {https://arxiv.org/abs/2608.08311}
+}</code></pre>
+  </main>
+  <footer class="text-footer"><a href="/">Home</a><a href="/about/">About</a><a href="/benchmarks/">Benchmarks</a><a href="/llms.txt">llms.txt</a></footer>
+</body>
+</html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -11,6 +11,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://ouroboros-agent.ai/paper/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://ouroboros-agent.ai/install/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>

--- a/site/about/index.html
+++ b/site/about/index.html
@@ -22,7 +22,7 @@
 </head>
 <body class="text-page">
   <div class="ambient" aria-hidden="true"></div>
-  <header class="text-nav"><a class="brand" href="/" aria-label="Ouroboros home"><img src="/assets/icon_1024.png" alt=""><span>Ouroboros</span></a><nav aria-label="Text pages"><a href="/install/">Install</a><a href="/benchmarks/">Benchmarks</a><a href="https://github.com/razzant/ouroboros">GitHub</a></nav></header>
+  <header class="text-nav"><a class="brand" href="/" aria-label="Ouroboros home"><img src="/assets/icon_1024.png" alt=""><span>Ouroboros</span></a><nav aria-label="Text pages"><a href="/paper/">Paper</a><a href="/install/">Install</a><a href="/benchmarks/">Benchmarks</a><a href="https://github.com/razzant/ouroboros">GitHub</a></nav></header>
   <main class="text-document">
     <p class="chapter-index">ABOUT / PLAIN TEXT</p>
     <h1>Ouroboros is an AI agent with a continuing identity and an editable implementation.</h1>
@@ -50,6 +50,6 @@
       <li><a href="/history/first-48-hours/">The first 48 hours</a> preserve the original generation as an archive.</li>
     </ul>
   </main>
-  <footer class="text-footer"><a href="/">Home</a><a href="/install/">Install</a><a href="/benchmarks/">Benchmarks</a><a href="/llms.txt">llms.txt</a></footer>
+  <footer class="text-footer"><a href="/">Home</a><a href="/paper/">Paper</a><a href="/install/">Install</a><a href="/benchmarks/">Benchmarks</a><a href="/llms.txt">llms.txt</a></footer>
 </body>
 </html>

--- a/site/benchmarks/index.html
+++ b/site/benchmarks/index.html
@@ -32,7 +32,7 @@
 </head>
 <body class="text-page">
   <div class="ambient" aria-hidden="true"></div>
-  <header class="text-nav"><a class="brand" href="/" aria-label="Ouroboros home"><img src="/assets/icon_1024.png" alt=""><span>Ouroboros</span></a><nav aria-label="Text pages"><a href="/about/">About</a><a href="/install/">Install</a><a href="https://github.com/razzant/ouroboros/tree/ouroboros/devtools/benchmarks">Harness code</a></nav></header>
+  <header class="text-nav"><a class="brand" href="/" aria-label="Ouroboros home"><img src="/assets/icon_1024.png" alt=""><span>Ouroboros</span></a><nav aria-label="Text pages"><a href="/paper/">Paper</a><a href="/about/">About</a><a href="/install/">Install</a><a href="https://github.com/razzant/ouroboros/tree/ouroboros/devtools/benchmarks">Harness code</a></nav></header>
   <main class="text-document text-document-wide">
     <p class="chapter-index">BENCHMARKS / PUBLIC EVIDENCE</p>
     <h1>Scores, status, and evidence.</h1>
@@ -56,6 +56,6 @@
     <h2>How to read the table</h2>
     <p>Each comparison binds a model to a harness. A model score from one harness does not describe the same system as the score from another harness. The repository keeps adapters and methods under <a href="https://github.com/razzant/ouroboros/tree/ouroboros/devtools/benchmarks">devtools/benchmarks</a>.</p>
   </main>
-  <footer class="text-footer"><a href="/">Home</a><a href="/about/">About</a><a href="/install/">Install</a><a href="https://habr.com/ru/companies/airi/articles/1065428/">Launch write-up</a></footer>
+  <footer class="text-footer"><a href="/">Home</a><a href="/paper/">Paper</a><a href="/about/">About</a><a href="/install/">Install</a><a href="https://habr.com/ru/companies/airi/articles/1065428/">Launch write-up</a></footer>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -48,7 +48,7 @@
   <div class="site-shell">
     <nav class="site-nav" aria-label="Primary navigation">
       <a class="brand" href="#top" aria-label="Ouroboros home"><img src="/assets/icon_1024.png" alt=""><span>Ouroboros</span></a>
-      <div class="nav-links"><a href="#work">Work</a><a href="/benchmarks/">Benchmarks</a><a href="/install/">Install</a><a href="#evolution">Evolution</a><a href="/about/">About</a></div>
+      <div class="nav-links"><a href="#work">Work</a><a href="/paper/">Paper</a><a href="/benchmarks/">Benchmarks</a><a href="/install/">Install</a><a href="#evolution">Evolution</a><a href="/about/">About</a></div>
       <div class="nav-actions"><a class="btn btn-quiet" href="https://github.com/razzant/ouroboros">GitHub</a><a class="btn btn-primary" href="https://github.com/razzant/ouroboros/releases/latest">Download</a></div>
     </nav>
 
@@ -99,7 +99,7 @@
           <figure class="media-panel reveal"><img src="/assets/bench-osworld.svg?v=26e6cdc7db" alt="Self-reported OSWorld-Verified results: Ouroboros 90.69% with Claude Opus-5 and 83.27% with Claude Sonnet-4.6" loading="lazy" width="1800" height="1000"><figcaption><span>OSWorld-Verified · 90.69% · self-reported</span><span><a href="https://huggingface.co/datasets/razzant/ouroboros-osworld-verified-opus5">Full traces</a></span></figcaption></figure>
           <figure class="media-panel reveal"><img src="/assets/bench-cl-bench.svg?v=633474d172" alt="Self-reported CL-Bench result: Ouroboros normalized reward 0.2301 with Claude Sonnet-4.6, rank 1" loading="lazy" width="1800" height="760"><figcaption><span>CL-Bench · 0.2301 · self-reported rank #1</span><span><a href="https://github.com/pgasawa/continual-learning-bench/pull/10">Open submission</a> · <a href="https://huggingface.co/datasets/razzant/ouroboros-clbench-traces">Full traces</a></span></figcaption></figure>
         </div>
-        <p class="bench-note reveal">The <a href="https://huggingface.co/datasets/razzant/swepro-luna-matched-pair">SWE-bench Pro matched-pair traces</a> support the statistical comparison with Codex CLI. A separate GAIA campaign reports 129/165 for Ouroboros and 131/165 for Claude Code, with strict pass@1 at 128/165 for both; its scrubbed trace capsule is still pending. Adapters, run scripts, and per-benchmark methodology live in <a href="https://github.com/razzant/ouroboros/tree/ouroboros/devtools/benchmarks">devtools/benchmarks</a>, and the full story with audits is in the <a href="https://habr.com/ru/companies/airi/articles/1065428/">launch write-up</a>.</p>
+        <p class="bench-note reveal">The <a href="https://huggingface.co/datasets/razzant/swepro-luna-matched-pair">SWE-bench Pro matched-pair traces</a> support the statistical comparison with Codex CLI. A separate GAIA campaign reports 129/165 for Ouroboros and 131/165 for Claude Code, with strict pass@1 at 128/165 for both; its scrubbed trace capsule is still pending. Adapters, run scripts, and per-benchmark methodology live in <a href="https://github.com/razzant/ouroboros/tree/ouroboros/devtools/benchmarks">devtools/benchmarks</a>. The <a href="/paper/">technical report</a> describes the system, campaigns, corrections, and limitations.</p>
       </section>
 
       <section class="chapter run-chapter" id="run" aria-labelledby="run-title">
@@ -161,7 +161,7 @@
       </section>
     </main>
 
-    <footer class="site-footer"><span>Ouroboros · open source</span><span><a href="/about/">About</a> · <a href="/install/">Install</a> · <a href="/benchmarks/">Benchmarks</a> · <a href="/llms.txt">llms.txt</a> · <a href="https://github.com/razzant/ouroboros/releases">Releases</a> · <a href="https://github.com/razzant/ouroboros/blob/ouroboros/CONTRIBUTING.md">Contributing</a> · <a href="/history/first-48-hours/">First 48 hours</a></span></footer>
+    <footer class="site-footer"><span>Ouroboros · open source</span><span><a href="/paper/">Paper</a> · <a href="/about/">About</a> · <a href="/install/">Install</a> · <a href="/benchmarks/">Benchmarks</a> · <a href="/llms.txt">llms.txt</a> · <a href="https://github.com/razzant/ouroboros/releases">Releases</a> · <a href="https://github.com/razzant/ouroboros/blob/ouroboros/CONTRIBUTING.md">Contributing</a> · <a href="/history/first-48-hours/">First 48 hours</a></span></footer>
   </div>
   <button class="motion-toggle" type="button" aria-label="Pause motion" aria-pressed="false"><span aria-hidden="true">Ⅱ</span><span class="motion-label">Pause motion</span></button>
   <script type="module" src="/src/ouroboros.js"></script>

--- a/site/install/index.html
+++ b/site/install/index.html
@@ -36,7 +36,7 @@
 </head>
 <body class="text-page">
   <div class="ambient" aria-hidden="true"></div>
-  <header class="text-nav"><a class="brand" href="/" aria-label="Ouroboros home"><img src="/assets/icon_1024.png" alt=""><span>Ouroboros</span></a><nav aria-label="Text pages"><a href="/about/">About</a><a href="/benchmarks/">Benchmarks</a><a href="https://github.com/razzant/ouroboros/releases/latest">Releases</a></nav></header>
+  <header class="text-nav"><a class="brand" href="/" aria-label="Ouroboros home"><img src="/assets/icon_1024.png" alt=""><span>Ouroboros</span></a><nav aria-label="Text pages"><a href="/paper/">Paper</a><a href="/about/">About</a><a href="/benchmarks/">Benchmarks</a><a href="https://github.com/razzant/ouroboros/releases/latest">Releases</a></nav></header>
   <main class="text-document">
     <p class="chapter-index">INSTALL / STABLE RELEASE</p>
     <h1>Install Ouroboros.</h1>
@@ -87,6 +87,6 @@ ouroboros server</code></pre>
     <h2>Verify the download</h2>
     <p>Proof files vary by release. Check the selected release for its checksums and evidence file, if present. Releases built by the current workflow also include CycloneDX SBOMs, packaged smoke receipts, and GitHub attestations. <a href="/install.json">install.json</a> gives machine-readable release discovery, artifact name templates, and accepted proof filenames.</p>
   </main>
-  <footer class="text-footer"><a href="/">Home</a><a href="/about/">About</a><a href="/benchmarks/">Benchmarks</a><a href="/install.json">install.json</a></footer>
+  <footer class="text-footer"><a href="/">Home</a><a href="/paper/">Paper</a><a href="/about/">About</a><a href="/benchmarks/">Benchmarks</a><a href="/install.json">install.json</a></footer>
 </body>
 </html>

--- a/site/paper/index.html
+++ b/site/paper/index.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Technical report for Ouroboros, a self-developing frontier coding agent with reviewed core evolution, persistent identity, and public benchmark evidence.">
+  <meta name="robots" content="index, follow, max-image-preview:large">
+  <link rel="canonical" href="https://ouroboros-agent.ai/paper/">
+  <link rel="alternate" type="application/pdf" href="https://arxiv.org/pdf/2608.08311">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="Ouroboros">
+  <meta property="og:title" content="Ouroboros: A Self-Developing Frontier Coding Agent with Reviewed Core Evolution">
+  <meta property="og:description" content="Technical report on reviewed core evolution, the 161-day Hope deployment, and the benchmark campaigns behind Ouroboros.">
+  <meta property="og:url" content="https://ouroboros-agent.ai/paper/">
+  <meta property="og:image" content="https://ouroboros-agent.ai/assets/og-preview.png?v=44a9e298f8">
+  <meta property="og:image:alt" content="Ouroboros, a self-developing frontier coding agent with reviewed core evolution">
+  <meta property="article:published_time" content="2026-08-08">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Ouroboros: A Self-Developing Frontier Coding Agent">
+  <meta name="twitter:description" content="Technical report on reviewed core evolution, the Hope deployment, and public benchmark campaigns.">
+  <meta name="twitter:image" content="https://ouroboros-agent.ai/assets/og-preview.png?v=44a9e298f8">
+  <meta name="twitter:image:alt" content="Ouroboros, a self-developing frontier coding agent with reviewed core evolution">
+  <meta name="citation_title" content="Ouroboros: A Self-Developing Frontier Coding Agent with Reviewed Core Evolution">
+  <meta name="citation_author" content="Anton Razzhigaev">
+  <meta name="citation_author" content="Andrei Gritsaev">
+  <meta name="citation_author" content="Andrei Kaznacheev">
+  <meta name="citation_author" content="Nikita Dragunov">
+  <meta name="citation_author" content="Roman Yampolskiy">
+  <meta name="citation_author" content="Andrei Kuznetsov">
+  <meta name="citation_publication_date" content="2026/08/08">
+  <meta name="citation_arxiv_id" content="2608.08311">
+  <meta name="citation_doi" content="10.48550/arXiv.2608.08311">
+  <meta name="citation_abstract_html_url" content="https://arxiv.org/abs/2608.08311">
+  <meta name="citation_pdf_url" content="https://arxiv.org/pdf/2608.08311">
+  <title>Ouroboros technical report</title>
+  <link rel="icon" href="/assets/icon_1024.png" type="image/png">
+  <link rel="stylesheet" href="/src/ouroboros.css">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ScholarlyArticle",
+      "headline": "Ouroboros: A Self-Developing Frontier Coding Agent with Reviewed Core Evolution",
+      "name": "Ouroboros: A Self-Developing Frontier Coding Agent with Reviewed Core Evolution",
+      "description": "Technical report on reviewed core evolution, the 161-day Hope deployment, and the benchmark campaigns behind Ouroboros.",
+      "datePublished": "2026-08-08",
+      "url": "https://ouroboros-agent.ai/paper/",
+      "mainEntityOfPage": "https://ouroboros-agent.ai/paper/",
+      "sameAs": [
+        "https://arxiv.org/abs/2608.08311",
+        "https://huggingface.co/papers/2608.08311",
+        "https://doi.org/10.48550/arXiv.2608.08311"
+      ],
+      "identifier": [
+        {"@type": "PropertyValue", "propertyID": "arXiv", "value": "2608.08311"},
+        {"@type": "PropertyValue", "propertyID": "DOI", "value": "10.48550/arXiv.2608.08311"}
+      ],
+      "author": [
+        {"@type": "Person", "name": "Anton Razzhigaev"},
+        {"@type": "Person", "name": "Andrei Gritsaev"},
+        {"@type": "Person", "name": "Andrei Kaznacheev"},
+        {"@type": "Person", "name": "Nikita Dragunov"},
+        {"@type": "Person", "name": "Roman Yampolskiy"},
+        {"@type": "Person", "name": "Andrei Kuznetsov"}
+      ],
+      "encoding": {
+        "@type": "MediaObject",
+        "contentUrl": "https://arxiv.org/pdf/2608.08311",
+        "encodingFormat": "application/pdf"
+      },
+      "about": {
+        "@type": "SoftwareApplication",
+        "name": "Ouroboros",
+        "url": "https://ouroboros-agent.ai/",
+        "codeRepository": "https://github.com/razzant/ouroboros"
+      }
+    }
+  </script>
+</head>
+<body class="text-page">
+  <div class="ambient" aria-hidden="true"></div>
+  <header class="text-nav"><a class="brand" href="/" aria-label="Ouroboros home"><img src="/assets/icon_1024.png" alt=""><span>Ouroboros</span></a><nav aria-label="Text pages"><a href="/about/">About</a><a href="/benchmarks/">Benchmarks</a><a href="https://github.com/razzant/ouroboros">GitHub</a></nav></header>
+  <main class="text-document">
+    <p class="chapter-index">TECHNICAL REPORT / 2026</p>
+    <h1>Ouroboros: A Self-Developing Frontier Coding Agent with Reviewed Core Evolution</h1>
+    <p class="text-lede">The report describes how Ouroboros changes its own runtime through reviewed Git history, preserves identity and memory across releases, and turns experience from ordinary work into structural improvements.</p>
+    <p>Anton Razzhigaev, Andrei Gritsaev, Andrei Kaznacheev, Nikita Dragunov, Roman Yampolskiy, and Andrei Kuznetsov.</p>
+    <div class="hero-actions"><a class="btn btn-primary" href="https://arxiv.org/abs/2608.08311">Read on arXiv</a><a class="btn btn-quiet" href="https://arxiv.org/pdf/2608.08311">PDF</a><a class="btn btn-quiet" href="https://huggingface.co/papers/2608.08311">Hugging Face</a></div>
+
+    <h2>What the report covers</h2>
+    <ul>
+      <li>Reviewed core evolution across code, prompts, tools, context assembly, architecture, and dependencies.</li>
+      <li>Hope, a 161-day deployment in which ordinary work and human interaction continually expose new problems and improvement opportunities.</li>
+      <li>Benchmark campaigns on Terminal-Bench 2.1, OSWorld-Verified, CL-Bench, SWE-bench Pro, and GAIA, including limitations and audit corrections.</li>
+      <li>The operational controls used to keep self-modification attributable, reviewable, and recoverable.</li>
+    </ul>
+
+    <h2>Paper and evidence</h2>
+    <ul class="link-list">
+      <li><a href="https://arxiv.org/abs/2608.08311">arXiv 2608.08311</a> is the canonical preprint record.</li>
+      <li><a href="https://huggingface.co/papers/2608.08311">Hugging Face Papers</a> carries the community discussion and linked artifacts.</li>
+      <li><a href="https://huggingface.co/collections/razzant/ouroboros-benchmark-evidence-6a6e7fec1cfdc2d8d93ed3a3">Benchmark evidence collection</a> groups the public datasets and explorer.</li>
+      <li><a href="https://huggingface.co/spaces/razzant/ouroboros-benchmark-explorer">Benchmark Explorer</a> provides a no-key view of the released evidence.</li>
+      <li><a href="https://github.com/razzant/ouroboros">Source repository</a> contains the implementation, history, benchmark adapters, and methodology.</li>
+    </ul>
+
+    <h2>Citation</h2>
+    <pre><code>@techreport{razzhigaev2026ouroboros,
+  title        = {Ouroboros: A Self-Developing Frontier Coding Agent with Reviewed Core Evolution},
+  author       = {Anton Razzhigaev and Andrei Gritsaev and Andrei Kaznacheev and Nikita Dragunov and Roman Yampolskiy and Andrei Kuznetsov},
+  year         = {2026},
+  eprint       = {2608.08311},
+  archivePrefix = {arXiv},
+  primaryClass = {cs.SE},
+  doi          = {10.48550/arXiv.2608.08311},
+  url          = {https://arxiv.org/abs/2608.08311}
+}</code></pre>
+  </main>
+  <footer class="text-footer"><a href="/">Home</a><a href="/about/">About</a><a href="/benchmarks/">Benchmarks</a><a href="/llms.txt">llms.txt</a></footer>
+</body>
+</html>

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -10,6 +10,7 @@ Ouroboros publishes self-reported benchmark results with status labels and links
 
 ## Start here
 
+- [Technical report](https://ouroboros-agent.ai/paper/): Paper metadata, authors, citation, code, and public evidence links.
 - [About](https://ouroboros-agent.ai/about/): What Ouroboros is and how it works.
 - [Install](https://ouroboros-agent.ai/install/): Packaged downloads and source setup.
 - [Benchmark evidence](https://ouroboros-agent.ai/benchmarks/): Scores, publication status, runs, traces, and methodology.

--- a/site/public/sitemap.xml
+++ b/site/public/sitemap.xml
@@ -11,6 +11,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://ouroboros-agent.ai/paper/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://ouroboros-agent.ai/install/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>

--- a/site/vite.config.js
+++ b/site/vite.config.js
@@ -10,6 +10,7 @@ export default defineConfig({
       input: {
         home: resolve(import.meta.dirname, "index.html"),
         about: resolve(import.meta.dirname, "about/index.html"),
+        paper: resolve(import.meta.dirname, "paper/index.html"),
         install: resolve(import.meta.dirname, "install/index.html"),
         benchmarks: resolve(import.meta.dirname, "benchmarks/index.html"),
         notFound: resolve(import.meta.dirname, "404.html"),

--- a/tests/test_public_site_metadata.py
+++ b/tests/test_public_site_metadata.py
@@ -8,7 +8,6 @@ import xml.etree.ElementTree as ET
 from html.parser import HTMLParser
 from pathlib import Path
 
-
 REPO = Path(__file__).resolve().parents[1]
 SITE = REPO / "site"
 DOCS = REPO / "docs"
@@ -16,6 +15,7 @@ ORIGIN = "https://ouroboros-agent.ai"
 INDEXABLE = {
     "/": SITE / "index.html",
     "/about/": SITE / "about" / "index.html",
+    "/paper/": SITE / "paper" / "index.html",
     "/install/": SITE / "install" / "index.html",
     "/benchmarks/": SITE / "benchmarks" / "index.html",
     "/history/first-48-hours/": SITE / "history" / "first-48-hours" / "index.html",
@@ -75,18 +75,32 @@ def test_indexable_pages_have_canonical_social_metadata():
 
 
 def test_json_ld_is_valid_and_current():
-    for relative in ("index.html", "install/index.html", "benchmarks/index.html"):
+    for relative in ("index.html", "paper/index.html", "install/index.html", "benchmarks/index.html"):
         page = _parse(SITE / relative)
         assert page.json_ld, relative
         documents = [json.loads(value) for value in page.json_ld]
         assert all(document.get("@context") == "https://schema.org" for document in documents)
     homepage = json.loads(_parse(SITE / "index.html").json_ld[0])
     install = json.loads(_parse(SITE / "install/index.html").json_ld[0])
+    paper = json.loads(_parse(SITE / "paper/index.html").json_ld[0])
     assert homepage["sameAs"] == "https://github.com/razzant/ouroboros"
     assert "huggingface.co/razzant" not in json.dumps(homepage)
     assert "softwareVersion" not in homepage
     assert "softwareVersion" not in install
     assert install["downloadUrl"] == "https://github.com/razzant/ouroboros/releases/latest"
+    assert paper["@type"] == "ScholarlyArticle"
+    assert paper["headline"] == "Ouroboros: A Self-Developing Frontier Coding Agent with Reviewed Core Evolution"
+    assert paper["datePublished"] == "2026-08-08"
+    assert [author["name"] for author in paper["author"]] == [
+        "Anton Razzhigaev",
+        "Andrei Gritsaev",
+        "Andrei Kaznacheev",
+        "Nikita Dragunov",
+        "Roman Yampolskiy",
+        "Andrei Kuznetsov",
+    ]
+    assert "https://arxiv.org/abs/2608.08311" in paper["sameAs"]
+    assert "https://huggingface.co/papers/2608.08311" in paper["sameAs"]
 
 
 def test_sitemap_exactly_matches_indexable_html():
@@ -112,6 +126,7 @@ def test_llms_file_is_a_small_absolute_navigation_map():
             linked_urls.append(match.group(1))
     assert f"{ORIGIN}/install/" in linked_urls
     assert f"{ORIGIN}/benchmarks/" in linked_urls
+    assert f"{ORIGIN}/paper/" in linked_urls
     for url in linked_urls:
         assert url.startswith((ORIGIN, "https://github.com/", "https://api.github.com/"))
 
@@ -225,9 +240,26 @@ def test_navigation_keeps_accessible_home_and_contributor_links():
             assert 'class="brand"' in html and 'aria-label="Ouroboros home"' in html
     homepage = (SITE / "index.html").read_text(encoding="utf-8")
     assert "CONTRIBUTING.md" in homepage
+    assert 'href="/paper/"' in homepage
     benchmarks = (SITE / "benchmarks" / "index.html").read_text(encoding="utf-8")
     assert 'class="table-scroll" tabindex="0" role="region"' in benchmarks
     assert 'aria-label="Ouroboros benchmark results"' in benchmarks
+
+
+def test_paper_page_exposes_citation_metadata_and_bibtex():
+    path = SITE / "paper" / "index.html"
+    html = path.read_text(encoding="utf-8")
+    page = _parse(path)
+
+    assert page.meta["citation_title"] == (
+        "Ouroboros: A Self-Developing Frontier Coding Agent with Reviewed Core Evolution"
+    )
+    assert page.meta["citation_publication_date"] == "2026/08/08"
+    assert page.meta["citation_arxiv_id"] == "2608.08311"
+    assert page.meta["citation_doi"] == "10.48550/arXiv.2608.08311"
+    assert page.meta["citation_pdf_url"] == "https://arxiv.org/pdf/2608.08311"
+    assert "@techreport{razzhigaev2026ouroboros" in html
+    assert "archivePrefix = {arXiv}" in html
 
 
 def test_og_preview_has_declared_dimensions_and_current_status():

--- a/tests/test_trust_metadata.py
+++ b/tests/test_trust_metadata.py
@@ -36,6 +36,23 @@ def test_citation_metadata_has_the_approved_author_and_acknowledgment():
     forbidden = {"orcid", "affiliation", "version", "date-released", "doi"}
     assert forbidden.isdisjoint(citation)
     assert forbidden.isdisjoint(citation["authors"][0])
+    preferred = citation["preferred-citation"]
+    assert preferred == {
+        "type": "article",
+        "title": "Ouroboros: A Self-Developing Frontier Coding Agent with Reviewed Core Evolution",
+        "authors": [
+            {"family-names": "Razzhigaev", "given-names": "Anton"},
+            {"family-names": "Gritsaev", "given-names": "Andrei"},
+            {"family-names": "Kaznacheev", "given-names": "Andrei"},
+            {"family-names": "Dragunov", "given-names": "Nikita"},
+            {"family-names": "Yampolskiy", "given-names": "Roman"},
+            {"family-names": "Kuznetsov", "given-names": "Andrei"},
+        ],
+        "journal": "arXiv",
+        "year": 2026,
+        "doi": "10.48550/arXiv.2608.08311",
+        "url": "https://arxiv.org/abs/2608.08311",
+    }
 
 
 def test_scorecard_workflow_is_fully_pinned_and_publishes_sarif():
@@ -185,6 +202,7 @@ def test_architecture_registers_each_new_public_metadata_surface():
         "CODE_OF_CONDUCT.md",
         "CITATION.cff",
         "docs/benchmarks/evidence.json",
+        "site/paper/index.html",
     ):
         assert path in architecture
     assert "README remains the claim SSOT" in architecture


### PR DESCRIPTION
This adds a canonical /paper/ page for arXiv:2608.08311 and connects the report to the README, site navigation, sitemap, llms.txt, ScholarlyArticle JSON-LD, Highwire citation metadata, and CITATION.cff. The generated Pages output is included and no version files change.

The site build passes, 23 focused metadata tests pass, CITATION.cff validates, and I checked the page at desktop and 390 px widths.