### PR TITLE
Scope plan-panel lane health to a slot's pinned credential profile

### DIFF
--- a/ouroboros/tools/plan_review_runtime.py
+++ b/ouroboros/tools/plan_review_runtime.py
@@ -404,23 +404,39 @@ def plan_payload_roots(ctx: ToolContext, locators: List[str]) -> list[pathlib.Pa
 # its per-ensure rotation reconcile — both bounded and fail-open (a spawn/probe
 # failure returns None here, never an exception).
 #
-# DISCLOSED LIMITATION: `subagents.route_health` — the ONE manifest reader — judges
-# a whole ROUTE (harness id + pinned model), never a slot's pinned credential
-# profile. A live sibling profile can therefore mask a pinned slot's exhaustion:
-# such a slot dispatches (fail-open) and fails typed downstream (B1). No second
-# health oracle is built here. api_chat rows have no route health source at all
-# and always dispatch. Cursor lanes without quota snapshots simply dispatch too.
+# SCOPE OF THE ANSWER: `subagents.route_health` — the ONE manifest reader — judges
+# a ROUTE (harness id + pinned model) NARROWED to the slot's pinned credential
+# profile whenever the row pins one, exactly as the dispatcher asks it
+# (`review_execution`: a pin is strict, so a healthy sibling account must not vouch
+# a spent pin). A row that pins NO profile keeps the route-wide answer: which
+# account an unpinned run lands on is Claudexor's rotation business, so a route
+# whose pool still holds a live account reads healthy — such a slot dispatches
+# (fail-open) and fails typed downstream (B1) if rotation lands it badly. No second
+# health oracle is built here. api_chat rows have no route health source at all and
+# always dispatch. Cursor lanes without quota snapshots simply dispatch too.
 
 
 def _slot_session_route(slot: Any) -> Any:
     """The route an agent_session slot would dispatch on (None when unresolvable —
-    the dispatch path owns that refusal; health has nothing to say about it)."""
+    the dispatch path owns that refusal; health has nothing to say about it).
+
+    Mirrors the dispatcher's own resolution (`review_execution` `_session_route`)
+    including the row's optional credential pin, so health judges the SAME account
+    the run would actually ride. Effort is deliberately NOT mirrored: health reads
+    route identity, model and profile only.
+    """
+    import dataclasses
+
     from ouroboros.review_execution import review_session_route
     from ouroboros.subagents import parse_subagent_harness
 
     spec = str(getattr(slot, "session_target", "") or "")
     if spec:
-        return parse_subagent_harness(spec)
+        route = parse_subagent_harness(spec)
+        pin = str(getattr(slot, "session_profile", "") or "")
+        if route is not None and pin:
+            route = dataclasses.replace(route, profile_id=pin)
+        return route
     return review_session_route()
 
 
@@ -470,10 +486,16 @@ def plan_panel_health_snapshot(slots: list) -> Optional[Dict[str, Dict[str, str]
             route = _slot_session_route(slot)
             if route is None:
                 continue
-            key = (route.route_id, route.model)
+            # The PIN is part of the subject, so it is part of the memo key: two
+            # rows on the same harness+model but different accounts must never
+            # share one verdict (a spent pin would otherwise be vouched for by a
+            # sibling's health, or vice versa).
+            pin = str(getattr(route, "profile_id", "") or "")
+            key = (route.route_id, route.model, pin)
             if key not in by_route:
                 by_route[key] = route_health(gateway, route.route_id, shape,
-                                             route_model=route.model)
+                                             route_model=route.model,
+                                             pinned_profile=pin)
             code = _structural_skip_code(*by_route[key])
             if code:
                 evidence[str(getattr(slot, "slot_id", "") or "")] = {
@@ -502,6 +524,13 @@ def plan_health_skip_rows(slots: list, evidence: Optional[Dict[str, Dict[str, st
             live.append(slot)
             continue
         code, reset = str(ev.get("failure_code") or ""), str(ev.get("reset_at") or "")
+        pin = str(getattr(slot, "session_profile", "") or "")
+        scope = (
+            f"Evidence is scoped to this slot's pinned credential profile {pin!r}."
+            if pin else
+            "Evidence is route-wide: this slot pins no credential profile, so the "
+            "answer covers the route's rotation pool rather than one account."
+        )
         rows.append({
             "slot_id": str(getattr(slot, "slot_id", "") or ""),
             "model": str(getattr(slot, "model", "") or ""),
@@ -510,8 +539,7 @@ def plan_health_skip_rows(slots: list, evidence: Optional[Dict[str, Dict[str, st
             "error": (
                 f"health_skip[{code}]: the pre-fan-out panel health snapshot shows this "
                 f"slot's delegated route window spent{f' (resets {reset})' if reset else ''}; "
-                "skipped before dispatch at $0. Route-level evidence only: the snapshot "
-                "judges the whole route, not a pinned credential profile."
+                f"skipped before dispatch at $0. {scope}"
             ),
             "failure_code": code, "reset_at": reset,
             "prompt_ref": {}, "response_ref": {}, "tokens_in": 0, "tokens_out": 0, "cost": 0.0,

--- a/tests/test_plan_review_epoch.py
+++ b/tests/test_plan_review_epoch.py
@@ -330,3 +330,117 @@ def test_cached_replay_of_an_open_wave_retries_a_failed_advisory_open_append(har
     rows = [json.loads(line) for line in
             events_path.read_text(encoding="utf-8").splitlines()]
     assert len([r for r in rows if r.get("type") == "plan_review_advisory_open"]) == 1
+
+
+# --------------------------------------------- panel health is PROFILE-scoped
+
+
+def _profile_slots(*specs):
+    """``specs`` = (slot_id, session_target, profile) → agent_session ``ReviewSlot``s."""
+    from ouroboros.review_execution import ReviewRouteKind
+    from ouroboros.review_substrate import ReviewSlot
+
+    return [
+        ReviewSlot(slot_id=sid, model="delegated", effort="high",
+                   role_hint="plan reviewer", route=ReviewRouteKind.AGENT_SESSION,
+                   session_target=target, session_profile=profile)
+        for sid, target, profile in specs
+    ]
+
+
+def _patch_snapshot_health(monkeypatch, answer):
+    """Run the REAL snapshot against a fake daemon; ``answer(route_id, model, pin)``
+    returns ``(reason, reset_at)``. Records every ask so memo scoping is provable."""
+    import ouroboros.claudexor_daemon as cd
+    import ouroboros.subagents as sa
+
+    asked: list[tuple[str, str, str]] = []
+
+    class _Gateway:
+        def close(self):
+            pass
+
+    def _health(gateway, route_id, shape, *, route_model="", pinned_profile=""):
+        asked.append((route_id, route_model, pinned_profile))
+        return answer(route_id, route_model, pinned_profile)
+
+    monkeypatch.setattr(cd, "owned_daemon_provisioned", lambda: True)
+    monkeypatch.setattr(cd, "ensure_owned_gateway", _Gateway)
+    monkeypatch.setattr(sa, "route_health", _health)
+    return asked
+
+
+_SPENT = ("subscription_window_exhausted", "2030-01-01T00:00:00+00:00")
+_HEALTHY = ("", "")
+
+
+def test_snapshot_skips_a_slot_whose_pinned_profile_is_spent(monkeypatch):
+    """A slot pinning a spent account is skipped even though the route AGGREGATE
+    (the unpinned answer a sibling account still vouches for) reads healthy: the
+    pin rides into the health read exactly as it does at dispatch."""
+    from ouroboros.tools.plan_review_runtime import plan_panel_health_snapshot
+
+    asked = _patch_snapshot_health(
+        monkeypatch, lambda rid, model, pin: _SPENT if pin == "spent-acct" else _HEALTHY)
+    slots = _profile_slots(("s1", "codex=gpt-5.6-sol", "spent-acct"))
+    assert plan_panel_health_snapshot(slots) == {
+        "s1": {"failure_code": "subscription_window_exhausted",
+               "reset_at": "2030-01-01T00:00:00+00:00"}}
+    assert asked == [("codex", "gpt-5.6-sol", "spent-acct")]
+
+
+def test_same_route_different_profiles_do_not_share_one_health_verdict(monkeypatch):
+    """The memo is keyed by the SUBJECT, pin included: two rows on the same
+    harness+model but different accounts are asked separately, so exactly the spent
+    one is skipped and the healthy one still dispatches."""
+    from ouroboros.tools.plan_review_runtime import (
+        plan_health_skip_rows, plan_panel_health_snapshot,
+    )
+
+    asked = _patch_snapshot_health(
+        monkeypatch, lambda rid, model, pin: _SPENT if pin == "spent-acct" else _HEALTHY)
+    slots = _profile_slots(("s1", "codex=gpt-5.6-sol", "spent-acct"),
+                           ("s2", "codex=gpt-5.6-sol", "live-acct"))
+    evidence = plan_panel_health_snapshot(slots)
+    assert set(evidence) == {"s1"}
+    assert asked == [("codex", "gpt-5.6-sol", "spent-acct"),
+                     ("codex", "gpt-5.6-sol", "live-acct")]
+    live, rows = plan_health_skip_rows(slots, evidence)
+    assert [s.slot_id for s in live] == ["s2"]
+    assert len(rows) == 1 and rows[0]["slot_id"] == "s1"
+    assert "'spent-acct'" in rows[0]["error"] and rows[0]["cost"] == 0.0
+    # And the memo still WORKS: a repeated identical subject is asked only once.
+    asked.clear()
+    plan_panel_health_snapshot(slots + _profile_slots(
+        ("s3", "codex=gpt-5.6-sol", "spent-acct")))
+    assert asked == [("codex", "gpt-5.6-sol", "spent-acct"),
+                     ("codex", "gpt-5.6-sol", "live-acct")]
+
+
+def test_unpinned_slots_keep_the_route_wide_answer(monkeypatch):
+    """No regression for rows that pin nothing: the ask carries an empty profile
+    (rotation stays Claudexor's business) and the skip row says so plainly."""
+    from ouroboros.tools.plan_review_runtime import (
+        plan_health_skip_rows, plan_panel_health_snapshot,
+    )
+
+    asked = _patch_snapshot_health(monkeypatch, lambda rid, model, pin: _SPENT)
+    slots = _profile_slots(("s1", "codex=gpt-5.6-sol", ""))
+    evidence = plan_panel_health_snapshot(slots)
+    assert set(evidence) == {"s1"} and asked == [("codex", "gpt-5.6-sol", "")]
+    _live, rows = plan_health_skip_rows(slots, evidence)
+    assert "route-wide" in rows[0]["error"] and "pins no credential profile" in rows[0]["error"]
+
+
+def test_transient_and_unknown_health_still_fail_open_for_a_pinned_slot(monkeypatch):
+    """Fail-open is unchanged by the narrowing: an undated exhaustion, a transient
+    daemon state and an unknown reason on a PINNED row all dispatch (no skip row)."""
+    from ouroboros.tools.plan_review_runtime import plan_panel_health_snapshot
+
+    for reason, reset in (("subscription_window_exhausted", ""),
+                          ("daemon_recovery_only", ""),
+                          ("route_status_disabled", ""),
+                          ("", "2001-01-01T00:00:00Z")):
+        _patch_snapshot_health(monkeypatch, lambda rid, model, pin, r=reason, t=reset: (r, t))
+        assert plan_panel_health_snapshot(
+            _profile_slots(("s1", "codex=gpt-5.6-sol", "spent-acct"))) == {}, reason


### PR DESCRIPTION
## Why

The delegation-substrate fix taught `subagents.route_health` to honour a slot's pinned credential profile, and `review_execution` forwards it ("a healthy sibling account must not vouch a spent pin"). The plan-review panel's pre-fan-out health snapshot, added by the rotation-visibility sprint, never got that treatment: it asked `route_health` about the whole route and memoised the answer under `(route_id, model)`.

Two consequences on the current branch tip:

- a plan-review slot pinned to a spent account was not skipped while a sibling account of the same route was healthy (the limitation the module disclosed as unavoidable, which it no longer is);
- worse, two slots sharing a harness and model but pinning **different** accounts shared one cached verdict, so one account's health silently spoke for the other.

## What changed

- `_slot_session_route` now applies the row's `session_profile` the same way the dispatcher does (`review_execution._session_route`), so the pin reaches the health reader.
- The snapshot passes `pinned_profile=` and keys its memo on `(route_id, model, pin)` — per-profile verdicts can no longer collide.
- The stale "DISCLOSED LIMITATION" block and the skip-row text now state the current truth: evidence is profile-scoped when the row pins an account, route-wide (the rotation pool) when it does not.

## Evidence

Four new tests in `tests/test_plan_review_epoch.py`: a pinned-but-spent slot is skipped while the route aggregate is healthy; two slots on one route with different pins are asked separately and only the spent one is skipped; unpinned slots keep the route-wide answer; transient and unknown health still fail open for a pinned slot.

Discriminator: with `plan_review_runtime.py` reverted to HEAD, three of the four fail (the fourth is the no-regression pin, green either way). With the fix: `tests/test_plan_review_epoch.py tests/test_plan_review.py tests/test_plan_review_engine.py tests/test_review_agent_session_route.py tests/test_repo_health_smoke.py` → 281 passed, exit 0; `ruff check --select F` clean. Version carriers untouched.
