### PR TITLE
test(ci): stabilize cross-platform path isolation

### DIFF
--- a/tests/test_packaged_cli.py
+++ b/tests/test_packaged_cli.py
@@ -22,6 +22,11 @@ def _make_bundle_root(tmp_path: pathlib.Path, root: pathlib.Path | None = None) 
     return root
 
 
+def _set_test_home(monkeypatch, home: pathlib.Path) -> None:
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+
 def test_packaged_cli_resolves_bundle_from_nested_bin(tmp_path):
     from ouroboros import packaged_cli
 
@@ -268,7 +273,7 @@ def test_installer_plan_chooses_user_local_path_dir(tmp_path, monkeypatch):
     home = tmp_path / "home"
     target_dir = home / ".local" / "bin"
     target_dir.mkdir(parents=True)
-    monkeypatch.setenv("HOME", str(home))
+    _set_test_home(monkeypatch, home)
     monkeypatch.setenv("PATH", str(target_dir))
 
     plan = plan_posix_install(root)
@@ -286,7 +291,7 @@ def test_installer_plan_ignores_ambient_path_dirs(tmp_path, monkeypatch):
     harness_dir.mkdir(parents=True)
     system_dir = tmp_path / "system-bin"
     system_dir.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    _set_test_home(monkeypatch, home)
     monkeypatch.setenv("PATH", os.pathsep.join([str(harness_dir), str(system_dir)]))
 
     plan = plan_posix_install(root)
@@ -309,7 +314,7 @@ def test_installer_default_migrates_owned_shadowing_shim(tmp_path, monkeypatch, 
     os.chmod(root / "bin" / "ouroboros", 0o755)
     os.chmod(old_root / "bin" / "ouroboros", 0o755)
     os.symlink(old_root / "bin" / "ouroboros", old_shim)
-    monkeypatch.setenv("HOME", str(home))
+    _set_test_home(monkeypatch, home)
     monkeypatch.setenv("PATH", os.pathsep.join([str(harness_dir), str(target_dir)]))
 
     plan = plan_posix_install(root)
@@ -344,7 +349,7 @@ def test_installer_keeps_unowned_shadowing_command(tmp_path, monkeypatch, capsys
     earlier_command = harness_dir / "ouroboros"
     earlier_command.write_text("#!/bin/sh\necho foreign\n", encoding="utf-8")
     os.chmod(earlier_command, 0o755)
-    monkeypatch.setenv("HOME", str(home))
+    _set_test_home(monkeypatch, home)
     monkeypatch.setenv("PATH", os.pathsep.join([str(harness_dir), str(target_dir)]))
 
     plan = plan_posix_install(root)
@@ -372,7 +377,7 @@ def test_installer_explicit_target_does_not_migrate_owned_shadow(tmp_path, monke
     explicit_dir = home / "bin"
     old_shim = harness_dir / "ouroboros"
     os.symlink(old_root / "bin" / "ouroboros", old_shim)
-    monkeypatch.setenv("HOME", str(home))
+    _set_test_home(monkeypatch, home)
     monkeypatch.setenv("PATH", os.pathsep.join([str(harness_dir), str(explicit_dir)]))
 
     plan = plan_posix_install(root, target_dir=explicit_dir)
@@ -398,7 +403,7 @@ def test_installer_removes_old_shim_only_after_new_install_succeeds(tmp_path, mo
     target_dir = home / ".local" / "bin"
     old_shim = harness_dir / "ouroboros"
     os.symlink(old_root / "bin" / "ouroboros", old_shim)
-    monkeypatch.setenv("HOME", str(home))
+    _set_test_home(monkeypatch, home)
     monkeypatch.setenv("PATH", os.pathsep.join([str(harness_dir), str(target_dir)]))
     plan = plan_posix_install(root)
 

--- a/tests/test_v6580_projects_foundation.py
+++ b/tests/test_v6580_projects_foundation.py
@@ -16,7 +16,20 @@ def _init_git_repo(path: pathlib.Path) -> None:
     (path / "README.md").write_text("x\n", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=str(path), check=True)
     subprocess.run(
-        ["git", "-c", "user.name=t", "-c", "user.email=t@local", "commit", "-qm", "init"],
+        [
+            "git",
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@local",
+            "-c",
+            "maintenance.auto=false",
+            "-c",
+            "gc.auto=0",
+            "commit",
+            "-qm",
+            "init",
+        ],
         cwd=str(path), check=True,
     )
 
@@ -135,8 +148,13 @@ def test_resolve_room_workspace_loud_fails_on_broken_working_dir(tmp_path):
 
     def _chmod_and_retry(func, path, _exc):
         # Windows: git object files are read-only; plain rmtree hits WinError 5.
-        os.chmod(path, stat.S_IWRITE)
-        func(path)
+        # Git maintenance may remove a transient lock between rmtree's failed
+        # unlink and this callback; an already-absent path is cleanup success.
+        try:
+            os.chmod(path, stat.S_IWRITE)
+            func(path)
+        except FileNotFoundError:
+            pass
 
     shutil.rmtree(gone, onerror=_chmod_and_retry)  # the folder disappears after registration
 
@@ -205,7 +223,20 @@ def _coop_tree_with_child_work(projects_root: pathlib.Path) -> tuple[pathlib.Pat
     (tree / "app.py").write_text("print('v1')\n", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=str(tree), check=True)
     subprocess.run(
-        ["git", "-c", "user.name=t", "-c", "user.email=t@local", "commit", "-qm", "child work"],
+        [
+            "git",
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@local",
+            "-c",
+            "maintenance.auto=false",
+            "-c",
+            "gc.auto=0",
+            "commit",
+            "-qm",
+            "child work",
+        ],
         cwd=str(tree), check=True,
     )
     patch = subprocess.run(


### PR DESCRIPTION
The macOS full-test job hit a race while deleting a temporary Git repository: Git 2.55 auto-maintenance removed `maintenance.lock` during the `shutil.rmtree` callback. The test helper now disables auto-maintenance for both temporary commits and treats an already-removed callback path as successful cleanup.

The Windows full-test job exposed five POSIX installer tests that set `HOME` but not `USERPROFILE`. Their shared helper now sets both, keeping `Path.home()` inside `tmp_path` on Windows.

Only tests changed; production code and version carriers are unchanged. Local verification passed 35 focused tests, full-tree Ruff F, the size-ratchet regeneration check, and a focused Cursor Fable review. No tag is created.
