### PR TITLE
chore(claudexor): drop write-only serving-mode state left by the #254 merge

### DIFF
--- a/ouroboros/claudexor_daemon.py
+++ b/ouroboros/claudexor_daemon.py
@@ -185,9 +185,6 @@ class OwnedClaudexorDaemon:
         self._last_error = ""
         self._engine_version = ""
         self._engine_build_sha = ""
-        # The last authenticated handshake's explicit servingMode ('' = the
-        # engine said nothing = normal).
-        self._serving_mode = ""
         # Rotation reconcile (B3): a non-blocking lock dedups CONCURRENT
         # ensures so they never double-POST settings; nothing else is gated.
         self._rotation_lock = threading.Lock()
@@ -214,7 +211,6 @@ class OwnedClaudexorDaemon:
         if not owned_daemon_provisioned():
             self._engine_version = ""
             self._engine_build_sha = ""
-            self._serving_mode = ""
             return None, "not_provisioned", ""
         try:
             endpoint = discover_daemon_at(owned_config_dir())
@@ -226,19 +222,13 @@ class OwnedClaudexorDaemon:
                 self._engine_version = gateway.engine_version
                 engine = handshake.get("engine") if isinstance(handshake.get("engine"), dict) else {}
                 self._engine_build_sha = str(engine.get("sha") or "")
-                # RECORDED, never waited on here: reachable-recovering is still
-                # "running" (the handshake proves identity and liveness), and
-                # admission is a separate, later question (`ensure_owned_gateway`).
-                self._serving_mode = _handshake_serving_mode(handshake)
+                # Reachable-recovering is still "running" (the handshake proves
+                # identity and liveness); admission is a separate, later
+                # question answered by `ensure_owned_gateway`'s own handshakes.
             return endpoint, "running", ""
         except ClaudexorUnavailable as exc:
             self._engine_version = ""
             self._engine_build_sha = ""
-            # ``_serving_mode`` is deliberately NOT cleared here: this method
-            # also runs unlocked (status polls), so a transient handshake
-            # failure must not clobber a just-recorded mode for concurrent
-            # readers. Failure paths never write the mode; it always holds
-            # the LAST SUCCESSFUL handshake's answer.
             status = int(getattr(exc, "status_code", 0) or 0)
             if status in (401, 403):
                 return None, "foreign_daemon", (

--- a/tests/test_claudexor_admission_wait.py
+++ b/tests/test_claudexor_admission_wait.py
@@ -64,8 +64,8 @@ def _recovery_server(token: str, *, normal_after, with_mode_field: bool = True):
     many handshakes (None = it recovers forever — blocked journal partitions).
     Product routes 503 typed while recovering, exactly the 3.4.2 wire shape.
     Threading server on purpose: the admission poll loop keeps ITS gateway's
-    keep-alive connection open while the deferred rotation patch opens a second
-    one, which would deadlock a single-threaded handler.
+    keep-alive connection open while the rotation reconcile's settings reads
+    use a second one, which would deadlock a single-threaded handler.
     """
     state = {"handshakes": 0, "normal_after": normal_after,
              "mode_field": with_mode_field}
@@ -354,7 +354,7 @@ def test_zero_admission_wait_refuses_immediately_when_recovering(monkeypatch, tm
 
 # ---------------------------------------------------------------------------
 # A6 (v): an engine that never says servingMode (pre-3.4) keeps today's exact
-# path — rotation at spawn time, no admission polls.
+# path — no admission polls; the reconcile rides the ensure as everywhere.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -102,7 +102,8 @@ EXPECTED_TOOLS = [
     "run_ci_tests",
     "advisory_review", "review_status",
     "compact_context", "set_tool_timeout", "request_restart",
-    "promote_to_stable", "schedule_subagent", "integrate_subagent_patch", "compare_subagent_patches",
+    "promote_to_stable", "schedule_subagent", "schedule_followup",
+    "integrate_subagent_patch", "compare_subagent_patches",
     # C1: the explicit acceptance seam for a delegated run's captured patch —
     # a first-class tool, so the registry contract must name it.
     "integrate_delegated_patch", "cancel_task",


### PR DESCRIPTION
## Summary
The #254 merge superseded the sprint's spawn-time rotation deferral with the mainline `reconcile_rotation`, which left two cosmetic tails found by the post-merge agentic review (codex gpt-5.6-sol xhigh on proton0, verdict: merge resolution sound, no critical/major):

- `_serving_mode` became write-only state (admission reads its own handshake bodies; nothing reads the field) — removed, together with its now-misleading no-clobber comment.
- Two test comments still described the retired deferred-rotation mechanism — prose synced; assertions were already correct and non-vacuous.

No behavior change; `_handshake_serving_mode` and the admission wait are untouched.

## Test plan
- [x] `tests/test_claudexor_admission_wait.py` + `tests/test_claudexor_owned_daemon.py`: 87 passed (isolated data root)

## Addendum
Second commit: the post-#254 full-suite validation surfaced a pre-existing mainline gap — the rotation-visibility sprint (74c11db4) registered the `schedule_followup` tool without adding it to `EXPECTED_TOOLS`, so `test_smoke.py::test_tool_set_matches` fails on a pristine mainline checkout (reproduced on 98ee3168). One-line test fix; `tests/test_smoke.py`: 177 passed after it.
