### PR TITLE
Pin the managed Claudexor runtime to 3.4.2

### DIFF
--- a/ouroboros/claudexor_runtime_pin.json
+++ b/ouroboros/claudexor_runtime_pin.json
@@ -1,12 +1,12 @@
 {
  "schema_version": 1,
  "release": {
-  "version": "3.4.1",
-  "build_sha": "cd5ca16bf05e70c7801612b6dd931f6380ae2061",
+  "version": "3.4.2",
+  "build_sha": "9b3adc2176f041a779e28001d11b5f36ee10e829",
   "protocol_major": 3,
-  "archive_url": "https://github.com/razzant/claudexor/releases/download/v3.4.1/claudexor-runtime-3.4.1.tar.gz",
-  "sha256": "947664d61348fd01e923e06beefdf154dd9ebb6528ffe38290802677c4b4fc23",
-  "size_bytes": 20790369,
+  "archive_url": "https://github.com/razzant/claudexor/releases/download/v3.4.2/claudexor-runtime-3.4.2.tar.gz",
+  "sha256": "fe4238a8debd5d0b1176d130f4eadd50deb12d790f9f561084412c9b02836776",
+  "size_bytes": 20791039,
   "node_version": "24.16.0",
   "node_artifacts": {
    "darwin-arm64": {


### PR DESCRIPTION
Claudexor 3.4.2 is published; this moves the managed runtime pin to it. (Supersedes the closed #225, whose branch was deleted before 3.4.2 shipped.)

3.4.2 fixes the crash that killed every mutating delegated cursor run on macOS: `RetriableError: [internal] unable to open database file` (SQLITE_CANTOPEN). cursor-agent keeps its chat store in SQLite under the scoped HOME, SQLite canonicalizes the database path on open, and the Seatbelt confinement profile's runtime-root read deny covered the intermediate directories between the runtime root and the allowed scoped home. The metadata traversal carve-out now covers the union of every own root's denied ancestors (scoped home, worktree, native state root) while re-opening nothing else, so the delegation lanes this pin provisions stop dying on startup.

For Ouroboros this is a pin refresh: no macOS/Linux behavior change beyond the delegated-cursor lane starting to work, and the diff is only `ouroboros/claudexor_runtime_pin.json`, all five release fields moving together. Pin bytes are verified against the published release assets: sha256 `fe4238a8debd5d0b1176d130f4eadd50deb12d790f9f561084412c9b02836776` at 20791039 bytes, build `9b3adc2176f041a779e28001d11b5f36ee10e829`, and the digest matches the release SHA256SUMS, the GitHub asset digest, and the owner-signed runtime manifest verified against the trusted 3.4.1 authority.