### PR TITLE
Pin the managed Claudexor runtime to 3.4.2

### DIFF
--- a/ouroboros/claudexor_runtime_pin.json
+++ b/ouroboros/claudexor_runtime_pin.json
@@ -1,12 +1,12 @@
 {
  "schema_version": 1,
  "release": {
-  "version": "3.4.0",
-  "build_sha": "d928b256f1cae483de5d4de2c5be97cf67efa0a9",
+  "version": "3.4.1",
+  "build_sha": "cd5ca16bf05e70c7801612b6dd931f6380ae2061",
   "protocol_major": 3,
-  "archive_url": "https://github.com/razzant/claudexor/releases/download/v3.4.0/claudexor-runtime-3.4.0.tar.gz",
-  "sha256": "389a7ef63c0228c68174d5e0b0a26e3ca88cc55b3fac6c2ff6524b286e81e031",
-  "size_bytes": 20772799,
+  "archive_url": "https://github.com/razzant/claudexor/releases/download/v3.4.1/claudexor-runtime-3.4.1.tar.gz",
+  "sha256": "947664d61348fd01e923e06beefdf154dd9ebb6528ffe38290802677c4b4fc23",
+  "size_bytes": 20790369,
   "node_version": "24.16.0",
   "node_artifacts": {
    "darwin-arm64": {


### PR DESCRIPTION
Claudexor 3.4.1 is published and this moves the managed runtime pin to it. The release is the Windows native-login groundwork grown from community PR #189: absolute paths that survive schema generation, an opt-in win32 kernel-birth-time process identity used only by the login lane, identity-gated taskkill termination with a disclosed leader-death proof, executable-image-only Windows binary resolution, case-aware Windows environment forwarding, a journal partition walker fix that stopped a Windows daemon from demanding recovery on its second start, and a required windows-latest CI lane.

Nothing here changes macOS or Linux behavior, so for Ouroboros this is a pin refresh rather than a functional change.

The diff is only ouroboros/claudexor_runtime_pin.json, all five release fields moving together. Pin bytes are verified against the published release assets: sha256 947664d61348fd01e923e06beefdf154dd9ebb6528ffe38290802677c4b4fc23 at 20790369 bytes, build cd5ca16bf05e70c7801612b6dd931f6380ae2061, and the digest matches both the release SHA256SUMS and the owner-signed runtime manifest.