### PR TITLE
Fix/retry bypass response cache

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -916,6 +916,15 @@ Retry budgets are failure-class specific. Empty/incomplete responses and transie
 
 Prompt caching is stable-first. Governance and task-stable contracts precede mutable evidence; review builders disclose the stable/dynamic boundary and keep untrusted payloads outside the governance cache block. Provider-specific cache hints are sent only where supported and receive one exact retry without the rejected hint. Rejection evidence is durable and route-specific. Cache identity must not weaken exact review bindings or create a second review authority.
 
+Gateway response-cache recovery is narrower and reactive. The first call remains
+cacheable; only a main-loop `provider_incomplete_response` arms a fresh-response
+request for later attempts. The generic `openai-compatible` route is Ouroboros's
+gateway/proxy route, so only it renders LiteLLM's documented
+`extra_body.cache.no-cache` control. A strict compatible endpoint that explicitly
+rejects `cache` receives the existing one exact cache-parameter removal retry.
+Direct providers and OpenRouter never receive this LiteLLM field; no URL/model
+heuristic or parallel gateway-capability subsystem is introduced.
+
 #### Vision and local image evidence
 
 `analyze_screenshot` and `vlm_query` are bounded secondary-model calls through `LLMClient.vision_query`; `view_image` attaches a local image natively to the active conversation. Send-time image routing works on a copy of the transcript so captioning or placeholder conversion never mutates canonical history. Image payloads are validated, capped/downscaled, and confined to readable roots derived from the Tool API policy matrix plus the protected-artifact rule; URLs and inline base64 are not accepted as local paths.

--- a/ouroboros/llm.py
+++ b/ouroboros/llm.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import hashlib
 import json
 import logging
@@ -10,7 +11,6 @@ import os
 import re
 import threading
 import time
-import copy
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from ouroboros.provider_models import (
@@ -1203,7 +1203,7 @@ class LLMClient:
         target: Dict[str, Any],
         exc: BaseException,
     ) -> Optional[Dict[str, Any]]:
-        """Remove only an explicitly rejected cache-affinity parameter once."""
+        """Remove only an explicitly rejected cache control or affinity once."""
         provider = str(target.get("provider") or "").strip().lower()
         extra_body = payload.get("extra_body")
         param = ""
@@ -1215,6 +1215,12 @@ class LLMClient:
             and "session_id" in extra_body
         ):
             param = "session_id"
+        elif (
+            provider == "openai-compatible"
+            and isinstance(extra_body, dict)
+            and "cache" in extra_body
+        ):
+            param = "cache"
         if not param:
             return None
 
@@ -1246,11 +1252,11 @@ class LLMClient:
         else:
             retry_extra = retry_payload.get("extra_body")
             if isinstance(retry_extra, dict):
-                retry_extra.pop("session_id", None)
+                retry_extra.pop(param, None)
             if not retry_extra:
                 retry_payload.pop("extra_body", None)
         log.warning(
-            "Retrying %s once without unsupported prompt-cache parameter %s",
+            "Retrying %s once without unsupported cache parameter %s",
             str(target.get("usage_model") or target.get("resolved_model") or "(unknown model)"),
             param,
         )
@@ -3610,7 +3616,7 @@ class LLMClient:
                     for tool in self._sanitize_chat_completion_tools(tools)
                 ]
                 kwargs["tool_choice"] = tool_choice
-            if bypass_response_cache:
+            if bypass_response_cache and provider == "openai-compatible":
                 # Must ride in extra_body: the OpenAI SDK rejects unknown top-level
                 # kwargs with TypeError, so a raw `cache=` argument never reaches
                 # the wire.
@@ -3702,15 +3708,6 @@ class LLMClient:
             kwargs["temperature"] = temperature
         if response_format:
             kwargs["response_format"] = dict(response_format)
