### PR TITLE
docs: simplify Trending award

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ouroboros
 
-<a href="#recognition"><img src="assets/github-trending.svg" width="250" height="55" alt="Highest independently observed rank: #9 on GitHub's weekly Python Trending list, August 2026"></a>
+<a href="https://github.com/oslook/github-trending/blob/1d61d20a46f66a9590286bf23a8ce8db99be3acf/2026-08-04/python_weekly_trending.json"><img src="assets/github-trending.svg" width="250" height="55" alt="GitHub Trending: #9 Python weekly, August 2026"></a>
 
 [![GitHub stars](https://img.shields.io/github/stars/razzant/ouroboros?style=flat&logo=github)](https://github.com/razzant/ouroboros/stargazers)
 [![Downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frazzant%2Fouroboros%2Fbadges%2Fdownloads.json)](https://github.com/razzant/ouroboros/releases)
@@ -32,10 +32,6 @@ The charts below are self-reported results on Terminal-Bench 2.1, OSWorld-Verifi
   <a href="https://ouroboros-agent.ai/benchmarks/"><img src="assets/bench-osworld.svg" width="375" alt="OSWorld-Verified: Ouroboros against the public leaderboard, including the matched Claude Sonnet-4.6 pair"></a>
   <a href="https://ouroboros-agent.ai/benchmarks/"><img src="assets/bench-cl-bench.svg" width="375" alt="CL-Bench: Ouroboros against in-context learning baselines, Claude Code, and Codex on matched models"></a>
 </p>
-
-## Recognition
-
-In August 2026, Ouroboros reached the highest independently observed rank of **#9** on GitHub's weekly Python Trending list. The result is preserved in an [ordered archive snapshot from August 4](https://github.com/oslook/github-trending/blob/1d61d20a46f66a9590286bf23a8ce8db99be3acf/2026-08-04/python_weekly_trending.json), an [independent archive snapshot from August 10](https://github.com/findmio/github-trending-api/blob/664b2aac5ce7c10fa31fa33b6a7b16a50b04ef44/raw/archives/2026-08-10/Python.week.json), and a [contemporary screenshot of GitHub Trending](https://t.me/abstractDL/437). Because GitHub Trending changes throughout the day, this is an observed historical rank rather than a claim of an official all-time maximum.
 
 ## Install
 

--- a/assets/github-trending.svg
+++ b/assets/github-trending.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="250" height="55" viewBox="0 0 250 55" role="img" aria-labelledby="title desc">
   <title id="title">GitHub Trending: #9 in Python, this week</title>
-  <desc id="desc">Highest independently observed rank in August 2026</desc>
+  <desc id="desc">Ranked #9 in Python weekly in August 2026</desc>
   <rect x="0.5" y="0.5" width="249" height="54" rx="10" fill="#fff" stroke="#4a0e99"/>
   <g fill="none" stroke="#49278e" stroke-linecap="round" stroke-width="1.5">
     <path d="M31 44C20 42 13 35 12 25"/>
@@ -20,6 +20,6 @@
   <g fill="#432787" font-family="Arial,Helvetica,sans-serif">
     <text x="64" y="16" font-size="9" letter-spacing="0.35">GITHUB TRENDING</text>
     <text x="64" y="34" font-size="14" font-weight="700">#9 Python · This Week</text>
-    <text x="64" y="47" font-size="8" letter-spacing="0.25">AUG 2026 · HIGHEST OBSERVED</text>
+    <text x="64" y="47" font-size="8" letter-spacing="0.25">AUGUST 2026</text>
   </g>
 </svg>


### PR DESCRIPTION
Removes the standalone Recognition section and its caveat-heavy prose. The award card now states only #9 Python weekly, August 2026, and links directly to the immutable archive snapshot.

Validation: SVG parse, git diff check, and 42 focused README and metadata tests. No version or changelog changes.