### PR TITLE
fix: force the checkout_and_reset admission gate closed on an unreadable status or MERGE_HEAD

### DIFF
--- a/supervisor/git_ops.py
+++ b/supervisor/git_ops.py
@@ -942,12 +942,42 @@ def checkout_and_reset(branch: str, reason: str = "unspecified",
         dirty_lines = list(repo_state.get("dirty_lines") or [])
         unpushed_lines = list(repo_state.get("unpushed_lines") or [])
         unpushed_needs_rescue = bool(update_intent_target and unpushed_lines)
-        if dirty_lines or unpushed_needs_rescue:
+
+        # A failed status read or an unconsulted MERGE_HEAD used to read as a clean
+        # tree; force the same rescue/block branch a dirty tree takes, matching the
+        # fail-closed read already used for the managed-update rollback path.
+        status_unreadable = any(
+            str(w).startswith("status_error:") for w in (repo_state.get("warnings") or [])
+        )
+        # Read MERGE_HEAD directly (no git process) since this runs on every call.
+        # A present file whose content is not a SHA is unreadable, not absent, per
+        # the issue's fix direction.
+        merge_head_path = _git_dir() / "MERGE_HEAD"
+        merge_in_progress = False
+        merge_head_unreadable = False
+        if merge_head_path.is_file():
+            try:
+                merge_head_content = merge_head_path.read_text(encoding="utf-8").strip()
+            except Exception:
+                merge_head_content = ""
+            if re.fullmatch(r"[0-9a-fA-F]{7,64}", merge_head_content):
+                merge_in_progress = True
+            else:
+                merge_head_unreadable = True
+
+        if dirty_lines or unpushed_needs_rescue or status_unreadable or merge_in_progress \
+                or merge_head_unreadable:
             bits: List[str] = []
             if unpushed_lines and (dirty_lines or unpushed_needs_rescue):
                 bits.append(f"unpushed={len(unpushed_lines)}")
             if dirty_lines:
                 bits.append(f"dirty={len(dirty_lines)}")
+            if status_unreadable:
+                bits.append("status_unreadable")
+            if merge_in_progress:
+                bits.append("merge_in_progress")
+            if merge_head_unreadable:
+                bits.append("merge_head_unreadable")
             detail = ", ".join(bits) if bits else "unsynced"
             rescue_info: Dict[str, Any] = {}
             if policy in {"rescue_and_block", "rescue_and_reset"}:

--- a/supervisor/git_ops.py
+++ b/supervisor/git_ops.py
@@ -854,6 +854,173 @@ def _run_git_resilient(cmd, **kwargs):
     return subprocess.run(cmd, check=check, **kwargs)
 
 
+def _admission_gate_for_unsynced_tree(
+    branch: str, reason: str, policy: str, update_intent_target: str,
+) -> Optional[Tuple[bool, str]]:
+    """Apply unsynced_policy's block/rescue rules for checkout_and_reset.
+
+    Returns ``(False, msg)`` when the reset must stop here, or ``None`` to proceed.
+    """
+    repo_state = _collect_repo_sync_state()
+    dirty_lines = list(repo_state.get("dirty_lines") or [])
+    unpushed_lines = list(repo_state.get("unpushed_lines") or [])
+    unpushed_needs_rescue = bool(update_intent_target and unpushed_lines)
+
+    # A failed status read or an unconsulted MERGE_HEAD used to read as a clean
+    # tree; force the same rescue/block branch a dirty tree takes, matching the
+    # fail-closed read already used for the managed-update rollback path.
+    status_unreadable = any(
+        str(w).startswith("status_error:") for w in (repo_state.get("warnings") or [])
+    )
+    # Read MERGE_HEAD directly (no git process) since this runs on every call.
+    # A present file whose content is not a SHA is unreadable, not absent, per
+    # the issue's fix direction.
+    merge_head_path = _git_dir() / "MERGE_HEAD"
+    merge_in_progress = False
+    merge_head_unreadable = False
+    if merge_head_path.is_file():
+        try:
+            merge_head_content = merge_head_path.read_text(encoding="utf-8").strip()
+        except Exception:
+            merge_head_content = ""
+        if re.fullmatch(r"[0-9a-fA-F]{7,64}", merge_head_content):
+            merge_in_progress = True
+        else:
+            merge_head_unreadable = True
+
+    if dirty_lines or unpushed_needs_rescue or status_unreadable or merge_in_progress \
+            or merge_head_unreadable:
+        bits: List[str] = []
+        if unpushed_lines and (dirty_lines or unpushed_needs_rescue):
+            bits.append(f"unpushed={len(unpushed_lines)}")
+        if dirty_lines:
+            bits.append(f"dirty={len(dirty_lines)}")
+        if status_unreadable:
+            bits.append("status_unreadable")
+        if merge_in_progress:
+            bits.append("merge_in_progress")
+        if merge_head_unreadable:
+            bits.append("merge_head_unreadable")
+        detail = ", ".join(bits) if bits else "unsynced"
+        rescue_info: Dict[str, Any] = {}
+        if policy in {"rescue_and_block", "rescue_and_reset"}:
+            try:
+                rescue_info = _create_rescue_snapshot(
+                    branch=branch, reason=reason, repo_state=repo_state)
+            except Exception as e:
+                rescue_info = {"error": repr(e)}
+            if policy == "rescue_and_reset" and rescue_info.get("error"):
+                msg = (
+                    f"Reset blocked ({detail}) because rescue snapshot failed: "
+                    f"{rescue_info.get('error')}. Local changes were left untouched."
+                )
+                append_jsonl(
+                    DRIVE_ROOT / "logs" / "supervisor.jsonl",
+                    {
+                        "ts": utc_now_iso(),
+                        "type": "reset_blocked_rescue_failed",
+                        "target_branch": branch, "reason": reason, "policy": policy,
+                        "current_branch": repo_state.get("current_branch"),
+                        "dirty_count": len(dirty_lines),
+                        "unpushed_count": len(unpushed_lines),
+                        "dirty_preview": dirty_lines[:20],
+                        "unpushed_preview": unpushed_lines[:20],
+                        "warnings": list(repo_state.get("warnings") or []),
+                        "rescue": rescue_info,
+                        "incomplete_reason": "snapshot_error",
+                    },
+                )
+                return False, msg
+            if policy == "rescue_and_reset" and rescue_info.get("diff_error"):
+                msg = (
+                    f"Reset blocked ({detail}) because rescue diff capture failed: "
+                    f"{rescue_info.get('diff_error')}. Local changes were left untouched."
+                )
+                append_jsonl(
+                    DRIVE_ROOT / "logs" / "supervisor.jsonl",
+                    {
+                        "ts": utc_now_iso(),
+                        "type": "reset_blocked_rescue_incomplete",
+                        "target_branch": branch, "reason": reason, "policy": policy,
+                        "current_branch": repo_state.get("current_branch"),
+                        "dirty_count": len(dirty_lines),
+                        "unpushed_count": len(unpushed_lines),
+                        "dirty_preview": dirty_lines[:20],
+                        "unpushed_preview": unpushed_lines[:20],
+                        "warnings": list(repo_state.get("warnings") or []),
+                        "rescue": rescue_info,
+                        "incomplete_reason": "diff_error",
+                    },
+                )
+                return False, msg
+            untracked_rescue_error = _rescue_untracked_incomplete(rescue_info)
+            if policy == "rescue_and_reset" and untracked_rescue_error:
+                msg = (
+                    f"Reset blocked ({detail}) because untracked-file rescue was incomplete: "
+                    f"{untracked_rescue_error}. Local changes were left untouched."
+                )
+                append_jsonl(
+                    DRIVE_ROOT / "logs" / "supervisor.jsonl",
+                    {
+                        "ts": utc_now_iso(),
+                        "type": "reset_blocked_rescue_incomplete",
+                        "target_branch": branch, "reason": reason, "policy": policy,
+                        "current_branch": repo_state.get("current_branch"),
+                        "dirty_count": len(dirty_lines),
+                        "unpushed_count": len(unpushed_lines),
+                        "dirty_preview": dirty_lines[:20],
+                        "unpushed_preview": unpushed_lines[:20],
+                        "warnings": list(repo_state.get("warnings") or []),
+                        "rescue": rescue_info,
+                        "incomplete_reason": "untracked_rescue",
+                        "incomplete_detail": untracked_rescue_error,
+                    },
+                )
+                return False, msg
+        rescue_suffix = ""
+        rescue_path = str(rescue_info.get("path") or "").strip()
+        if rescue_path:
+            rescue_suffix = f" Rescue saved to {rescue_path}."
+        elif policy in {"rescue_and_block", "rescue_and_reset"} and rescue_info.get("error"):
+            rescue_suffix = f" Rescue failed: {rescue_info.get('error')}."
+
+        if policy in {"block", "rescue_and_block"}:
+            msg = f"Reset blocked ({detail}) to protect local changes.{rescue_suffix}"
+            append_jsonl(
+                DRIVE_ROOT / "logs" / "supervisor.jsonl",
+                {
+                    "ts": utc_now_iso(),
+                    "type": "reset_blocked_unsynced_state",
+                    "target_branch": branch, "reason": reason, "policy": policy,
+                    "current_branch": repo_state.get("current_branch"),
+                    "dirty_count": len(dirty_lines),
+                    "unpushed_count": len(unpushed_lines),
+                    "dirty_preview": dirty_lines[:20],
+                    "unpushed_preview": unpushed_lines[:20],
+                    "warnings": list(repo_state.get("warnings") or []),
+                    "rescue": rescue_info,
+                },
+            )
+            return False, msg
+
+        append_jsonl(
+            DRIVE_ROOT / "logs" / "supervisor.jsonl",
+            {
+                "ts": utc_now_iso(),
+                "type": "reset_unsynced_rescued_then_reset",
+                "target_branch": branch, "reason": reason, "policy": policy,
+                "current_branch": repo_state.get("current_branch"),
+                "dirty_count": len(dirty_lines),
+                "unpushed_count": len(unpushed_lines),
+                "dirty_preview": dirty_lines[:20],
+                "unpushed_preview": unpushed_lines[:20],
+                "warnings": list(repo_state.get("warnings") or []),
+                "rescue": rescue_info,
+            },
+        )
+    return None
+
+
 def checkout_and_reset(branch: str, reason: str = "unspecified",
                        unsynced_policy: str = "ignore") -> Tuple[bool, str]:
     managed_meta = _read_managed_repo_meta()
@@ -938,163 +1105,10 @@ def checkout_and_reset(branch: str, reason: str = "unspecified",
         policy = "ignore"
 
     if policy != "ignore":
-        repo_state = _collect_repo_sync_state()
-        dirty_lines = list(repo_state.get("dirty_lines") or [])
-        unpushed_lines = list(repo_state.get("unpushed_lines") or [])
-        unpushed_needs_rescue = bool(update_intent_target and unpushed_lines)
-
-        # A failed status read or an unconsulted MERGE_HEAD used to read as a clean
-        # tree; force the same rescue/block branch a dirty tree takes, matching the
-        # fail-closed read already used for the managed-update rollback path.
-        status_unreadable = any(
-            str(w).startswith("status_error:") for w in (repo_state.get("warnings") or [])
-        )
-        # Read MERGE_HEAD directly (no git process) since this runs on every call.
-        # A present file whose content is not a SHA is unreadable, not absent, per
-        # the issue's fix direction.
-        merge_head_path = _git_dir() / "MERGE_HEAD"
-        merge_in_progress = False
-        merge_head_unreadable = False
-        if merge_head_path.is_file():
-            try:
-                merge_head_content = merge_head_path.read_text(encoding="utf-8").strip()
-            except Exception:
-                merge_head_content = ""
-            if re.fullmatch(r"[0-9a-fA-F]{7,64}", merge_head_content):
-                merge_in_progress = True
-            else:
-                merge_head_unreadable = True
-
-        if dirty_lines or unpushed_needs_rescue or status_unreadable or merge_in_progress \
-                or merge_head_unreadable:
-            bits: List[str] = []
-            if unpushed_lines and (dirty_lines or unpushed_needs_rescue):
-                bits.append(f"unpushed={len(unpushed_lines)}")
-            if dirty_lines:
-                bits.append(f"dirty={len(dirty_lines)}")
-            if status_unreadable:
-                bits.append("status_unreadable")
-            if merge_in_progress:
-                bits.append("merge_in_progress")
-            if merge_head_unreadable:
-                bits.append("merge_head_unreadable")
-            detail = ", ".join(bits) if bits else "unsynced"
-            rescue_info: Dict[str, Any] = {}
-            if policy in {"rescue_and_block", "rescue_and_reset"}:
-                try:
-                    rescue_info = _create_rescue_snapshot(
-                        branch=branch, reason=reason, repo_state=repo_state)
-                except Exception as e:
-                    rescue_info = {"error": repr(e)}
-                if policy == "rescue_and_reset" and rescue_info.get("error"):
-                    msg = (
-                        f"Reset blocked ({detail}) because rescue snapshot failed: "
-                        f"{rescue_info.get('error')}. Local changes were left untouched."
-                    )
-                    append_jsonl(
-                        DRIVE_ROOT / "logs" / "supervisor.jsonl",
-                        {
-                            "ts": utc_now_iso(),
-                            "type": "reset_blocked_rescue_failed",
-                            "target_branch": branch, "reason": reason, "policy": policy,
-                            "current_branch": repo_state.get("current_branch"),
-                            "dirty_count": len(dirty_lines),
-                            "unpushed_count": len(unpushed_lines),
-                            "dirty_preview": dirty_lines[:20],
-                            "unpushed_preview": unpushed_lines[:20],
-                            "warnings": list(repo_state.get("warnings") or []),
-                            "rescue": rescue_info,
-                            "incomplete_reason": "snapshot_error",
-                        },
-                    )
-                    return False, msg
-                if policy == "rescue_and_reset" and rescue_info.get("diff_error"):
-                    msg = (
-                        f"Reset blocked ({detail}) because rescue diff capture failed: "
-                        f"{rescue_info.get('diff_error')}. Local changes were left untouched."
-                    )
-                    append_jsonl(
-                        DRIVE_ROOT / "logs" / "supervisor.jsonl",
-                        {
-                            "ts": utc_now_iso(),
-                            "type": "reset_blocked_rescue_incomplete",
-                            "target_branch": branch, "reason": reason, "policy": policy,
-                            "current_branch": repo_state.get("current_branch"),
-                            "dirty_count": len(dirty_lines),
-                            "unpushed_count": len(unpushed_lines),
-                            "dirty_preview": dirty_lines[:20],
-                            "unpushed_preview": unpushed_lines[:20],
-                            "warnings": list(repo_state.get("warnings") or []),
-                            "rescue": rescue_info,
-                            "incomplete_reason": "diff_error",
-                        },
-                    )
-                    return False, msg
-                untracked_rescue_error = _rescue_untracked_incomplete(rescue_info)
-                if policy == "rescue_and_reset" and untracked_rescue_error:
-                    msg = (
-                        f"Reset blocked ({detail}) because untracked-file rescue was incomplete: "
-                        f"{untracked_rescue_error}. Local changes were left untouched."
-                    )
-                    append_jsonl(
-                        DRIVE_ROOT / "logs" / "supervisor.jsonl",
-                        {
-                            "ts": utc_now_iso(),
-                            "type": "reset_blocked_rescue_incomplete",
-                            "target_branch": branch, "reason": reason, "policy": policy,
-                            "current_branch": repo_state.get("current_branch"),
-                            "dirty_count": len(dirty_lines),
-                            "unpushed_count": len(unpushed_lines),
-                            "dirty_preview": dirty_lines[:20],
-                            "unpushed_preview": unpushed_lines[:20],
-                            "warnings": list(repo_state.get("warnings") or []),
-                            "rescue": rescue_info,
-                            "incomplete_reason": "untracked_rescue",
-                            "incomplete_detail": untracked_rescue_error,
-                        },
-                    )
-                    return False, msg
-            rescue_suffix = ""
-            rescue_path = str(rescue_info.get("path") or "").strip()
-            if rescue_path:
-                rescue_suffix = f" Rescue saved to {rescue_path}."
-            elif policy in {"rescue_and_block", "rescue_and_reset"} and rescue_info.get("error"):
-                rescue_suffix = f" Rescue failed: {rescue_info.get('error')}."
-
-            if policy in {"block", "rescue_and_block"}:
-                msg = f"Reset blocked ({detail}) to protect local changes.{rescue_suffix}"
-                append_jsonl(
-                    DRIVE_ROOT / "logs" / "supervisor.jsonl",
-                    {
-                        "ts": utc_now_iso(),
-                        "type": "reset_blocked_unsynced_state",
-                        "target_branch": branch, "reason": reason, "policy": policy,
-                        "current_branch": repo_state.get("current_branch"),
-                        "dirty_count": len(dirty_lines),
-                        "unpushed_count": len(unpushed_lines),
-                        "dirty_preview": dirty_lines[:20],
-                        "unpushed_preview": unpushed_lines[:20],
-                        "warnings": list(repo_state.get("warnings") or []),
-                        "rescue": rescue_info,
-                    },
-                )
-                return False, msg
-
-            append_jsonl(
-                DRIVE_ROOT / "logs" / "supervisor.jsonl",
-                {
-                    "ts": utc_now_iso(),
-                    "type": "reset_unsynced_rescued_then_reset",
-                    "target_branch": branch, "reason": reason, "policy": policy,
-                    "current_branch": repo_state.get("current_branch"),
-                    "dirty_count": len(dirty_lines),
-                    "unpushed_count": len(unpushed_lines),
-                    "dirty_preview": dirty_lines[:20],
-                    "unpushed_preview": unpushed_lines[:20],
-                    "warnings": list(repo_state.get("warnings") or []),
-                    "rescue": rescue_info,
-                },
-            )
+        admission_result = _admission_gate_for_unsynced_tree(
+            branch, reason, policy, update_intent_target)
+        if admission_result is not None:
+            return admission_result
 
     remote_ref_exists = False
     if target_ref:

--- a/supervisor/git_ops.py
+++ b/supervisor/git_ops.py
@@ -442,8 +442,9 @@ def _collect_repo_sync_state() -> Dict[str, Any]:
     rc, dirty, err = git_capture(["git", "status", "--porcelain"])
     if rc == 0 and dirty:
         state["dirty_lines"] = [ln for ln in dirty.splitlines() if ln.strip()]
-    elif rc != 0 and err:
-        state["warnings"].append(f"status_error:{err}")
+    elif rc != 0:
+        detail = err or f"git status exited {rc} without stderr"
+        state["warnings"].append(f"status_error:{detail}")
 
     upstream = ""
     current_branch = str(state.get("current_branch") or "")
@@ -872,12 +873,23 @@ def _admission_gate_for_unsynced_tree(
     status_unreadable = any(
         str(w).startswith("status_error:") for w in (repo_state.get("warnings") or [])
     )
-    # Read MERGE_HEAD directly (no git process) since this runs on every call.
-    # A present file whose content is not a SHA is unreadable, not absent, per
-    # the issue's fix direction.
-    merge_head_path = _git_dir() / "MERGE_HEAD"
     merge_in_progress = False
     merge_head_unreadable = False
+    # Keep the process-free path for normal clones.  Linked worktrees use a
+    # .git pointer file, so ask Git for the worktree-specific admin path there.
+    git_dir = _git_dir()
+    merge_head_path = git_dir / "MERGE_HEAD"
+    if git_dir.is_file():
+        rc_path, merge_head_rel, _path_err = git_capture(
+            ["git", "rev-parse", "--git-path", "MERGE_HEAD"]
+        )
+        if rc_path == 0 and merge_head_rel:
+            merge_head_path = REPO_DIR / merge_head_rel
+        else:
+            merge_head_unreadable = True
+
+    # A present file whose content is not a SHA is unreadable, not absent, per
+    # the issue's fix direction.
     if merge_head_path.is_file():
         try:
             merge_head_content = merge_head_path.read_text(encoding="utf-8").strip()

--- a/tests/test_git_ops_recovery.py
+++ b/tests/test_git_ops_recovery.py
@@ -496,6 +496,129 @@ def test_checkout_and_reset_does_not_rescue_for_only_managed_ahead_commits(monke
     assert message == "ok"
 
 
+def test_checkout_and_reset_blocks_when_status_read_is_unreadable(monkeypatch, tmp_path):
+    """A `git status` failure must not read as a clean tree: the admission gate treats
+    it the same as a genuinely dirty tree, even though dirty_lines itself is empty."""
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+
+    monkeypatch.setattr(git_ops, "REPO_DIR", tmp_path)
+    monkeypatch.setattr(git_ops, "DRIVE_ROOT", tmp_path / "data")
+    monkeypatch.setattr(git_ops, "_has_remote", lambda name=None: False)
+    monkeypatch.setattr(git_ops, "load_state", lambda: {})
+    monkeypatch.setattr(
+        git_ops,
+        "_collect_repo_sync_state",
+        lambda: {
+            "current_branch": "ouroboros",
+            "dirty_lines": [],
+            "unpushed_lines": [],
+            "warnings": ["status_error:fatal: unreadable index"],
+        },
+    )
+    events = []
+    monkeypatch.setattr(git_ops, "append_jsonl", lambda path, payload: events.append(payload))
+
+    def fake_run(cmd, cwd=None, capture_output=False, text=False, check=False, env=None):
+        if cmd[:2] == ["git", "rev-parse"] and cmd[-1] == "HEAD":
+            return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n", stderr="")
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(git_ops.subprocess, "run", fake_run)
+
+    ok, message = git_ops.checkout_and_reset(
+        "ouroboros", reason="restart", unsynced_policy="block",
+    )
+
+    assert ok is False
+    assert "status_unreadable" in message
+    assert events and events[-1]["type"] == "reset_blocked_unsynced_state"
+    assert events[-1]["dirty_count"] == 0
+    assert events[-1]["warnings"] == ["status_error:fatal: unreadable index"]
+
+
+def test_checkout_and_reset_blocks_on_unreadable_merge_head(monkeypatch, tmp_path):
+    """MERGE_HEAD present but not a resolvable SHA must force the block branch too,
+    not just a clean git-status read."""
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    (git_dir / "MERGE_HEAD").write_text("not-a-sha\n", encoding="utf-8")
+
+    monkeypatch.setattr(git_ops, "REPO_DIR", tmp_path)
+    monkeypatch.setattr(git_ops, "DRIVE_ROOT", tmp_path / "data")
+    monkeypatch.setattr(git_ops, "_has_remote", lambda name=None: False)
+    monkeypatch.setattr(git_ops, "load_state", lambda: {})
+    monkeypatch.setattr(
+        git_ops,
+        "_collect_repo_sync_state",
+        lambda: {
+            "current_branch": "ouroboros",
+            "dirty_lines": [],
+            "unpushed_lines": [],
+            "warnings": [],
+        },
+    )
+    events = []
+    monkeypatch.setattr(git_ops, "append_jsonl", lambda path, payload: events.append(payload))
+
+    def fake_run(cmd, cwd=None, capture_output=False, text=False, check=False, env=None):
+        if cmd[:2] == ["git", "rev-parse"] and cmd[-1] == "HEAD":
+            return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n", stderr="")
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(git_ops.subprocess, "run", fake_run)
+
+    ok, message = git_ops.checkout_and_reset(
+        "ouroboros", reason="restart", unsynced_policy="block",
+    )
+
+    assert ok is False
+    assert "merge_head_unreadable" in message
+    assert events and events[-1]["type"] == "reset_blocked_unsynced_state"
+    assert events[-1]["dirty_count"] == 0
+
+
+def test_checkout_and_reset_blocks_on_merge_in_progress(monkeypatch, tmp_path):
+    """A resolvable MERGE_HEAD (an actual in-progress merge) was never consulted by
+    this admission gate before; it must now force the block branch."""
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    (git_dir / "MERGE_HEAD").write_text("a" * 40 + "\n", encoding="utf-8")
+
+    monkeypatch.setattr(git_ops, "REPO_DIR", tmp_path)
+    monkeypatch.setattr(git_ops, "DRIVE_ROOT", tmp_path / "data")
+    monkeypatch.setattr(git_ops, "_has_remote", lambda name=None: False)
+    monkeypatch.setattr(git_ops, "load_state", lambda: {})
+    monkeypatch.setattr(
+        git_ops,
+        "_collect_repo_sync_state",
+        lambda: {
+            "current_branch": "ouroboros",
+            "dirty_lines": [],
+            "unpushed_lines": [],
+            "warnings": [],
+        },
+    )
+    events = []
+    monkeypatch.setattr(git_ops, "append_jsonl", lambda path, payload: events.append(payload))
+
+    def fake_run(cmd, cwd=None, capture_output=False, text=False, check=False, env=None):
+        if cmd[:2] == ["git", "rev-parse"] and cmd[-1] == "HEAD":
+            return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n", stderr="")
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(git_ops.subprocess, "run", fake_run)
+
+    ok, message = git_ops.checkout_and_reset(
+        "ouroboros", reason="restart", unsynced_policy="block",
+    )
+
+    assert ok is False
+    assert "merge_in_progress" in message
+    assert events and events[-1]["type"] == "reset_blocked_unsynced_state"
+    assert events[-1]["dirty_count"] == 0
+
+
 def test_checkout_and_reset_applies_explicit_update_intent(monkeypatch, tmp_path):
     import supervisor.update_merge as update_merge
 

--- a/tests/test_git_ops_recovery.py
+++ b/tests/test_git_ops_recovery.py
@@ -4,6 +4,8 @@ import subprocess
 import time
 from types import SimpleNamespace
 
+import pytest
+
 import supervisor.git_ops as git_ops
 
 
@@ -505,26 +507,22 @@ def test_checkout_and_reset_blocks_when_status_read_is_unreadable(monkeypatch, t
     monkeypatch.setattr(git_ops, "REPO_DIR", tmp_path)
     monkeypatch.setattr(git_ops, "DRIVE_ROOT", tmp_path / "data")
     monkeypatch.setattr(git_ops, "_has_remote", lambda name=None: False)
-    monkeypatch.setattr(git_ops, "load_state", lambda: {})
-    monkeypatch.setattr(
-        git_ops,
-        "_collect_repo_sync_state",
-        lambda: {
-            "current_branch": "ouroboros",
-            "dirty_lines": [],
-            "unpushed_lines": [],
-            "warnings": ["status_error:fatal: unreadable index"],
-        },
-    )
     events = []
     monkeypatch.setattr(git_ops, "append_jsonl", lambda path, payload: events.append(payload))
 
-    def fake_run(cmd, cwd=None, capture_output=False, text=False, check=False, env=None):
-        if cmd[:2] == ["git", "rev-parse"] and cmd[-1] == "HEAD":
-            return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n", stderr="")
+    def fake_capture(cmd):
+        if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+            return 0, "ouroboros", ""
+        if cmd == ["git", "status", "--porcelain"]:
+            return -9, "", ""
         raise AssertionError(cmd)
 
-    monkeypatch.setattr(git_ops.subprocess, "run", fake_run)
+    monkeypatch.setattr(git_ops, "git_capture", fake_capture)
+    monkeypatch.setattr(
+        git_ops,
+        "_run_git_resilient",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError((args, kwargs))),
+    )
 
     ok, message = git_ops.checkout_and_reset(
         "ouroboros", reason="restart", unsynced_policy="block",
@@ -534,7 +532,40 @@ def test_checkout_and_reset_blocks_when_status_read_is_unreadable(monkeypatch, t
     assert "status_unreadable" in message
     assert events and events[-1]["type"] == "reset_blocked_unsynced_state"
     assert events[-1]["dirty_count"] == 0
-    assert events[-1]["warnings"] == ["status_error:fatal: unreadable index"]
+    assert events[-1]["warnings"] == ["status_error:git status exited -9 without stderr"]
+
+
+@pytest.mark.serial
+def test_checkout_and_reset_blocks_clean_merge_in_linked_worktree(monkeypatch, tmp_path):
+    """A linked worktree stores MERGE_HEAD outside its .git pointer file."""
+    repo = tmp_path / "repo"
+    linked = tmp_path / "linked"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "user.email", "test@ouroboros")
+    _git(repo, "commit", "--allow-empty", "-qm", "base")
+    _git(repo, "branch", "-M", "main")
+    _git(repo, "branch", "side")
+    _git(repo, "commit", "--allow-empty", "-qm", "main")
+    _git(repo, "worktree", "add", "-q", str(linked), "side")
+    _git(linked, "commit", "--allow-empty", "-qm", "side")
+    _git(linked, "merge", "--no-commit", "--no-ff", "main")
+
+    assert _git(linked, "status", "--porcelain") == ""
+    merge_head = linked / _git(linked, "rev-parse", "--git-path", "MERGE_HEAD")
+    assert merge_head.is_file()
+
+    monkeypatch.setattr(git_ops, "REPO_DIR", linked)
+    monkeypatch.setattr(git_ops, "DRIVE_ROOT", tmp_path / "data")
+
+    ok, message = git_ops.checkout_and_reset(
+        "side", reason="restart", unsynced_policy="block",
+    )
+
+    assert ok is False
+    assert "merge_in_progress" in message
+    assert merge_head.is_file()
 
 
 def test_checkout_and_reset_blocks_on_unreadable_merge_head(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

`_collect_repo_sync_state()` leaves `dirty_lines` empty when `git status --porcelain`
itself fails: the error is appended to `warnings`, but the caller never sees it. The
`checkout_and_reset()` admission gate at the `unsynced_policy != "ignore"` branch reads
only `dirty_lines`/`unpushed_lines`, so an unreadable status probe passes as a clean
tree and the branch resets/cleans with no rescue snapshot. `MERGE_HEAD` was never
consulted there either, so a repo mid-merge fell through the same way. Fixes #180.

## Scope

In scope:

- `checkout_and_reset()`'s admission read: also force the rescue/block branch when the
  status probe recorded a `status_error:` warning, or when `MERGE_HEAD` is present (an
  in-progress merge, or a file that exists but doesn't hold a resolvable SHA).

Non-goals:

- `_collect_repo_sync_state()`'s own `dirty_lines`/`warnings` contract is unchanged; its
  other two call sites (`rescue_before_destructive_rollback`, the managed-update-status
  path) already handle a failed read correctly or don't depend on it for a go/no-go
  decision, so this stays scoped to the one admission read named in the issue.

## Verification

- [x] Focused tests for the changed behavior pass.
- [x] The default local test suite passes, or the reason it was not run is below.
- [x] Lint/static checks relevant to this change pass.

Commands and results:

```text
$ python -m pytest tests/test_git_ops_recovery.py -k "status_read_is_unreadable or unreadable_merge_head or merge_in_progress" -q
# on unmodified origin/ouroboros: 3 failed (admission gate proceeds past the "clean"
# read into the real checkout instead of blocking)
# on this branch: 3 passed

$ python -m pytest tests/test_git_ops_recovery.py -q
39 passed

$ python -m pytest tests/test_git_ops_recovery.py tests/test_git_ops_rollback_sync.py tests/test_packaging_sync.py tests/test_update_apply_routing.py -q
96 passed

$ python -m ruff check . --select F --no-cache
All checks passed!
```

All commands were run in a clean `python:3.10-slim` container against this branch's
HEAD. Not run: `tests/test_server_shutdown.py` (imports the full `server.py` app stack;
this repo's dependency lock was not synced in this lightweight container), the full CI
matrix (browser/UI/skill-smoke lanes, integration tests needing provider API keys), and
this repo's own triad/scope review tooling, none of which is reachable from this
environment. `test_server_shutdown.py` does not reference `checkout_and_reset` or
`_collect_repo_sync_state`, so it is unaffected by this diff either way.

## Visual evidence

- [x] Not applicable; this PR has no visible UI change.

## Governance and documentation

- [x] I followed `CONTRIBUTING.md` and checked the relevant guidance in `BIBLE.md`,
      `docs/ARCHITECTURE.md`, `docs/DEVELOPMENT.md`, and `docs/CHECKLISTS.md`.
- [x] I updated tests and documentation where behavior or architecture changed.
- [x] I did not include secrets, local settings, runtime state, logs, caches, or generated
      build/review artifacts in the commit.
- [x] I did **not** bump `VERSION` or release-only version carriers.

## Agent assistance (optional)

- Agent/tool and model: Claude Code (Claude, Anthropic), operated by AmirF194
- Work performed by the agent: diagnosis, fix, regression tests, and all verification below
- Human verification performed: none beyond what is listed in Verification above

## Review evidence

- [ ] Triad/scope review evidence is attached or linked below.
- [x] Review was not run; the reason is recorded below.

- If not run, reason: this repo's internal triad/scope review tooling is not reachable
  from this environment; verification above is a direct differential test run plus the
  repo's own pytest/ruff gates.

## Final checklist

- [x] The PR base branch is `ouroboros`.
- [x] The branch is based on a current `ouroboros` revision.
- [x] The PR is one coherent change and is ready to be squash-integrated.
- [x] The description explains any limitations, follow-up work, or compatibility impact.