-        if bypass_response_cache:
-            # A retry of a byte-identical request only helps when nothing between
-            # us and the model caches responses.  A gateway response cache (e.g.
-            # LiteLLM `cache: true`) otherwise replays the SAME failed body for
-            # every attempt, so the whole transient-retry budget never reaches the
-            # model.  `cache.no-cache` is LiteLLM's documented per-request opt-out
-            # and must ride in extra_body — the OpenAI SDK raises TypeError on
-            # unknown top-level kwargs.  Servers that do not know the field ignore it.
-            extra_body["cache"] = {"no-cache": True}
         server_web_tool = (
             self._openrouter_main_web_search_tool()
             if (tools and allow_server_web_search)

--- a/ouroboros/llm.py
+++ b/ouroboros/llm.py
@@ -2302,6 +2302,7 @@ class LLMClient:
         allow_server_web_search: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         cache_affinity: str = "",
+        bypass_response_cache: bool = False,
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         """Single LLM call returning (message, usage); no_proxy avoids macOS fork proxy crashes.
 
@@ -2327,6 +2328,7 @@ class LLMClient:
                     allow_server_web_search=allow_server_web_search,
                     response_format=response_format,
                     cache_affinity=cache_affinity,
+                    bypass_response_cache=bypass_response_cache,
                 )
             usage["ledger_attempt_ids"] = list(attempt_ids)
             return message, usage
@@ -3544,6 +3546,7 @@ class LLMClient:
         allow_server_web_search: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         cache_affinity: str = "",
+        bypass_response_cache: bool = False,
     ) -> Dict[str, Any]:
         messages = self._normalize_system_message_placement(messages)
         resolved_model = str(target.get("resolved_model") or "")
@@ -3607,6 +3610,13 @@ class LLMClient:
                     for tool in self._sanitize_chat_completion_tools(tools)
                 ]
                 kwargs["tool_choice"] = tool_choice
+            if bypass_response_cache:
+                # Must ride in extra_body: the OpenAI SDK rejects unknown top-level
+                # kwargs with TypeError, so a raw `cache=` argument never reaches
+                # the wire.
+                _eb = kwargs.setdefault("extra_body", {})
+                if isinstance(_eb, dict):
+                    _eb["cache"] = {"no-cache": True}
             self._apply_rejected_param_cache(kwargs, str(target.get("usage_model") or resolved_model))
             return kwargs
 
@@ -3692,6 +3702,15 @@ class LLMClient:
             kwargs["temperature"] = temperature
         if response_format:
             kwargs["response_format"] = dict(response_format)
+        if bypass_response_cache:
+            # A retry of a byte-identical request only helps when nothing between
+            # us and the model caches responses.  A gateway response cache (e.g.
+            # LiteLLM `cache: true`) otherwise replays the SAME failed body for
+            # every attempt, so the whole transient-retry budget never reaches the
+            # model.  `cache.no-cache` is LiteLLM's documented per-request opt-out
+            # and must ride in extra_body — the OpenAI SDK raises TypeError on
+            # unknown top-level kwargs.  Servers that do not know the field ignore it.
+            extra_body["cache"] = {"no-cache": True}
         server_web_tool = (
             self._openrouter_main_web_search_tool()
             if (tools and allow_server_web_search)
@@ -4145,6 +4164,7 @@ class LLMClient:
         allow_server_web_search: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         cache_affinity: str = "",
+        bypass_response_cache: bool = False,
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         """Send remote chat; no_proxy uses a one-shot client and skips OS proxy lookup."""
         if target.get("provider") == "anthropic":
@@ -4170,6 +4190,7 @@ class LLMClient:
                     allow_server_web_search=allow_server_web_search,
                     response_format=response_format,
                     cache_affinity=cache_affinity,
+                    bypass_response_cache=bypass_response_cache,
                 )
                 prompt_cache_ttl = self._normalize_payload_cache_ttl(target, kwargs)
                 resp = self._create_chat_completion_with_retries(
@@ -4196,6 +4217,7 @@ class LLMClient:
             allow_server_web_search=allow_server_web_search,
             response_format=response_format,
             cache_affinity=cache_affinity,
+            bypass_response_cache=bypass_response_cache,
         )
         if timeout and timeout > 0:
             # Cached clients are built without a timeout; honor the caller's

--- a/ouroboros/loop_llm_call.py
+++ b/ouroboros/loop_llm_call.py
@@ -119,11 +119,6 @@ def fold_retrieval_usage(accumulated_usage: Dict[str, Any], usage: Dict[str, Any
 # large) keep failing fast. There is NO cross-model fallback here — the same
 # request is retried on the SAME model.
 _TRANSIENT_RETRY_KINDS = frozenset({"provider_transient", "provider_incomplete_response"})
-# Every attempt in call_llm_with_retry rebuilds the SAME request, so a response
-# cache in front of the provider (e.g. a LiteLLM proxy with `cache: true`) replays
-# the identical failed body and the retry budget above never reaches the model.
-# Hence `bypass_response_cache=attempt > 0` there: retries opt out of the cache,
-# while the first attempt still benefits from a warm one.
 # Error kinds that put a model on the F1 fallback cooldown. Superset of the same-model
 # retry kinds: a body-error 429 (HTTP 200 with an error in the body — the canonical
 # cloud.ru/OpenRouter rate-limit shape) is classified "rate_limit", which must cool the
@@ -838,7 +833,7 @@ def call_llm_with_retry(
     execution_id = str(accumulated_usage.setdefault("execution_id", new_execution_id()))
     round_id = f"{execution_id}:round:{round_idx}"
     transient_budget = _attempt_loop_budget(max_retries, attempt_cap)
-
+    response_cache_bypass_requested = False
     for attempt in range(transient_budget):
         accumulated_usage["_llm_attempts_used"] = attempt + 1
         llm_call_id = new_call_id("llm")
@@ -882,8 +877,8 @@ def call_llm_with_retry(
                 "max_tokens": MAIN_LOOP_MAX_TOKENS,
                 "use_local": use_local,
                 "allow_server_web_search": bool(allow_server_web_search),
+                "bypass_response_cache": response_cache_bypass_requested,
             }
-            kwargs["bypass_response_cache"] = attempt > 0
             if tools:
                 kwargs["tools"] = tools
             try:
@@ -901,6 +896,7 @@ def call_llm_with_retry(
                         "max_tokens": MAIN_LOOP_MAX_TOKENS,
                         "use_local": bool(use_local),
                         "allow_server_web_search": bool(allow_server_web_search),
+                        "response_cache_bypass_requested": response_cache_bypass_requested,
                     },
                     manifest={
                         "execution_id": execution_id,
@@ -910,14 +906,13 @@ def call_llm_with_retry(
                         "attempt": attempt + 1,
                         "model": model,
                         "reasoning_effort": effort,
+                        "response_cache_bypass_requested": response_cache_bypass_requested,
                         **_context_fit_event_fields(accumulated_usage),
                     },
                 )
             except Exception:
                 log.debug("Failed to persist LLM request observability payload", exc_info=True)
-            # #4 self-DoS guard: cap concurrent calls to THIS model route (excess worker
-            # threads wait, bounded by the deadline, instead of storming a rate limit). Wraps
-            # ONLY the provider call — not the retry loop, not the backoff. Fail-soft.
+            # Cap only the provider call, not retries/backoff; fail-soft and deadline-bounded.
             with model_concurrency.model_call_slot(model, use_local, deadline_ts):
                 resp_msg, usage = llm.chat(**kwargs)
             msg = resp_msg
@@ -996,8 +991,9 @@ def call_llm_with_retry(
                     task_type=task_type, content=content, tool_calls=tool_calls,
                     request_ref=request_ref, response_ref=response_ref, transient_budget=transient_budget,
                 )
-                # Transient response glitches (and transient body errors) retry the SAME model
-                # within the transient budget, deadline-bounded; a PERMANENT body error fails fast.
+                if event_type == "provider_incomplete_response":
+                    response_cache_bypass_requested = True
+                # Transient response glitches retry the same model; permanent body errors fail fast.
                 if not permanent_body_error and attempt < transient_budget - 1:
                     if _sleep_within_deadline(
                         min(2.0 ** attempt, _TRANSIENT_BACKOFF_CAP_SEC), deadline_ts

--- a/ouroboros/loop_llm_call.py
+++ b/ouroboros/loop_llm_call.py
@@ -991,7 +991,7 @@ def call_llm_with_retry(
                     task_type=task_type, content=content, tool_calls=tool_calls,
                     request_ref=request_ref, response_ref=response_ref, transient_budget=transient_budget,
                 )
-                if event_type == "provider_incomplete_response":
+                if event_type == "provider_incomplete_response" and not usage.get("provider_error"):
                     response_cache_bypass_requested = True
                 # Transient response glitches retry the same model; permanent body errors fail fast.
                 if not permanent_body_error and attempt < transient_budget - 1:

--- a/ouroboros/loop_llm_call.py
+++ b/ouroboros/loop_llm_call.py
@@ -119,6 +119,11 @@ def fold_retrieval_usage(accumulated_usage: Dict[str, Any], usage: Dict[str, Any
 # large) keep failing fast. There is NO cross-model fallback here — the same
 # request is retried on the SAME model.
 _TRANSIENT_RETRY_KINDS = frozenset({"provider_transient", "provider_incomplete_response"})
+# Every attempt in call_llm_with_retry rebuilds the SAME request, so a response
+# cache in front of the provider (e.g. a LiteLLM proxy with `cache: true`) replays
+# the identical failed body and the retry budget above never reaches the model.
+# Hence `bypass_response_cache=attempt > 0` there: retries opt out of the cache,
+# while the first attempt still benefits from a warm one.
 # Error kinds that put a model on the F1 fallback cooldown. Superset of the same-model
 # retry kinds: a body-error 429 (HTTP 200 with an error in the body — the canonical
 # cloud.ru/OpenRouter rate-limit shape) is classified "rate_limit", which must cool the
@@ -878,6 +883,7 @@ def call_llm_with_retry(
                 "use_local": use_local,
                 "allow_server_web_search": bool(allow_server_web_search),
             }
+            kwargs["bypass_response_cache"] = attempt > 0
             if tools:
                 kwargs["tools"] = tools
             try:

--- a/tests/test_retry_bypass_response_cache.py
+++ b/tests/test_retry_bypass_response_cache.py
@@ -13,6 +13,8 @@ the same request replayed later succeeded.
 
 from __future__ import annotations
 
+import pytest
+
 
 class TestBuildRemoteKwargsCacheOptOut:
     def test_no_cache_field_absent_by_default(self):
@@ -183,6 +185,62 @@ class TestRetryLoopRequestsCacheOptOut:
             2,
             tmp_path,
             "task-transient-cache",
+            1,
+            None,
+            {},
+        )
+
+        assert msg["content"] == "recovered"
+        assert [call["bypass_response_cache"] for call in calls] == [False, False]
+
+    @pytest.mark.parametrize(("kind", "code"), [("rate_limit", 429), ("provider_transient", 503)])
+    def test_transient_body_error_does_not_request_litellm_cache_bypass(
+        self, kind, code, tmp_path, monkeypatch,
+    ):
+        import time
+
+        from ouroboros.llm import LLMClient
+        from ouroboros.loop_llm_call import call_llm_with_retry
+
+        monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+        target = {
+            "provider": "openai-compatible",
+            "resolved_model": "local-reason",
+            "usage_model": "openai-compatible/local-reason",
+            "supports_openrouter_extensions": False,
+        }
+        body_error_msg, body_error_usage = LLMClient(api_key="test")._normalize_remote_response(
+            {
+                "id": f"body-error-{code}",
+                "choices": [],
+                "error": {"code": code, "message": "transient provider error"},
+                "usage": {},
+            },
+            target,
+            skip_cost_fetch=True,
+        )
+        assert body_error_usage["provider_error"]["kind"] == kind
+        calls = []
+
+        class BodyErrorThenSuccessfulLLM:
+            def chat(self, **kwargs):
+                calls.append(kwargs)
+                if len(calls) == 1:
+                    return body_error_msg, body_error_usage
+                return (
+                    {"content": "recovered", "tool_calls": [], "finish_reason": "stop"},
+                    {"provider": "openai-compatible", "resolved_model": "local-reason"},
+                )
+
+        msg, _cost = call_llm_with_retry(
+            BodyErrorThenSuccessfulLLM(),
+            [{"role": "user", "content": "hi"}],
+            "openai-compatible::local-reason",
+            None,
+            "medium",
+            2,
+            tmp_path,
+            f"task-body-error-{code}",
             1,
             None,
             {},

--- a/tests/test_retry_bypass_response_cache.py
+++ b/tests/test_retry_bypass_response_cache.py
@@ -41,7 +41,7 @@ class TestBuildRemoteKwargsCacheOptOut:
         )
         assert "cache" not in kwargs, "cache must never be a top-level kwarg"
 
-    def test_no_cache_field_present_when_bypassing(self):
+    def test_cache_field_present_when_bypassing(self):
         from ouroboros.llm import LLMClient
 
         client = LLMClient(api_key="test")
@@ -72,27 +72,168 @@ class TestBuildRemoteKwargsCacheOptOut:
             "opt-out must ride in extra_body"
         )
 
+    def test_litellm_control_is_not_sent_to_direct_providers_or_openrouter(self):
+        from ouroboros.llm import LLMClient
+
+        client = LLMClient(api_key="test")
+        targets = [
+            {
+                "provider": "openai",
+                "resolved_model": "gpt-5.5",
+                "usage_model": "openai/gpt-5.5",
+                "supports_openrouter_extensions": False,
+            },
+            {
+                "provider": "minimax",
+                "resolved_model": "MiniMax-M2.5",
+                "usage_model": "minimax/MiniMax-M2.5",
+                "supports_openrouter_extensions": False,
+            },
+            {
+                "provider": "cloudru",
+                "resolved_model": "foundation-model",
+                "usage_model": "cloudru/foundation-model",
+                "supports_openrouter_extensions": False,
+            },
+            {
+                "provider": "openrouter",
+                "resolved_model": "openai/gpt-5.5",
+                "usage_model": "openai/gpt-5.5",
+                "supports_openrouter_extensions": True,
+            },
+        ]
+
+        for target in targets:
+            kwargs = client._build_remote_kwargs(
+                target=target,
+                messages=[{"role": "user", "content": "hi"}],
+                reasoning_effort="medium",
+                max_tokens=256,
+                tool_choice="auto",
+                temperature=None,
+                tools=None,
+                skip_capability_fetch=True,
+                bypass_response_cache=True,
+            )
+            assert "cache" not in (kwargs.get("extra_body") or {}), target["provider"]
+
 
 class TestRetryLoopRequestsCacheOptOut:
-    def test_first_attempt_does_not_bypass_but_retry_does(self):
-        """The kwargs the retry loop hands to `LLM.chat` must differ across attempts.
+    def test_incomplete_response_arms_only_the_following_attempt(self, tmp_path, monkeypatch):
+        import time
 
-        Guards the actual defect: the payload used to be rebuilt byte-identically on
-        every attempt, which is what made the cached response unavoidable.
-        """
-        import inspect
+        from ouroboros.loop_llm_call import call_llm_with_retry
 
-        from ouroboros import loop_llm_call
+        monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+        calls = []
 
-        source = inspect.getsource(loop_llm_call.call_llm_with_retry)
-        assert "bypass_response_cache" in source, (
-            "call_llm_with_retry must vary the request on retries; without it a "
-            "response cache in front of the provider makes the retry budget useless"
+        class IncompleteThenSuccessfulLLM:
+            def chat(self, **kwargs):
+                calls.append(kwargs)
+                if len(calls) == 1:
+                    return {"content": "", "tool_calls": [], "finish_reason": None}, {}
+                return (
+                    {"content": "recovered", "tool_calls": [], "finish_reason": "stop"},
+                    {"provider": "openai-compatible", "resolved_model": "local-reason"},
+                )
+
+        msg, _cost = call_llm_with_retry(
+            IncompleteThenSuccessfulLLM(),
+            [{"role": "user", "content": "hi"}],
+            "openai-compatible::local-reason",
+            None,
+            "medium",
+            2,
+            tmp_path,
+            "task-incomplete-cache",
+            1,
+            None,
+            {},
         )
-        assert "attempt > 0" in source, (
-            "the cache opt-out must be tied to retry attempts, not applied to the "
-            "first call (which should still benefit from a warm cache)"
+
+        assert msg["content"] == "recovered"
+        assert [call["bypass_response_cache"] for call in calls] == [False, True]
+
+    def test_transport_retry_does_not_request_litellm_cache_bypass(self, tmp_path, monkeypatch):
+        import time
+
+        from ouroboros.loop_llm_call import call_llm_with_retry
+
+        monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+        calls = []
+
+        class TransientThenSuccessfulLLM:
+            def chat(self, **kwargs):
+                calls.append(kwargs)
+                if len(calls) == 1:
+                    error = RuntimeError("503 service unavailable")
+                    error.status_code = 503
+                    raise error
+                return (
+                    {"content": "recovered", "tool_calls": [], "finish_reason": "stop"},
+                    {"provider": "openai-compatible", "resolved_model": "local-reason"},
+                )
+
+        msg, _cost = call_llm_with_retry(
+            TransientThenSuccessfulLLM(),
+            [{"role": "user", "content": "hi"}],
+            "openai-compatible::local-reason",
+            None,
+            "medium",
+            2,
+            tmp_path,
+            "task-transient-cache",
+            1,
+            None,
+            {},
         )
+
+        assert msg["content"] == "recovered"
+        assert [call["bypass_response_cache"] for call in calls] == [False, False]
+
+
+class TestStrictCompatibleRecovery:
+    def test_explicit_cache_rejection_gets_one_exact_retry(self, monkeypatch):
+        import ouroboros.llm as llm_mod
+        from ouroboros.llm import LLMClient
+
+        monkeypatch.setattr(
+            llm_mod,
+            "execute_physical_attempt",
+            lambda _request, send: send(),
+        )
+        client = LLMClient(api_key="unused")
+        calls = []
+        expected = object()
+
+        def create(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise RuntimeError("400 unknown parameter: cache")
+            return expected
+
+        target = {
+            "provider": "openai-compatible",
+            "resolved_model": "strict-model",
+            "usage_model": "openai-compatible/strict-model",
+            "supports_openrouter_extensions": False,
+        }
+        kwargs = {
+            "model": "strict-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "extra_body": {
+                "cache": {"no-cache": True},
+                "future_extension": {"keep": True},
+            },
+        }
+
+        result = client._create_chat_completion_with_retries(create, kwargs, target)
+
+        assert result is expected
+        assert len(calls) == 2
+        assert calls[0]["extra_body"]["cache"] == {"no-cache": True}
+        assert "cache" not in calls[1]["extra_body"]
+        assert calls[1]["extra_body"]["future_extension"] == {"keep": True}
 
 
 class TestChatSignatureThreadsFlag:

--- a/tests/test_retry_bypass_response_cache.py
+++ b/tests/test_retry_bypass_response_cache.py
@@ -1,0 +1,110 @@
+"""Regression tests: a retried LLM call must not be served from a response cache.
+
+`provider_incomplete_response` is classified as transient (`_TRANSIENT_RETRY_KINDS`),
+i.e. the retry loop assumes a repeat MAY produce a different result.  That assumption
+only holds when nothing between the client and the model caches responses.  A gateway
+response cache (LiteLLM `cache: true`) replays the identical failed body for every
+attempt, so the whole transient-retry budget is spent without ever reaching the model
+and the task ends as `infra_failed` / `provider_unavailable`.
+
+Observed in the field: six attempts, one shared `response_id`, each returned in ~0.0s;
+the same request replayed later succeeded.
+"""
+
+from __future__ import annotations
+
+
+class TestBuildRemoteKwargsCacheOptOut:
+    def test_no_cache_field_absent_by_default(self):
+        from ouroboros.llm import LLMClient
+
+        client = LLMClient(api_key="test")
+        target = {
+            "provider": "openai-compatible",
+            "resolved_model": "local-reason",
+            "usage_model": "local-reason",
+            "api_key": "test",
+            "base_url": "http://127.0.0.1:4000/v1",
+            "default_headers": {},
+        }
+        kwargs = client._build_remote_kwargs(
+            target=target,
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_effort="medium",
+            max_tokens=256,
+            tool_choice="auto",
+            temperature=None,
+            tools=None,
+        )
+        assert "cache" not in (kwargs.get("extra_body") or {}), (
+            "the first attempt must stay cacheable; only retries opt out"
+        )
+        assert "cache" not in kwargs, "cache must never be a top-level kwarg"
+
+    def test_no_cache_field_present_when_bypassing(self):
+        from ouroboros.llm import LLMClient
+
+        client = LLMClient(api_key="test")
+        target = {
+            "provider": "openai-compatible",
+            "resolved_model": "local-reason",
+            "usage_model": "local-reason",
+            "api_key": "test",
+            "base_url": "http://127.0.0.1:4000/v1",
+            "default_headers": {},
+        }
+        kwargs = client._build_remote_kwargs(
+            target=target,
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_effort="medium",
+            max_tokens=256,
+            tool_choice="auto",
+            temperature=None,
+            tools=None,
+            bypass_response_cache=True,
+        )
+        assert (kwargs.get("extra_body") or {}).get("cache") == {"no-cache": True}, (
+            "a retry must carry LiteLLM's documented per-request cache opt-out, "
+            "otherwise the gateway replays the cached failed response"
+        )
+        assert "cache" not in kwargs, (
+            "the OpenAI SDK raises TypeError on unknown top-level kwargs, so the "
+            "opt-out must ride in extra_body"
+        )
+
+
+class TestRetryLoopRequestsCacheOptOut:
+    def test_first_attempt_does_not_bypass_but_retry_does(self):
+        """The kwargs the retry loop hands to `LLM.chat` must differ across attempts.
+
+        Guards the actual defect: the payload used to be rebuilt byte-identically on
+        every attempt, which is what made the cached response unavoidable.
+        """
+        import inspect
+
+        from ouroboros import loop_llm_call
+
+        source = inspect.getsource(loop_llm_call.call_llm_with_retry)
+        assert "bypass_response_cache" in source, (
+            "call_llm_with_retry must vary the request on retries; without it a "
+            "response cache in front of the provider makes the retry budget useless"
+        )
+        assert "attempt > 0" in source, (
+            "the cache opt-out must be tied to retry attempts, not applied to the "
+            "first call (which should still benefit from a warm cache)"
+        )
+
+
+class TestChatSignatureThreadsFlag:
+    def test_chat_accepts_bypass_response_cache(self):
+        import inspect
+
+        from ouroboros.llm import LLMClient
+
+        params = inspect.signature(LLMClient.chat).parameters
+        assert "bypass_response_cache" in params, (
+            "LLM.chat must expose the flag so the retry loop can request a fresh call"
+        )
+        assert params["bypass_response_cache"].default is False, (
+            "bypassing the cache must be opt-in"
+        )


### PR DESCRIPTION
<!--
Thank you for contributing to Ouroboros.

Open this PR against the `ouroboros` branch, not `main` or
`ouroboros-stable`. Keep review artifacts out of the git diff: attach or link
them in the Review evidence section instead.
-->

## Summary

A retry after `provider_incomplete_response` re-sent a byte-identical request.
When any response cache sits between the client and the model, every attempt is
served the same cached failure, the transient-retry budget is spent without
reaching the model, and the task ends as `infra_failed` / `provider_unavailable`.

`provider_incomplete_response` is classified as transient
(`_TRANSIENT_RETRY_KINDS` in `ouroboros/loop_llm_call.py`), i.e. the loop assumes
a repeat *may* produce a different result. That assumption only holds if nothing
caches. Inside the attempt loop, `attempt` was used solely for bookkeeping —
`_llm_attempts_used` and the observability manifests — while `send_messages` and
`kwargs` were rebuilt identically every time.

### How it showed up

Ouroboros → LiteLLM proxy with `cache: true` → local model:

- six attempts, all returning `content: ""`, `tool_calls: null`, 61 completion
  tokens;
- **the same `response_id` in all six responses**;
- each returned in ~0.0 s, so no attempt reached the model;
- the same request replayed by hand later succeeded, with
  `finish_reason=tool_calls` and valid arguments.

Nothing errors anywhere: the model is fine, the gateway is fine, Ouroboros is
fine. Only the combination fails, and it fails silently — the task reports
`completed` at the lifecycle level while the execution axis says `infra_failed`.

### Fix

From the first retry onward the request carries LiteLLM's documented per-request
cache opt-out. The first attempt is left untouched, so it still benefits from a
warm cache.

The flag rides in `extra_body`. This is not cosmetic: the OpenAI SDK raises
`TypeError: Completions.create() got an unexpected keyword argument 'cache'` on
unknown top-level kwargs, so a raw `cache=` argument never reaches the wire.
Servers that do not know the field ignore it — verified against a plain Ollama
OpenAI-compatible endpoint, which accepted the request unchanged.

Threaded along the same path as the existing `cache_affinity` parameter:

```text
call_llm_with_retry   (attempt > 0)
      ↓
LLM.chat
      ↓
_chat_remote          (both branches: pooled client and no_proxy)
      ↓
_build_remote_kwargs  (both branches: direct providers and OpenRouter)
```

`cache_affinity` itself is not usable for this — it does the opposite, pinning
repeat calls to one upstream so its prompt cache stays warm.

## Scope

In scope:

- `ouroboros/llm.py` — optional `bypass_response_cache` flag threaded through
  `chat`, `_chat_remote` and `_build_remote_kwargs`, emitted into `extra_body`.
- `ouroboros/loop_llm_call.py` — set the flag from the first retry.
- `tests/test_retry_bypass_response_cache.py` — regression tests.

Non-goals:

- The first attempt is deliberately still cacheable; this does not disable
  caching, only the replay of a failed response.
- No change to the runtime's own prompt cache. That one is worth keeping: a
  prefill cache hit measured ~25x faster than a cold pass on the same request
  (423 → 11,656 tokens/s). Only the gateway's *response* cache is opted out of.
- No retry-policy change: budgets, backoff and classification are untouched.

## Verification

- [x] Focused tests for the changed behavior pass.
- [ ] The default local test suite passes, or the reason it was not run is below.
- [x] Lint/static checks relevant to this change pass.

`make test` and `make lint` could not be run as documented: the pinned toolchain
requires `uv==0.12.1` and this machine has `0.9.2`, so `uv run --locked` refuses
to start. Tests were run directly with the bundled interpreter instead.

Commands and results:

```text
$ python3 -m pytest tests/test_retry_bypass_response_cache.py -q
....                                                                     [100%]
4 passed

$ python3 -m pytest tests/ -k "llm or retry or cache or context_fit"
364 passed, 1 skipped, 8521 deselected

$ uv run --locked python -m pytest tests/ -q --tb=short
error: Required uv version `==0.12.1` does not match the running version `0.9.2`.
```

The tests fail without the change. Checked by restoring both source files to the
base revision and re-running:

```text
FAILED ...::TestBuildRemoteKwargsCacheOptOut::test_no_cache_field_present_when_bypassing
FAILED ...::TestRetryLoopRequestsCacheOptOut::test_first_attempt_does_not_bypass_but_retry_does
FAILED ...::TestChatSignatureThreadsFlag::test_chat_accepts_bypass_response_cache
```

Live behaviour on the affected setup (GTX 1080 Ti, LiteLLM gateway, `qwen3.5:9b`
via an `openai-compatible::` route), same task each time:

| Configuration | `provider_incomplete_response` | API errors | Result |
|---|---:|---:|---|
| Before, gateway cache on | 6 | 0 | `failed` |
| Before, gateway cache off | 3 | 0 | `completed` |
| First version of this fix (top-level `cache`) | 1 | **2** | `failed` |
| This fix | 0 | 0 | `completed` |
| This fix, second cycle | 1 | 0 | **`completed`** — the retry recovered |

The last row is the point: a provider failure still occurred, and the task
survived it because the retry actually reached the model.

**Not verified end-to-end against a live cache.** Re-enabling `cache: true` on
the gateway to reproduce the original failure is currently impossible — that
LiteLLM image crashes on startup with
`AttributeError: 'Cache' object has no attribute 'cache'` in `_init_cache`. So
the mechanism is proven at the unit level and by the retry recovering in the
table above, but not by a before/after against a working response cache.

The branch was rebased from the fork's `main` onto `ouroboros`, moving the base
forward by five commits. Everything above was re-run afterwards rather than
carried over; `git log dcf48aac..ouroboros -- ouroboros/llm.py
ouroboros/loop_llm_call.py` is empty, so neither file was touched by those
commits, and the three changed files are byte-identical across the rebase.

## Visual evidence

- [x] Not applicable; this PR has no visible UI change.

Evidence: —

## Governance and documentation

- [x] I followed `CONTRIBUTING.md` and checked the relevant guidance in
      `BIBLE.md`, `docs/ARCHITECTURE.md`, `docs/DEVELOPMENT.md`, and
      `docs/CHECKLISTS.md`.
- [x] I updated tests and documentation where behavior or architecture changed.
      Behaviour is internal to the retry path; the rationale lives in code
      comments at both edit sites and in the test docstrings.
- [x] I did not include secrets, local settings, runtime state, logs, caches, or
      generated build/review artifacts in the commit.
- [x] I did **not** bump `VERSION` or release-only version carriers.

## Agent assistance (optional)

<!-- Disclosure is useful context, not a quality signal. Remove this section if unused. -->

- Agent/tool and model:
- Work performed by the agent:
- Human verification performed:

## Review evidence

<!--
Attach or link the final triad/scope review output when available. Evidence must
correspond to the current PR diff; rerun it after code changes or a rebase. If it
was not run, say why. Missing evidence does not prevent opening a PR, but it can
make maintainer integration slower.
-->

- [ ] Triad/scope review evidence is attached or linked below.
- [x] Review was not run; the reason is recorded below.

- Reviewed base SHA: `1952e042a06cc32926b12d1dece4e567e958d11f` (`ouroboros`)
- Reviewed head/diff SHA: `07937b6b`
- Review command/profile: —
- Triad verdict: —
- Scope verdict: —
- Run artifacts/link: —
- Known advisory findings or accepted tradeoffs: `cache: {"no-cache": true}` is
  LiteLLM's spelling. Another OpenAI-compatible gateway with a response cache
  would need its own opt-out; this change does not attempt to generalise, it
  makes the common deployment behave correctly and stays inert elsewhere.
- If not run: the triad/scope tooling was not available in this environment.

## Final checklist

- [x] The PR base branch is `ouroboros`.
- [x] The branch is based on a current `ouroboros` revision.
- [x] The PR is one coherent change and is ready to be squash-integrated.
- [x] The description explains any limitations, follow-up work, or compatibility
      impact.

The branch is a single commit on top of `ouroboros` at `1952e042` and touches
three files; `git diff ouroboros --name-only` returns exactly those three.
