### PR TITLE
fix: distinguish an unreadable git ref from a missing one in the tests/ preflight gate

### DIFF
--- a/ouroboros/preflight_runner.py
+++ b/ouroboros/preflight_runner.py
@@ -328,9 +328,21 @@ def _baseline_refs(phase: str) -> tuple:
 
 
 def _ref_tracks_tests(repo: pathlib.Path, ref: str) -> bool:
+    # `ls-tree` failing is not evidence the ref is absent; it also fails when
+    # the ref resolves but its tree cannot be read. Resolve first so that case
+    # is not reported as "never tracked tests".
+    resolved = _run_git(repo, ["rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"])
+    if resolved.returncode != 0:
+        return False  # no such ref (root commit, empty repository)
     listed = _run_git(repo, ["ls-tree", "-r", "--name-only", ref, "--", "tests"])
     if listed.returncode != 0:
-        return False  # no such ref (root commit, empty repository)
+        # The ref exists, so this is a real git failure, not "no such ref";
+        # reporting it as "never tracked tests" would wave a tests/-deleting
+        # candidate through the hard block below.
+        raise RuntimeError(
+            f"git ls-tree failed on resolvable ref {ref!r}: "
+            f"{listed.stderr.strip() or 'no error output'}"
+        )
     return bool((listed.stdout or "").strip())
 
 
