### PR TITLE
Fix account removal confirmation handling

### DIFF
--- a/web/modules/harness_accounts.js
+++ b/web/modules/harness_accounts.js
@@ -1026,25 +1026,35 @@ async function toggleAccountEnabled(harness, profileId, enabled) {
     renderRows();
 }
 
-async function confirmRemoveAccount(harness, profileId) {
+/**
+ * Complete destructive flow behind a row's Remove button. Injectable deps let
+ * the node suite drive the production handler; confirm mode authorizes only on
+ * its documented strict boolean `true`, never the input mode's object shape.
+ */
+export async function confirmRemoveAccount(harness, profileId, {
+    dialogImpl = openConfirmDialog,
+    removeImpl = removeAccount,
+    store = state.store,
+    renderImpl = renderRows,
+} = {}) {
     if (!harness || !profileId) return;
-    const family = familyLabel(harness, state.store.snapshot || {});
-    const answer = await openConfirmDialog({
+    const family = familyLabel(harness, store.snapshot || {});
+    const answer = await dialogImpl({
         title: 'Remove account',
         body: removeAccountConfirmBody(profileId, family),
         confirmLabel: 'Remove',
         danger: true,
     });
-    if (!answer?.confirmed) return;
+    if (answer !== true) return;
     state.removeError = '';
     try {
-        await removeAccount(harness, profileId);
+        await removeImpl(harness, profileId);
     } catch (error) {
         state.removeError = `Could not remove "${profileId}": ${error.message || error}. `
             + 'The account is unchanged.';
     }
-    await state.store.refresh();
-    renderRows();
+    await store.refresh();
+    renderImpl();
 }
 
 /**

--- a/web/tests/agents_tab.test.js
+++ b/web/tests/agents_tab.test.js
@@ -22,6 +22,7 @@ import {
     accountGroups,
     accountMetaLine,
     accountName,
+    confirmRemoveAccount,
     familyActionLabel,
     familyLabel,
     familyStatus,
@@ -626,6 +627,46 @@ test('a partial gap obeys the SAME fault precedence as a total one', () => {
 // ---------------------------------------------------------------------------
 // Removal.
 // ---------------------------------------------------------------------------
+
+test('Remove consumes the non-input confirm boolean and performs the mutation once', async () => {
+    const calls = [];
+    const store = {
+        snapshot: { harnesses: [{ id: 'claude', display_name: 'Claude Code' }] },
+        refresh: async () => calls.push(['refresh']),
+    };
+
+    await confirmRemoveAccount('claude', 'work', {
+        dialogImpl: async (options) => {
+            assert.notEqual(options.input, true);
+            assert.equal(options.danger, true);
+            assert.equal(options.confirmLabel, 'Remove');
+            calls.push(['dialog']);
+            return true;
+        },
+        removeImpl: async (harness, profileId) => calls.push(['remove', harness, profileId]),
+        store,
+        renderImpl: () => calls.push(['render']),
+    });
+
+    assert.deepEqual(calls, [
+        ['dialog'],
+        ['remove', 'claude', 'work'],
+        ['refresh'],
+        ['render'],
+    ]);
+
+    for (const resolution of [false, undefined, null, { confirmed: true }]) {
+        const skipped = [];
+        await confirmRemoveAccount('claude', 'work', {
+            dialogImpl: async () => { skipped.push(['dialog']); return resolution; },
+            removeImpl: async () => skipped.push(['remove']),
+            store: { snapshot: store.snapshot, refresh: async () => skipped.push(['refresh']) },
+            renderImpl: () => skipped.push(['render']),
+        });
+        assert.deepEqual(skipped, [['dialog']],
+            `resolution ${JSON.stringify(resolution)} must stop after the dialog`);
+    }
+});
 
 test('removing a named account goes through the engine contract, and says so', () => {
     const calls = [];


### PR DESCRIPTION
## Summary

The shared confirmation dialog returns a strict boolean in confirm mode, but the account Remove handler was reading `.confirmed` from that boolean. A confirmed `true` therefore returned before the DELETE request, making every named-account Remove button a no-op.

This change makes the real production handler accept only the documented boolean `true` and adds a regression test for the complete confirm → remove → refresh → render flow.

## Scope

In scope:

- Fix the frontend confirmation contract for named-account removal.
- Exercise the real production handler and destructive-dialog options in the Node suite.

Non-goals:

- No backend, daemon, account-storage, or version-carrier changes.
- No change to the shared status-store concurrency model. A status GET that began before the DELETE can still briefly repaint the old row until the next poll; it does not restore the deleted account and also affects existing enable/disable flows.

## Verification

- [x] Focused tests for the changed behavior pass.
- [x] The default local test suite passes, or the reason it was not run is below.
- [x] Lint/static checks relevant to this change pass.

Commands and results:

```text
node --test web/tests/*.test.js
419 passed, 0 failed; exit 0

node --check web/modules/harness_accounts.js
node --check web/tests/agents_tab.test.js
exit 0

OUROBOROS_DATA_DIR=<isolated-temp> python -m pytest -q \
  tests/test_web_dialogs_static.py \
  tests/test_agents_tab_static.py \
  tests/test_claudexor_owned_daemon.py::test_account_removal_is_the_engine_contract_and_refuses_out_loud
15 passed; exit 0

OUROBOROS_DATA_DIR=<isolated-temp> python -m pytest -q tests/test_smoke.py
passed; exit 0

ruff check . --select F
All checks passed; exit 0

git diff --check 923743e1484393a44d5f7001f5f076d9fc6e650b..125956300123e7f7b30717fd7e2da7dfae6dc762
exit 0
```

The new behavior test was also run as a negative control: with the injectable production flow in place but the old `answer?.confirmed` condition retained, it failed before the remove call; changing only the condition to strict boolean confirmation made it pass.

The broad default `make test` target was not run locally. The change is frontend-only; the full 419-test web suite, focused Python contract/static tests, smoke suite, and relevant lint checks were run, while CI remains the broad combined-tree gate.

## Visual evidence

- [ ] Not applicable; this PR has no visible UI change.
- [x] Before/after screenshots or other rendered-flow evidence are attached below.

Evidence:

An interactive browser check loaded the candidate's real account module, shared dialog, and styles against a stubbed removal endpoint. Clicking Remove opened the destructive confirmation with the expected account and harness copy; confirming invoked removal once and the row disappeared. No live credential or account state was mutated.

## Governance and documentation

- [x] I read `CONTRIBUTING.md`; for a substantive change I also read `BIBLE.md`, `docs/ARCHITECTURE.md`, `docs/DEVELOPMENT.md`, and `docs/CHECKLISTS.md` in full.
- [x] I updated tests and documentation where behavior or architecture changed.
- [x] I did not include secrets, local settings, runtime state, logs, caches, or generated build/review artifacts in the commit.
- [x] I did **not** bump `VERSION` or release-only version carriers; maintainers assign the collision-free release version during final integration.

The existing architecture and development docs already define confirm mode as strict boolean and require exact confirmation plus side effect in one injectable flow. The code now conforms to those docs, so no documentation edit was needed.

## Review evidence

- Review status (`PASS`, `NEEDS_CHANGES`, `INCOMPLETE`, or `NOT_RUN`): PASS
- Authoring agent/context: local operator context on a clean dedicated worktree
- Separate review agent/context: three read-only contexts: Claudexor Claude Code, Claudexor Cursor, and a fresh independent subagent
- Reviewer model and effort (when exposed): `claude-opus-5` at max; `cursor-grok-4.6-high` observed as Cursor Grok 4.6 High; independent subagent model not exposed
- Reviewed base SHA: `923743e1484393a44d5f7001f5f076d9fc6e650b`
- Reviewed head SHA: `125956300123e7f7b30717fd7e2da7dfae6dc762`
- Findings and disposition: no blocking or material findings. Reviewers independently identified the existing in-flight status-read repaint as a shared-store follow-up, not a defect introduced by this diff. Suggestions to centralize the strict predicate or expand junk-value test cases were advisory and intentionally left out of this microfix.
- Checks performed and coverage limitations: reviewers traced the dialog contract, production click wiring, DELETE helper, refresh/render ordering, adjacent callers, class-wide `.confirmed` uses, version carriers, size ratchet, and required checklists. Claude and Cursor did not execute tests; the authoring context and independent subagent supplied the recorded test evidence and browser inspection.
- Full review output or artifact link: durable Claudexor runs `run-0c9134e3b47b` (Claude) and `run-659c641c8e48` (Cursor); independent subagent verdict retained with the authoring task
- If not run, reason: n/a

The first Cursor submission requested `web=off` and was refused before model execution because that adapter cannot guarantee the policy. The successful rerun used `web=auto`; terminal telemetry reports the requested Grok model and `web.attempted=false`.

## Final checklist

- [x] The PR base branch is `ouroboros`.
- [x] The branch is based on a current `ouroboros` revision.
- [x] The PR is one coherent change and is ready for maintainer integration.
- [x] The description explains any limitations, follow-up work, or compatibility impact.
