### PR TITLE
Bounded Windows sharing-violation retry in the atomic state writer

### DIFF
--- a/ouroboros/claudexor_runtime.py
+++ b/ouroboros/claudexor_runtime.py
@@ -31,6 +31,8 @@ from dataclasses import dataclass
 from typing import Any, Mapping, Optional
 from urllib.parse import urlparse
 
+from ouroboros.utils import replace_atomic
+
 log = logging.getLogger(__name__)
 
 _PIN_SCHEMA_VERSION = 1
@@ -366,7 +368,7 @@ def _fetch_exact_file(
                     sink.flush()
                     os.fsync(sink.fileno())
         verify(temporary)
-        os.replace(temporary, target)
+        replace_atomic(temporary, target)
         return verify(target)
     except ClaudexorRuntimeError:
         raise
@@ -981,7 +983,7 @@ class ClaudexorRuntimeManager:
             try:
                 shutil.copyfile(seed, temporary)
                 verify_runtime_archive(temporary, pin)
-                os.replace(temporary, cache)
+                replace_atomic(temporary, cache)
                 return verify_runtime_archive(cache, pin), "bundle_seed"
             finally:
                 try:

--- a/ouroboros/config.py
+++ b/ouroboros/config.py
@@ -1459,9 +1459,10 @@ def save_settings(
                 f"{baseline_mode!r} -> {new_mode!r}.{hint}"
             )
         try:
+            from ouroboros.utils import replace_atomic
             tmp = SETTINGS_PATH.with_suffix(".tmp")
             tmp.write_text(json.dumps(settings, indent=2), encoding="utf-8")
-            os.replace(str(tmp), str(SETTINGS_PATH))
+            replace_atomic(str(tmp), str(SETTINGS_PATH))
         except OSError:
             SETTINGS_PATH.write_text(json.dumps(settings, indent=2), encoding="utf-8")
     finally:

--- a/ouroboros/consolidator.py
+++ b/ouroboros/consolidator.py
@@ -5,7 +5,7 @@ import pathlib
 from typing import Any, Dict, List, Optional, Tuple
 
 from ouroboros.contracts.chat_id_policy import is_a2a_chat_id
-from ouroboros.utils import atomic_write_json, read_json_dict, utc_now_iso, read_text, write_text
+from ouroboros.utils import atomic_write_json, read_json_dict, replace_atomic, utc_now_iso, read_text, write_text
 
 from ouroboros.platform_layer import (
     file_lock_exclusive as _lock_ex,
@@ -469,7 +469,7 @@ def _load_blocks(path: pathlib.Path) -> List[Dict[str, Any]]:
         # for forensic recovery instead of overwriting it on the next write.
         quarantine = path.with_name(f"{path.name}.corrupt-{utc_now_iso().replace(':', '')}.bak")
         try:
-            os.replace(path, quarantine)
+            replace_atomic(path, quarantine)
             log.error("Corrupt blocks file %s — quarantined to %s, starting fresh", path, quarantine)
         except OSError:
             log.error("Corrupt blocks file %s — quarantine failed, starting fresh", path, exc_info=True)

--- a/ouroboros/headless.py
+++ b/ouroboros/headless.py
@@ -23,7 +23,7 @@ from ouroboros.task_results import (
     TASK_COST_META_FIELDS,
     cancellation_blocks_child_result, load_task_result, validate_task_id, write_task_result,
 )
-from ouroboros.utils import atomic_write_json, utc_now_iso
+from ouroboros.utils import atomic_write_json, replace_atomic, utc_now_iso
 
 log = logging.getLogger(__name__)
 
@@ -488,7 +488,7 @@ def _publish_child_verification_receipts(
             return  # shared-drive shape: already the canonical file
         tmp = dest.with_name(f"{dest.name}.tmp.{os.getpid()}")
         shutil.copy2(src, tmp)
-        os.replace(tmp, dest)
+        replace_atomic(tmp, dest)
     except Exception:
         log.warning("Failed to publish child receipts for task %s", task_id, exc_info=True)
 

--- a/ouroboros/observability.py
+++ b/ouroboros/observability.py
@@ -18,7 +18,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
-from ouroboros.utils import atomic_write_json, utc_now_iso
+from ouroboros.utils import atomic_write_json, replace_atomic, utc_now_iso
 
 
 OBSERVABILITY_DIR = "observability"
@@ -279,7 +279,7 @@ def write_blob(drive_root: pathlib.Path, payload: Any, *, kind: str = "json") ->
             with gzip.open(tmp, "wb") as fh:
                 fh.write(raw)
             _chmod_private(tmp)
-            os.replace(tmp, path)
+            replace_atomic(tmp, path)
             _chmod_private(path)
         except Exception:
             if path.exists():
@@ -629,7 +629,7 @@ def preserve_salvaged_output(preserve_root: pathlib.Path, task_id: str, text: st
     try:
         tmp.write_text(str(text), encoding="utf-8")
         _chmod_private(tmp)
-        os.replace(tmp, path)
+        replace_atomic(tmp, path)
         _chmod_private(path)
     except Exception:
         try:

--- a/ouroboros/packaged_cli.py
+++ b/ouroboros/packaged_cli.py
@@ -209,10 +209,12 @@ def _hidden_run(command: Sequence[str], **kwargs: object) -> subprocess.Complete
 
 
 def _save_settings(path: pathlib.Path, settings: dict) -> None:
+    from ouroboros.utils import replace_atomic
+
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(json.dumps(settings, indent=2), encoding="utf-8")
-    os.replace(tmp, path)
+    replace_atomic(tmp, path)
 
 
 def _run_inner_cli(runtime: PackagedRuntime, args: Sequence[str]) -> int:

--- a/ouroboros/process_custody.py
+++ b/ouroboros/process_custody.py
@@ -274,7 +274,7 @@ def _rewrite_ledger(drive_root: pathlib.Path, entries: List[Dict[str, Any]]) -> 
 
     path = ledger_path(drive_root)
     try:
-        from ouroboros.utils import jsonl_append_lock_path
+        from ouroboros.utils import jsonl_append_lock_path, replace_atomic
         from ouroboros.platform_layer import acquire_exclusive_file_lock, release_exclusive_file_lock
 
         lock_path = jsonl_append_lock_path(path)
@@ -285,7 +285,7 @@ def _rewrite_ledger(drive_root: pathlib.Path, entries: List[Dict[str, Any]]) -> 
                 "".join(json.dumps(entry, ensure_ascii=False) + "\n" for entry in entries),
                 encoding="utf-8",
             )
-            os.replace(tmp, path)
+            replace_atomic(tmp, path)
         finally:
             release_exclusive_file_lock(lock_path, lock_fd)
     except Exception:

--- a/ouroboros/project_dialogue.py
+++ b/ouroboros/project_dialogue.py
@@ -16,7 +16,7 @@ import uuid
 from typing import Any, Dict, Iterable, List
 
 from ouroboros.platform_layer import acquire_exclusive_file_lock, release_exclusive_file_lock
-from ouroboros.utils import iter_jsonl_objects, jsonl_append_lock_path, utc_now_iso
+from ouroboros.utils import iter_jsonl_objects, jsonl_append_lock_path, replace_atomic, utc_now_iso
 
 _ANNOTATIONS_NAME = "chat_annotations.jsonl"
 _COMPACT_AT_BYTES = 800_000
@@ -186,7 +186,7 @@ def _compact_annotations_locked(drive_root: Any, path: pathlib.Path) -> None:
         os.fsync(fd)
     finally:
         os.close(fd)
-    os.replace(tmp, path)
+    replace_atomic(tmp, path)
 
 
 def append_chat_annotation(

--- a/ouroboros/task_continuation.py
+++ b/ouroboros/task_continuation.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import json
-import os
 import pathlib
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
-from ouroboros.utils import atomic_write_json, utc_now_iso
+from ouroboros.utils import atomic_write_json, replace_atomic, utc_now_iso
 
 _CONTINUATION_DIR_RELPATH = "state/review_continuations"
 _CORRUPT_DIR_NAME = "corrupt"
@@ -358,7 +357,7 @@ def _quarantine_corrupt_continuation(drive_root: Any, task_id: str, *, reason: s
     corrupt_dir = corrupt_continuation_dir(drive_root)
     archived = corrupt_dir / f"{task_id}.{stamp}.json"
     note = archived.with_suffix(".txt")
-    os.replace(src, archived)
+    replace_atomic(src, archived)
     note.write_text(reason.strip() or "corrupt continuation quarantined", encoding="utf-8")
 
 

--- a/ouroboros/usage_ledger.py
+++ b/ouroboros/usage_ledger.py
@@ -25,7 +25,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterator, Optional, Sequence, Tuple
 
-from ouroboros.utils import append_jsonl, utc_now_iso
+from ouroboros.utils import append_jsonl, replace_atomic, utc_now_iso
 
 log = logging.getLogger(__name__)
 
@@ -186,7 +186,7 @@ def _write_bytes_atomic_fsync(path: pathlib.Path, payload: bytes) -> None:
         os.fsync(fd)
         os.close(fd)
         fd = None
-        os.replace(tmp, path)
+        replace_atomic(tmp, path)
     except Exception:
         if fd is not None:
             os.close(fd)

--- a/ouroboros/utils.py
+++ b/ouroboros/utils.py
@@ -120,6 +120,37 @@ def write_text(path: pathlib.Path, content: str) -> None:
     write_text_atomic(pathlib.Path(path), content)
 
 
+# Windows sharing-violation retry bound: os.replace over a file that another
+# thread/process holds open (CPython opens files WITHOUT FILE_SHARE_DELETE)
+# raises PermissionError (winerror 5/32) even though the reader is transient —
+# e.g. the skill-review heartbeat replacing review_job.json while a poller
+# reads it. ~10 attempts with doubling backoff ≈ 0.5s total, then the original
+# PermissionError is raised honestly.
+_REPLACE_RETRY_ATTEMPTS = 10
+_REPLACE_RETRY_INITIAL_DELAY_SEC = 0.002
+_REPLACE_RETRY_MAX_DELAY_SEC = 0.1
+
+
+def replace_atomic(src: pathlib.Path | str, dst: pathlib.Path | str) -> None:
+    """``os.replace`` with a bounded retry on Windows sharing violations.
+
+    Retries ONLY on PermissionError, which POSIX rename(2) never raises for an
+    open destination — so POSIX behavior is byte-identical (one syscall, no
+    sleeps). After the bound is exhausted the last PermissionError propagates
+    unchanged; every other exception propagates immediately.
+    """
+    delay = _REPLACE_RETRY_INITIAL_DELAY_SEC
+    for attempt in range(_REPLACE_RETRY_ATTEMPTS):
+        try:
+            os.replace(src, dst)
+            return
+        except PermissionError:
+            if attempt == _REPLACE_RETRY_ATTEMPTS - 1:
+                raise
+            time.sleep(delay)
+            delay = min(delay * 2, _REPLACE_RETRY_MAX_DELAY_SEC)
+
+
 def write_text_atomic(
     path: pathlib.Path,
     content: str,
@@ -168,7 +199,7 @@ def write_text_atomic(
                 os.chmod(tmp, existing_mode)
             except OSError:
                 pass
-        os.replace(tmp, path)
+        replace_atomic(tmp, path)
     except Exception:
         try:
             tmp.unlink()

--- a/tests/test_atomic_write_v639.py
+++ b/tests/test_atomic_write_v639.py
@@ -62,3 +62,61 @@ def test_atomic_write_json_still_works(tmp_path):
     atomic_write_json(target, {"a": 1, "b": [2, 3]})
     import json
     assert json.loads(target.read_text(encoding="utf-8")) == {"a": 1, "b": [2, 3]}
+
+
+def test_replace_retries_windows_sharing_violation_then_succeeds(tmp_path, monkeypatch):
+    """Transient PermissionError (Windows winerror 5/32 sharing violation: a
+    reader holds the destination open without FILE_SHARE_DELETE) must be
+    absorbed by a bounded retry — the write lands and the file is intact."""
+    target = tmp_path / "job.json"
+    target.write_text("OLD", encoding="utf-8")
+    real_replace = utils.os.replace
+    calls = {"n": 0}
+
+    def _flaky_replace(src, dst):
+        calls["n"] += 1
+        if calls["n"] <= 3:
+            raise PermissionError(13, "The process cannot access the file")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(utils.os, "replace", _flaky_replace)
+    monkeypatch.setattr(utils.time, "sleep", lambda _s: None)
+    write_text_atomic(target, "NEW")
+    assert calls["n"] == 4
+    assert target.read_text(encoding="utf-8") == "NEW"
+    assert not list(tmp_path.glob(".job.json.tmp.*"))
+
+
+def test_replace_raises_permission_error_after_bounded_retries(tmp_path, monkeypatch):
+    """A persistent PermissionError (a genuinely locked file) must surface
+    honestly after the retry bound — never swallowed, never unbounded."""
+    target = tmp_path / "job.json"
+    target.write_text("OLD", encoding="utf-8")
+    calls = {"n": 0}
+
+    def _always_denied(src, dst):
+        calls["n"] += 1
+        raise PermissionError(13, "The process cannot access the file")
+
+    monkeypatch.setattr(utils.os, "replace", _always_denied)
+    monkeypatch.setattr(utils.time, "sleep", lambda _s: None)
+    with pytest.raises(PermissionError):
+        write_text_atomic(target, "NEW CONTENT THAT NEVER LANDS")
+    assert calls["n"] == utils._REPLACE_RETRY_ATTEMPTS
+    assert target.read_text(encoding="utf-8") == "OLD"
+    assert not list(tmp_path.glob(".job.json.tmp.*"))
+
+
+def test_replace_atomic_does_not_retry_other_oserrors(tmp_path, monkeypatch):
+    """Only the Windows sharing-violation class retries; any other OSError
+    (POSIX-visible failures included) propagates on the first attempt."""
+    calls = {"n": 0}
+
+    def _boom(src, dst):
+        calls["n"] += 1
+        raise OSError("disk detached")
+
+    monkeypatch.setattr(utils.os, "replace", _boom)
+    with pytest.raises(OSError):
+        utils.replace_atomic(tmp_path / "a", tmp_path / "b")
+    assert calls["n"] == 1


### PR DESCRIPTION
Root fix for the recurring windows-latest CI flake (PermissionError on review_job.json in test_skill_review_persist_guard): CPython opens files without FILE_SHARE_DELETE on Windows, so os.replace over a file any concurrent reader holds open raises a sharing violation. The heartbeat/reconcile concurrency that the test exercises exists in production on Windows installs too.

The fix adds replace_atomic to the shared atomic writer (ouroboros/utils.py): os.replace retried only on PermissionError, 10 attempts with doubling backoff (~0.5s total), the original exception re-raised honestly after exhaustion; POSIX behavior is byte-identical (single syscall, no sleep). All 13 direct os.replace state-file sites migrate onto the helper (class closure); the four directory swaps in claudexor_runtime.py are deliberately untouched (different class with its own rollback logic).

Tests: new unit simulation (transient violation succeeds on retry; permanent violation raises after the bound with the old file intact); the ex-flaky test ran 20x clean; all touched-module suites and test_smoke green (exit 0).

Note: this was first landed directly on ouroboros as 6c9c1a49 and reverted in c96098c3 per the owner's request to route it through a PR; this PR cherry-picks the same change.