@@ -1076,7 +1088,19 @@ def run_hermetic_pytest(
         # all-passes-empty hard block below never ran and the change that
         # deleted the gate sailed through it.
         baseline_refs = _baseline_refs(phase)
-        if _head_tracks_tests(repo, baseline_refs):
+        try:
+            baseline_tracks_tests = _head_tracks_tests(repo, baseline_refs)
+        except (RuntimeError, subprocess.SubprocessError, OSError) as exc:
+            return _diagnosis(
+                "⚠️ PRE_PUSH_TEST_ERROR: PREFLIGHT_TESTS_BASELINE_UNREADABLE (hard block): "
+                f"could not read {' or '.join(baseline_refs)}",
+                "The working tree just lost its tests/ directory and git could not read "
+                "one of the baseline refs well enough to say whether that loss is real. "
+                "Treating an unreadable ref as 'never tracked tests' would let this "
+                "candidate through the gate it exists to trip. This is not a test failure.",
+                str(exc), max_output,
+            )
+        if baseline_tracks_tests:
             return (
                 "⚠️ PRE_PUSH_TEST_ERROR: the candidate change removes the entire tests/ tree "
                 f"that {' or '.join(baseline_refs)} carries. The preflight cannot verify "

--- a/ouroboros/preflight_runner.py
+++ b/ouroboros/preflight_runner.py
@@ -327,23 +327,57 @@ def _baseline_refs(phase: str) -> tuple:
     return _PRE_COMMIT_BASELINE_REFS if phase == PRE_COMMIT_PHASE else _TESTS_BASELINE_REFS
 
 
-def _ref_tracks_tests(repo: pathlib.Path, ref: str) -> bool:
-    # `ls-tree` failing is not evidence the ref is absent; it also fails when
-    # the ref resolves but its tree cannot be read. Resolve first so that case
-    # is not reported as "never tracked tests".
-    resolved = _run_git(repo, ["rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"])
+def _baseline_commit_oids(
+    repo: pathlib.Path, refs: Sequence[str]
+) -> tuple[tuple[str, str], ...]:
+    """Resolve the phase baselines without mistaking unreadable history for absence."""
+    # Deliberately do not peel here: rev-parse returns the ref's recorded OID
+    # even when the commit object itself is missing. A quiet rc=1 with no output
+    # can mean either an unborn HEAD or a broken ref, so only a successfully read
+    # symbolic HEAD proves the former; every other failure is an operational
+    # error the caller must hard-block.
+    resolved = _run_git(repo, ["rev-parse", "--verify", "--quiet", "HEAD"])
     if resolved.returncode != 0:
-        return False  # no such ref (root commit, empty repository)
-    listed = _run_git(repo, ["ls-tree", "-r", "--name-only", ref, "--", "tests"])
-    if listed.returncode != 0:
-        # The ref exists, so this is a real git failure, not "no such ref";
-        # reporting it as "never tracked tests" would wave a tests/-deleting
-        # candidate through the hard block below.
-        raise RuntimeError(
-            f"git ls-tree failed on resolvable ref {ref!r}: "
-            f"{listed.stderr.strip() or 'no error output'}"
+        if (
+            resolved.returncode == 1
+            and not (resolved.stdout or "").strip()
+            and not (resolved.stderr or "").strip()
+        ):
+            symbolic = _run_git(repo, ["symbolic-ref", "--quiet", "HEAD"])
+            if symbolic.returncode == 0 and (symbolic.stdout or "").strip():
+                return ()
+            detail = (
+                symbolic.stderr.strip()
+                or symbolic.stdout.strip()
+                or f"exit {symbolic.returncode}"
+            )
+            raise RuntimeError(f"git could not prove HEAD is unborn: {detail}")
+        detail = (
+            resolved.stderr.strip()
+            or resolved.stdout.strip()
+            or f"exit {resolved.returncode}"
         )
-    return bool((listed.stdout or "").strip())
+        raise RuntimeError(f"git could not resolve HEAD: {detail}")
+
+    head_oid = (resolved.stdout or "").strip()
+    head_commit = _run_git(repo, ["cat-file", "commit", head_oid])
+    if head_commit.returncode != 0:
+        detail = (
+            head_commit.stderr.strip()
+            or head_commit.stdout.strip()
+            or f"exit {head_commit.returncode}"
+        )
+        raise RuntimeError(f"git could not read HEAD commit {head_oid}: {detail}")
+
+    headers = (head_commit.stdout or "").partition("\n\n")[0].splitlines()
+    first_parent = next(
+        (line.removeprefix("parent ") for line in headers if line.startswith("parent ")),
+        None,
+    )
+    by_ref = {"HEAD": head_oid}
+    if first_parent is not None:
+        by_ref["HEAD~1"] = first_parent
+    return tuple((ref, by_ref[ref]) for ref in refs if ref in by_ref)
 
 
 def _head_tracks_tests(repo: pathlib.Path, refs: Sequence[str] = _TESTS_BASELINE_REFS) -> bool:
@@ -355,7 +389,20 @@ def _head_tracks_tests(repo: pathlib.Path, refs: Sequence[str] = _TESTS_BASELINE
     phase baseline — see above; it defaults to the post-commit pair, which is the
     conservative direction for a caller that does not say.
     """
-    return any(_ref_tracks_tests(repo, ref) for ref in refs)
+    for ref, oid in _baseline_commit_oids(repo, refs):
+        listed = _run_git(repo, ["ls-tree", "-r", "--name-only", oid, "--", "tests"])
+        if listed.returncode != 0:
+            detail = (
+                listed.stderr.strip()
+                or listed.stdout.strip()
+                or f"exit {listed.returncode}"
+            )
+            raise RuntimeError(
+                f"git could not read tests/ from baseline {ref} ({oid}): {detail}"
+            )
+        if (listed.stdout or "").strip():
+            return True
+    return False
 
 
 def _apply_diff(worktree: pathlib.Path, diff_text: "str | bytes") -> None:

--- a/tests/test_preflight_runner.py
+++ b/tests/test_preflight_runner.py
@@ -87,6 +87,14 @@ def _commit_all(repo: pathlib.Path) -> None:
     )
 
 
+def _delete_loose_object(repo: pathlib.Path, oid: str) -> None:
+    obj_path = repo / ".git" / "objects" / oid[:2] / oid[2:]
+    assert obj_path.exists(), (
+        "fixture assumption: a fresh repo keeps this object loose"
+    )
+    obj_path.unlink()
+
+
 def _make_repo(tmp_path: pathlib.Path, files: dict[str, str]) -> pathlib.Path:
     """Init a tiny git repo whose `tests/` holds only the given probe files."""
     repo = tmp_path / "repo"
@@ -2197,6 +2205,40 @@ def test_a_gate_blocked_update_tx_is_never_promoted_by_boot_recovery():
     )
 
 
+def test_an_unborn_head_is_proven_absent_not_unreadable(
+    tmp_path, two_pass_env, stub_passes
+):
+    from ouroboros.preflight_runner import run_hermetic_pytest
+
+    events = stub_passes([])
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "checkout", "-b", "ouroboros")
+
+    assert run_hermetic_pytest(repo, timeout=120) is None
+    assert [event[0] for event in events].count("pass") == 0
+
+
+def test_a_broken_head_ref_does_not_masquerade_as_unborn(
+    tmp_path, two_pass_env, stub_passes
+):
+    """A quiet rev-parse rc=1 is ambiguous until symbolic HEAD is readable."""
+    from ouroboros.preflight_runner import PRE_COMMIT_PHASE, run_hermetic_pytest
+
+    events = stub_passes([])
+    repo = _make_repo(tmp_path, {"tests/test_plain.py": "def test_ok():\n    assert True\n"})
+    _git(repo, "rm", "-r", "--quiet", "tests")
+    (repo / ".git" / "refs" / "heads" / "ouroboros").write_text(
+        "not-an-object-id\n", encoding="utf-8"
+    )
+
+    result = run_hermetic_pytest(repo, timeout=120, phase=PRE_COMMIT_PHASE)
+    assert result is not None
+    assert "PREFLIGHT_TESTS_BASELINE_UNREADABLE" in result
+    assert [event[0] for event in events].count("pass") == 0
+
+
 def test_a_repository_that_never_had_tests_is_still_out_of_scope(tmp_path, two_pass_env, stub_passes):
     """...and the control: the block keys on the committed history carrying a
     suite, not on the working tree lacking one, so a repo with no test suite at
@@ -2238,7 +2280,9 @@ def test_the_post_commit_baseline_reaches_back_exactly_one_commit(tmp_path, two_
     assert [event[0] for event in events].count("pass") == 0
 
 
-def test_an_unreadable_baseline_ref_hard_blocks_instead_of_reading_as_no_tests(tmp_path, two_pass_env, stub_passes):
+def test_an_unreadable_baseline_tree_hard_blocks_instead_of_reading_as_no_tests(
+    tmp_path, two_pass_env, stub_passes
+):
     """`ls-tree` returning nonzero is not on its own evidence a ref is absent:
     git fails that way too when the ref resolves fine but its tree cannot be
     read (a corrupt or missing object, a permissions/IO error). Reading that
@@ -2257,12 +2301,57 @@ def test_an_unreadable_baseline_ref_hard_blocks_instead_of_reading_as_no_tests(t
     _git(repo, "rm", "-r", "--quiet", "tests")
     _commit_all(repo)
 
-    obj_path = repo / ".git" / "objects" / tree_oid[:2] / tree_oid[2:]
-    assert obj_path.exists(), "fixture assumption: a fresh repo keeps this tree as a loose object"
-    obj_path.unlink()
+    _delete_loose_object(repo, tree_oid)
 
     result = run_hermetic_pytest(repo, timeout=120)
     assert result is not None, "an unreadable baseline ref must hard-block, not silently pass"
+    assert "PREFLIGHT_TESTS_BASELINE_UNREADABLE" in result
+    assert [event[0] for event in events].count("pass") == 0
+
+
+def test_an_unreadable_head_commit_hard_blocks_the_pre_commit_baseline(
+    tmp_path, two_pass_env, stub_passes
+):
+    from ouroboros.preflight_runner import PRE_COMMIT_PHASE, run_hermetic_pytest
+
+    events = stub_passes([])
+    repo = _make_repo(tmp_path, {"tests/test_plain.py": "def test_ok():\n    assert True\n"})
+    head_oid = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    _git(repo, "rm", "-r", "--quiet", "tests")
+    _delete_loose_object(repo, head_oid)
+
+    result = run_hermetic_pytest(repo, timeout=120, phase=PRE_COMMIT_PHASE)
+    assert result is not None
+    assert "PREFLIGHT_TESTS_BASELINE_UNREADABLE" in result
+    assert [event[0] for event in events].count("pass") == 0
+
+
+def test_an_unreadable_first_parent_hard_blocks_the_post_commit_baseline(
+    tmp_path, two_pass_env, stub_passes
+):
+    from ouroboros.preflight_runner import run_hermetic_pytest
+
+    events = stub_passes([])
+    repo = _make_repo(tmp_path, {"tests/test_plain.py": "def test_ok():\n    assert True\n"})
+    parent_oid = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    _git(repo, "rm", "-r", "--quiet", "tests")
+    _commit_all(repo)
+    _delete_loose_object(repo, parent_oid)
+
+    result = run_hermetic_pytest(repo, timeout=120)
+    assert result is not None
     assert "PREFLIGHT_TESTS_BASELINE_UNREADABLE" in result
     assert [event[0] for event in events].count("pass") == 0
 

--- a/tests/test_preflight_runner.py
+++ b/tests/test_preflight_runner.py
@@ -2238,6 +2238,35 @@ def test_the_post_commit_baseline_reaches_back_exactly_one_commit(tmp_path, two_
     assert [event[0] for event in events].count("pass") == 0
 
 
+def test_an_unreadable_baseline_ref_hard_blocks_instead_of_reading_as_no_tests(tmp_path, two_pass_env, stub_passes):
+    """`ls-tree` returning nonzero is not on its own evidence a ref is absent:
+    git fails that way too when the ref resolves fine but its tree cannot be
+    read (a corrupt or missing object, a permissions/IO error). Reading that
+    failure as "this ref never tracked tests" lets a candidate that deletes
+    tests/ sail through the hard block below merely because git could not
+    read a real, resolvable ref's tree. The corrupted ref here is HEAD~1,
+    which legitimately carries the suite the deletion commit removed."""
+    from ouroboros.preflight_runner import run_hermetic_pytest
+
+    events = stub_passes([])
+    repo = _make_repo(tmp_path, {"tests/test_plain.py": "def test_ok():\n    assert True\n"})
+    tree_oid = subprocess.run(
+        ["git", "rev-parse", "HEAD:tests"], cwd=str(repo),
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    _git(repo, "rm", "-r", "--quiet", "tests")
+    _commit_all(repo)
+
+    obj_path = repo / ".git" / "objects" / tree_oid[:2] / tree_oid[2:]
+    assert obj_path.exists(), "fixture assumption: a fresh repo keeps this tree as a loose object"
+    obj_path.unlink()
+
+    result = run_hermetic_pytest(repo, timeout=120)
+    assert result is not None, "an unreadable baseline ref must hard-block, not silently pass"
+    assert "PREFLIGHT_TESTS_BASELINE_UNREADABLE" in result
+    assert [event[0] for event in events].count("pass") == 0
+
+
 def test_the_pre_commit_baseline_is_head_only_after_a_deliberate_removal(tmp_path, two_pass_env, stub_passes):
     """HEAD~1 belongs to the POST-commit phase and false-blocks the pre-commit one.
 


### PR DESCRIPTION
## Summary

`_ref_tracks_tests()` treated any nonzero exit from `git ls-tree` as "no such ref". That
collapses two different cases: a ref that genuinely does not resolve (root commit, empty
repo) and a ref that resolves fine but whose tree git could not read (a corrupt or missing
object, a permissions/IO error). The second case was silently read as "never tracked
tests", so a candidate that deletes `tests/` while a baseline ref is unreadable would slip
past the hard block at `run_hermetic_pytest()` that exists to catch exactly that. Fixes #179.

## Scope

In scope:

- `_ref_tracks_tests()`: resolve the ref with `git rev-parse --verify` before running
  `ls-tree`, so a resolvable-but-unreadable ref no longer reads as absent.
- `run_hermetic_pytest()`: catch the new failure at the one call site and turn it into a
  `PREFLIGHT_TESTS_BASELINE_UNREADABLE` hard block instead of letting it propagate or
  silently return `None`.

Non-goals:

- The GPU/CPU-unrelated "secondary bug" class (unreadable objects elsewhere in the
  preflight pipeline) is out of scope; this PR only covers the two baseline refs
  `_head_tracks_tests()` consults.

## Verification

- [x] Focused tests for the changed behavior pass.
- [x] The default local test suite passes, or the reason it was not run is below.
- [x] Lint/static checks relevant to this change pass.

Commands and results:

```text
$ python -m pytest tests/test_preflight_runner.py -k test_an_unreadable_baseline_ref_hard_blocks_instead_of_reading_as_no_tests -q
# on unmodified origin/ouroboros: 1 failed (result is None; the candidate silently passed)
# on this branch: 1 passed

$ python -m pytest tests/test_preflight_runner.py tests/test_advisory_preflight.py tests/test_delegate_preflight.py -q
226 passed, 2 skipped (skips are pre-existing: claude_agent_sdk not installed in this
container)

$ python -m ruff check . --select F --no-cache
All checks passed!
```

The new regression test corrupts a real git repository (deletes the loose object backing
a resolvable ref's `tests/` tree) rather than mocking `_run_git`, so it exercises the exact
failure class described above. All commands were run in a clean `python:3.10-slim`
container against this branch's HEAD.

Not run: the full CI matrix (browser/UI/skill-smoke lanes, integration tests needing
provider API keys) and this repo's own triad/scope review tooling, neither of which is
reachable from this environment.

## Visual evidence

- [x] Not applicable; this PR has no visible UI change.

## Governance and documentation

- [x] I followed `CONTRIBUTING.md` and checked the relevant guidance in `BIBLE.md`,
      `docs/ARCHITECTURE.md`, `docs/DEVELOPMENT.md`, and `docs/CHECKLISTS.md`.
- [x] I updated tests and documentation where behavior or architecture changed.
- [x] I did not include secrets, local settings, runtime state, logs, caches, or generated
      build/review artifacts in the commit.
- [x] I did **not** bump `VERSION` or release-only version carriers.

## Agent assistance (optional)

- Agent/tool and model: Claude Code (Claude, Anthropic), operated by AmirF194
- Work performed by the agent: diagnosis, fix, regression test, and all verification below
- Human verification performed: none beyond what is listed in Verification above

## Review evidence

- [ ] Triad/scope review evidence is attached or linked below.
- [x] Review was not run; the reason is recorded below.

- If not run, reason: this repo's internal triad/scope review tooling is not reachable
  from this environment; verification above is a direct differential test run plus the
  repo's own pytest/ruff gates.

## Final checklist

- [x] The PR base branch is `ouroboros`.
- [x] The branch is based on a current `ouroboros` revision.
- [x] The PR is one coherent change and is ready to be squash-integrated.
- [x] The description explains any limitations, follow-up work, or compatibility impact.
