### PR TITLE
test(ci): make Windows boundary checks deterministic

### DIFF
--- a/tests/test_delegated_subagent_transport.py
+++ b/tests/test_delegated_subagent_transport.py
@@ -5409,20 +5409,30 @@ def test_a_daemon_that_dies_mid_window_is_refused_not_reported_as_a_quiet_wait(
 
 def test_a_daemon_that_dies_only_at_the_spent_window_poll_still_expires_gracefully(
         tmp_path, monkeypatch):
-    """The other half of the same split, and the reason it is a split rather than a
-    removal. Once the window IS spent there is nothing left to wait for, so a daemon that
-    cannot answer the last poll is this window's expiry — the graceful typed payload,
-    built on what the wait already holds — and never a transport refusal raised out of a
-    tool that is still holding a live, possibly overpowered, run."""
+    """A failed final poll expires a spent window instead of refusing the wait, and preserves prior progress too."""
+    from types import SimpleNamespace
+
+    import ouroboros.tools.delegate as delegate
+
+    clock = {"now": 0.0}
+
+    def sleep(seconds):
+        clock["now"] += seconds
+
+    monkeypatch.setattr(
+        delegate,
+        "time",
+        SimpleNamespace(monotonic=lambda: clock["now"], sleep=sleep),
+    )
     stub = _DiesAfter(answers=1)
 
-    out, elapsed = _wait_against_a_streaming_run(
+    out, _ = _wait_against_a_streaming_run(
         _nanny_ctx(tmp_path), tmp_path, monkeypatch, wait_sec=1, stub=stub)
 
     assert out["status"] == "progress", out
     assert out["waited_sec"] == 1, out
     assert stub.seq == 2, f"the spent window still owes its last poll: {stub.seq}"
-    assert 0.9 <= elapsed < 6.0, elapsed
+    assert clock["now"] == pytest.approx(1.0)
 
 
 def test_the_last_poll_of_a_spent_window_is_bounded_not_skipped(tmp_path, monkeypatch):

--- a/tests/test_packaged_cli.py
+++ b/tests/test_packaged_cli.py
@@ -330,7 +330,8 @@ def test_installer_default_migrates_owned_shadowing_shim(tmp_path, monkeypatch, 
 
     assert not old_shim.is_symlink()
     assert plan.target.resolve() == (root / "bin" / "ouroboros").resolve()
-    assert shutil.which("ouroboros", path=os.environ["PATH"]) == str(plan.target)
+    if os.name != "nt":
+        assert shutil.which("ouroboros", path=os.environ["PATH"]) == str(plan.target)
 
     reinstall = plan_posix_install(root)
     assert reinstall.action == "refresh"


### PR DESCRIPTION
The full Windows matrix exposed two test-only portability defects after the first cleanup fix. One boundary test depended on the scheduler waking exactly at its monotonic deadline; the other asked Windows PATHEXT lookup to find an extensionless POSIX shim.

This makes the spent-window case deterministic with a clock local to the delegate module and keeps only the POSIX command-lookup assertion off Windows. The production wait and installer paths are unchanged, while Windows still executes the migration and filesystem assertions.

Verification passed 231 focused tests, a 20/20 timing stress loop, full-tree Ruff F, and diff checks. A focused Cursor Fable review returned SAFE TO COMMIT. No version carrier or tag changes are included.
