### PR TITLE
Fix cross-provider tool schema compatibility and add full-registry canaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,10 @@
 # Tier 2.6 (Skill smoke): Push to ouroboros-stable / manual / tag                     → LIVE OuroborosHub official-skill install smoke (3-OS, ~5 min) + review→grant→enable-persistence flow on one cheap reviewer slot (ubuntu-only step, OPENROUTER_API_KEY, ~$1.2/run)
 # Tier 3 (Build+Release): Tag v*                                                       → PyInstaller + GitHub Release (~15 min)
 #
-# Tier 2.5 requires OPENROUTER_API_KEY / OPENAI_API_KEY / ANTHROPIC_API_KEY /
-# CLOUDRU_FOUNDATION_MODELS_API_KEY in
-# repository secrets and runs the `integration` pytest marker; locally these
-# tests are excluded by `addopts = -m 'not integration'` in pyproject.toml.
+# Tier 2.5 requires OPENROUTER_API_KEY / OPENAI_API_KEY / ANTHROPIC_API_KEY.
+# Optional MiniMax / Cloud.ru / GigaChat rows run when their repository secrets
+# exist. The job runs the `integration` pytest marker; locally these tests are
+# excluded by `addopts = -m 'not integration'` in pyproject.toml.
 
 name: CI
 
@@ -145,13 +145,12 @@ jobs:
   # ──────────────────────────────────────────────────────────────────
   # Tier 2.5: Integration tests against real provider APIs
   # Triggered on push to main / ouroboros / ouroboros-stable, manual,
-  # or tag v*. Requires OPENROUTER_API_KEY / OPENAI_API_KEY /
-  # ANTHROPIC_API_KEY / CLOUDRU_FOUNDATION_MODELS_API_KEY in repository secrets. The `integration` pytest
-  # marker (in pyproject.toml) controls inclusion via `-m integration`;
-  # within an included test file, missing-key skipping is done by per-
-  # test `@pytest.mark.skipif(not os.environ.get(KEY))` decorators (see
-  # tests/test_provider_integration.py). NOT a `needs:` of build/
-  # release: a provider outage must not block a tagged release.
+  # or tag v*. OPENROUTER_API_KEY / OPENAI_API_KEY / ANTHROPIC_API_KEY
+  # are required in the official trusted job; MiniMax / Cloud.ru / GigaChat
+  # credentials are optional and their absent rows remain visible as skips.
+  # The `integration` pytest marker controls inclusion via `-m integration`.
+  # Confirmed provider-contract failures block release-preflight; the test
+  # classifier keeps quota/rate-limit/5xx/timeout outcomes inconclusive.
   # ──────────────────────────────────────────────────────────────────
   integration-test:
     if: |
@@ -169,9 +168,11 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
           CLOUDRU_FOUNDATION_MODELS_API_KEY: ${{ secrets.CLOUDRU_FOUNDATION_MODELS_API_KEY }}
           CLOUDRU_FOUNDATION_MODELS_BASE_URL: ${{ secrets.CLOUDRU_FOUNDATION_MODELS_BASE_URL }}
-        run: python -m pytest tests/test_provider_integration.py -m integration -q --tb=short
+          GIGACHAT_CREDENTIALS: ${{ secrets.GIGACHAT_CREDENTIALS }}
+        run: python -m pytest tests/test_provider_integration.py -m integration -q -rs --tb=short
 
   # ──────────────────────────────────────────────────────────────────
   # Tier 2.6: Official-skill install smoke against the LIVE OuroborosHub
@@ -183,8 +184,9 @@ jobs:
   # broken official skill); there is deliberately NO fallback-skip on
   # network failure, and gating the release on live external services
   # (GitHub raw, PyPI, DuckDuckGo, wttr.in, OpenRouter) is a deliberate
-  # owner decision — the opposite trade-off from integration-test, which is
-  # deliberately NOT a release need. Runs the `skill_smoke` pytest marker
+  # owner decision. Provider integration is now a separate release-preflight
+  # dependency with typed inconclusive outcomes for transient outages. Runs
+  # the `skill_smoke` pytest marker
   # (pyproject.toml) as serial pytest invocations: real network installs +
   # real pip installs into per-skill isolated envs are not xdist-safe —
   # never add -n here (the lane's tests are also kept out of the quick/full
@@ -360,7 +362,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────
   release-preflight:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: full-test
+    needs: [full-test, integration-test]
     runs-on: ubuntu-latest
     outputs:
       is_prerelease: ${{ steps.release_meta.outputs.is_prerelease }}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2389,11 +2389,37 @@ Claude Runtime Status appears when an Anthropic key exists or when backend/runti
 
 The local `ouroboros-stable` ref also remains a recovery fallback maintained by explicit promotion; that local role does not select the official QA feed. Colab seeds it from the already validated shared Stable release when possible and otherwise from the selected validated channel, then leaves it pinned until promotion. Launcher metadata describes bootstrap provenance only. Runtime status, preflight, Colab bootstrap, and apply resolve the selected channel and exact fetched SHA themselves, so an older frozen launcher cannot silently redirect updates. Stable additionally requires the shared plain release tag; QA and Development do not use version comparison as an admission gate.
 
-The main CI workflow has five roles: fork-safe quick checks with no provider secrets; the full cross-platform matrix; provider integration when secrets exist; official-skill install, preflight, review, dependency, and keyless execution smoke; and tag-triggered build/release. Quick and full checkouts fetch complete history because the size ratchet fails closed unless its immutable bootstrap and every first-parent transition are locally provable. Secret-bearing skill review runs before any step that imports downloaded plugin code, and a missing required key is red rather than skipped. Release jobs build three platform archives, an AppImage, and three native Linux package assets, verify each final asset, produce checksums, SBOMs and source-bound attestations, and recheck the remote annotated tag against the event SHA before draft creation and publication.
+The main CI workflow has five roles: fork-safe quick checks with no provider secrets; the full cross-platform matrix; trusted provider integration; official-skill install, preflight, review, dependency, and keyless execution smoke; and tag-triggered build/release. Quick and full checkouts fetch complete history because the size ratchet fails closed unless its immutable bootstrap and every first-parent transition are locally provable. Secret-bearing skill review runs before any step that imports downloaded plugin code, and a missing required key is red rather than skipped. Release jobs build three platform archives, an AppImage, and three native Linux package assets, verify each final asset, produce checksums, SBOMs and source-bound attestations, and recheck the remote annotated tag against the event SHA before draft creation and publication.
 
-Request-wire compatibility has two CI layers without changing the workflow. Fork-safe pull-request tests deterministically pin the custom codec, exact-route typed recovery, success-only/TTL evidence, ordered terminal-call history, all tool-bearing consumers, and direct-Anthropic custody/scrubbing. The existing trusted `integration` lane on target-branch pushes, manual runs, and tags derives unique direct OpenAI models from `OPENAI_DIRECT_DEFAULTS` and exercises public `LLMClient.chat`: custom+`medium`, a real registry tool schema, normalized/schema-valid calls, and a nonce-bearing tool-result continuation on the shipped Main model. Missing OpenAI credentials are red only in the official repository job; explicit quota/429/5xx/timeout outcomes are typed inconclusive, while auth/model/reasoning/tool contract 4xx remain red. An applied `none` can restore availability but cannot satisfy this reasoning-integrity canary.
+Tool-schema compatibility has two CI layers. Fork-safe pull-request tests build the
+complete shipped built-in catalog without loading MCP or extensions, validate every
+schema as general JSON Schema plus the known cross-provider subset (including no empty
+enum and no root `anyOf` / `oneOf` / `allOf`), and require OpenRouter/function, direct
+Anthropic, GigaChat, and direct OpenAI projections to preserve the complete tool-name
+set. The trusted `integration` lane runs only on `main` / `ouroboros` /
+`ouroboros-stable` pushes, manual runs, and tags. It sends that same full registry in
+one bounded `delegate_start` canary per physical route without executing the returned
+call: OpenRouter Gemini (`google/gemini-3.7-flash`), Opus
+(`anthropic/claude-opus-5`), GPT (`openai/gpt-5.6-luna`), Grok
+(`x-ai/grok-4.6`), and DeepSeek (`deepseek/deepseek-v4-pro-0813`); the three shipped
+direct OpenAI defaults; direct Anthropic (`anthropic::claude-sonnet-5`); and optional
+MiniMax (`minimax::MiniMax-M3`), Cloud.ru (`cloudru::zai-org/GLM-4.7`), and GigaChat
+(`gigachat::GigaChat-2-Max`). The shipped direct-OpenAI Main route alone keeps its
+second-turn nonce-bearing continuation. Each canary requires positive usage, exact
+provider/model identity, and a normalized schema-valid tool call; supported reasoning
+routes request `medium`, while GigaChat uses its supported automatic tool choice.
+Missing core credentials are red only in the official trusted job; absent optional
+credentials are loud skips. Quota/billing, 429, 5xx, and timeout outcomes remain typed
+inconclusive, while contract/auth/model/tool/reasoning 4xx are red.
 
-Quick pull-request jobs are read-only and never use `pull_request_target`. The live catalog skill lane is intentionally a release dependency: it proves that the published payloads still install on this runtime, while keeping provider credentials out of every process that imports payload code. This external-service dependency is an explicit owner trade-off rather than an accidental source of flaky authority.
+Quick pull-request jobs are read-only, receive no provider secrets, and never use
+`pull_request_target`; there is no scheduled paid run. `release-preflight` depends on
+the trusted integration job as well as the full test matrix, so a reproducible
+provider-contract failure blocks tag builds while an inconclusive provider outage does not. The
+live catalog skill lane remains an independent release dependency: it proves that the
+published payloads still install on this runtime, while keeping provider credentials
+out of every process that imports payload code. These external-service dependencies are
+explicit owner trade-offs rather than accidental sources of flaky authority.
 
 The separate Scorecard workflow runs on `main` pushes and weekly. It pins every action by full commit SHA, defaults permissions to read-only, and adds only `security-events: write` and `id-token: write` for SARIF upload and OpenSSF publication. `CODE_OF_CONDUCT.md` owns community rules and reporting; `CITATION.cff` owns the software citation and preferred technical-report citation; `site/paper/index.html` owns the canonical human- and machine-readable paper landing page; `docs/benchmarks/evidence.json` is a historical, release-bound non-GAIA projection of public benchmark claims and immutable evidence links. README remains the claim SSOT.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -285,6 +285,12 @@ One configured provider must be sufficient for the agent loop, commit review,
 scope policy, safety, and context/memory flows. Core capability must not acquire
 a hidden OpenRouter or second-provider dependency.
 
+Tool-schema changes are provider-contract changes. Every shipped built-in schema
+must pass general JSON Schema and the known cross-provider subset over the
+complete registry; trusted integration CI sends that same registry in one bounded
+tool canary per supported provider family/API surface, while pull-request CI
+remains secretless.
+
 When adding or changing a provider, update one coherent route contract:
 
 1. credential/readiness detection and exact model-id migration;

--- a/ouroboros/llm.py
+++ b/ouroboros/llm.py
@@ -2898,18 +2898,19 @@ class LLMClient:
     def _build_anthropic_tool_choice(tool_choice: Any) -> Optional[Dict[str, Any]]:
         if not tool_choice or tool_choice == "auto":
             return None
-        if tool_choice in {"required", "any"}:
-            return {"type": "any"}
-        if tool_choice == "none":
-            return {"type": "none"}
         if isinstance(tool_choice, dict):
             function = tool_choice.get("function") or {}
             name = str(function.get("name") or "").strip()
             if name:
                 return {"type": "tool", "name": name}
-        if isinstance(tool_choice, str):
-            return {"type": "tool", "name": tool_choice}
-        return None
+            return None
+        if not isinstance(tool_choice, str):
+            return None
+        if tool_choice in {"required", "any"}:
+            return {"type": "any"}
+        if tool_choice == "none":
+            return {"type": "none"}
+        return {"type": "tool", "name": tool_choice}
 
     @staticmethod
     def _cache_write_split(raw_usage: Dict[str, Any]) -> Dict[str, int]:

--- a/ouroboros/tools/delegate.py
+++ b/ouroboros/tools/delegate.py
@@ -1442,17 +1442,19 @@ def get_tools() -> List[ToolEntry]:
                 "delegate_cancel. The run's output is a CLAIM you must check — you are the "
                 "host, so verification receipts are still yours to write. If no route is "
                 "configured or it is unavailable you get a typed refusal: choose an "
-                "explicit configured alternative, wait, narrow, or report blocked."
+                "explicit configured alternative, wait, narrow, or report blocked. Fresh "
+                "starts require subagent_id; recovery retries use retry_of without a new "
+                "subagent selector."
             ),
             "parameters": {
                 "type": "object",
                 "required": ["prompt"],
-                "anyOf": [{"required": ["subagent_id"]}, {"required": ["retry_of"]}],
                 "properties": {
                 "prompt": {"type": "string", "description": "The complete task for the delegated session."},
                 "subagent_id": {"type": "string", "description":
-                    "Exact agent_session actor id from Available subagents. API actor ids are "
-                    "refused here and must be scheduled as recursive children."},
+                    "Required for a fresh start: exact agent_session actor id from Available "
+                    "subagents. Omit when replaying retry_of. API actor ids are refused here "
+                    "and must be scheduled as recursive children."},
                 "root": {"type": "string", "enum": ["skill_payload"], "description":
                     "Optional exact-resource selector: 'skill_payload' delegates ONE "
                     "installed non-native skill payload you can already write. Omit "
@@ -1473,6 +1475,8 @@ def get_tools() -> List[ToolEntry]:
                     "outcome was unknown (transport failure, lost response). Replays THAT "
                     "invocation byte-identically under its original key, so the engine "
                     "returns the run it already accepted instead of starting a second one. "
+                    "Omit subagent_id on this recovery path; supplying both selectors is a "
+                    "typed conflict. "
                     "Never set it for an intended new run — a plain call always starts a "
                     "NEW invocation, even with an identical prompt."},
                 },

--- a/tests/provider_contract_catalog.py
+++ b/tests/provider_contract_catalog.py
@@ -1,0 +1,93 @@
+"""Deterministic shipped-tool catalog for static and live provider contracts.
+
+This is intentionally test-only.  Production ``ToolRegistry.schemas()`` also
+discovers live extension and MCP tools, which would make a provider canary
+depend on mutable local state and may refresh external MCP servers.  Contract
+tests need the complete shipped built-in surface before any runtime filtering,
+so they project the registry's already-loaded built-in entries directly.
+"""
+
+from __future__ import annotations
+
+import copy
+import pathlib
+import tempfile
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from jsonschema import exceptions as jsonschema_exceptions
+from jsonschema import validators
+
+
+ROOT_SCHEMA_COMBINATORS = ("anyOf", "oneOf", "allOf")
+
+
+def shipped_builtin_tool_schemas() -> list[dict[str, Any]]:
+    """Return every shipped built-in in deterministic canonical function shape.
+
+    Do not replace the private-entry projection with ``registry.schemas()``:
+    that public runtime surface intentionally loads extensions and refreshes
+    MCP discovery.  The copy keeps canary callers from mutating the registry's
+    module-owned schema dictionaries.
+    """
+    from ouroboros.tools.registry import ToolRegistry
+
+    repo_dir = pathlib.Path(__file__).resolve().parents[1]
+    with tempfile.TemporaryDirectory(prefix="ouroboros-provider-contract-") as tmp:
+        registry = ToolRegistry(repo_dir=repo_dir, drive_root=pathlib.Path(tmp))
+        schemas = [
+            registry._schema_for_entry(registry._entries[name])
+            for name in sorted(registry._entries)
+        ]
+    return copy.deepcopy(schemas)
+
+
+def _assert_no_blank_enum(node: Any, *, tool_name: str, path: str) -> None:
+    if isinstance(node, Mapping):
+        enum = node.get("enum")
+        if isinstance(enum, list):
+            blank = [value for value in enum if isinstance(value, str) and not value.strip()]
+            if blank:
+                raise AssertionError(
+                    f"{tool_name}: empty enum value at {path}: {enum!r}"
+                )
+        for key, value in node.items():
+            _assert_no_blank_enum(
+                value,
+                tool_name=tool_name,
+                path=f"{path}.{key}",
+            )
+    elif isinstance(node, Sequence) and not isinstance(node, (str, bytes, bytearray)):
+        for index, value in enumerate(node):
+            _assert_no_blank_enum(
+                value,
+                tool_name=tool_name,
+                path=f"{path}[{index}]",
+            )
+
+
+def assert_portable_tool_schemas(schemas: Sequence[Mapping[str, Any]]) -> None:
+    """Apply the free complete-registry JSON Schema portability contract."""
+    for tool in schemas:
+        function = tool.get("function")
+        if not isinstance(function, Mapping):
+            raise AssertionError("<unknown>: missing function tool object")
+        tool_name = str(function.get("name") or "<unknown>")
+        parameters = function.get("parameters")
+        if not isinstance(parameters, Mapping):
+            raise AssertionError(f"{tool_name}: parameters must be a JSON Schema object")
+
+        validator = validators.validator_for(parameters)
+        try:
+            validator.check_schema(parameters)
+        except jsonschema_exceptions.SchemaError as exc:
+            raise AssertionError(
+                f"{tool_name}: invalid JSON Schema: {exc.message}"
+            ) from exc
+
+        for keyword in ROOT_SCHEMA_COMBINATORS:
+            if keyword in parameters:
+                raise AssertionError(
+                    f"{tool_name}: root schema keyword {keyword!r} is not portable"
+                )
+        _assert_no_blank_enum(parameters, tool_name=tool_name, path=tool_name)

--- a/tests/provider_contract_ci.py
+++ b/tests/provider_contract_ci.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import copy
 import json
 import os
-import pathlib
 from dataclasses import dataclass
 from enum import Enum
 
@@ -14,20 +13,104 @@ import pytest
 from ouroboros.provider_models import OPENAI_DIRECT_DEFAULTS, normalize_model_identity
 from ouroboros.utils import sanitize_tool_result_for_log
 
-OPENAI_CANARY_TIMEOUT_SEC = 120.0
-OPENAI_CANARY_MAX_TOKENS = 1024
-OPENAI_CANARY_TOOL_NAME = "read_file"
-OPENAI_CANARY_ARGUMENTS = {
-    "path": "BIBLE.md",
-    "root": "system_repo",
-    "start_line": 1,
-    "max_lines": 1,
-}
+CANARY_TIMEOUT_SEC = 120.0
+CANARY_MAX_TOKENS = 1024
+CANARY_CONTINUATION_MAX_TOKENS = 2048
+CANARY_TOOL_NAME = "delegate_start"
+CANARY_SUBAGENT_ID = "provider-contract-canary"
+
+
+@dataclass(frozen=True)
+class ProviderCanary:
+    """One physical provider/API surface in the trusted full-registry matrix."""
+
+    canary_id: str
+    model: str
+    expected_provider: str
+    credential_env: str
+    credential_required: bool
+    reasoning_effort: str
+    named_tool_choice: bool = True
+    continue_to_final: bool = False
+
+
+_OPENROUTER_CANARIES = (
+    ProviderCanary(
+        "openrouter_gemini", "google/gemini-3.7-flash", "openrouter",
+        "OPENROUTER_API_KEY", True, "medium",
+    ),
+    ProviderCanary(
+        "openrouter_opus", "anthropic/claude-opus-5", "openrouter",
+        "OPENROUTER_API_KEY", True, "medium",
+    ),
+    ProviderCanary(
+        "openrouter_gpt", "openai/gpt-5.6-luna", "openrouter",
+        "OPENROUTER_API_KEY", True, "medium",
+    ),
+    ProviderCanary(
+        "openrouter_grok", "x-ai/grok-4.6", "openrouter",
+        "OPENROUTER_API_KEY", True, "medium",
+    ),
+    ProviderCanary(
+        "openrouter_deepseek", "deepseek/deepseek-v4-pro-0813", "openrouter",
+        "OPENROUTER_API_KEY", True, "medium",
+    ),
+)
+
+_DIRECT_ANTHROPIC_CANARY = ProviderCanary(
+    "anthropic_direct", "anthropic::claude-sonnet-5", "anthropic",
+    "ANTHROPIC_API_KEY", True, "medium",
+)
+
+_OPTIONAL_DIRECT_CANARIES = (
+    ProviderCanary(
+        "minimax_direct", "minimax::MiniMax-M3", "minimax",
+        "MINIMAX_API_KEY", False, "none",
+    ),
+    ProviderCanary(
+        "cloudru_direct", "cloudru::zai-org/GLM-4.7", "cloudru",
+        "CLOUDRU_FOUNDATION_MODELS_API_KEY", False, "none",
+    ),
+    ProviderCanary(
+        "gigachat_direct", "gigachat::GigaChat-2-Max", "gigachat",
+        "GIGACHAT_CREDENTIALS", False, "none", named_tool_choice=False,
+    ),
+)
 
 
 def unique_openai_direct_defaults():
-    """Derive the live matrix from the shipped provider-default SSOT."""
+    """Derive the live direct-OpenAI matrix from the shipped provider SSOT."""
     return tuple(dict.fromkeys(model for model in OPENAI_DIRECT_DEFAULTS.values() if model))
+
+
+def _openai_direct_canaries():
+    seen = set()
+    rows = []
+    main_model = OPENAI_DIRECT_DEFAULTS.get("main")
+    for role, model in OPENAI_DIRECT_DEFAULTS.items():
+        if not model or model in seen:
+            continue
+        seen.add(model)
+        rows.append(ProviderCanary(
+            canary_id=f"openai_direct_{role}",
+            model=model,
+            expected_provider="openai",
+            credential_env="OPENAI_API_KEY",
+            credential_required=True,
+            reasoning_effort="medium",
+            continue_to_final=model == main_model,
+        ))
+    return tuple(rows)
+
+
+def provider_canary_matrix():
+    """Return the exact paid matrix in stable physical-call order."""
+    return (
+        *_OPENROUTER_CANARIES,
+        *_openai_direct_canaries(),
+        _DIRECT_ANTHROPIC_CANARY,
+        *_OPTIONAL_DIRECT_CANARIES,
+    )
 
 
 class ProviderFailureKind(str, Enum):
@@ -85,6 +168,7 @@ def classify_provider_failure(
     Contract/auth/model/tool/reasoning 4xx stay RED. In particular, the #229
     function-tools + reasoning 400 must never be hidden by a broad text match.
     """
+    del provider_id
     status, body, message, chain = provider_error_evidence(exc)
     lowered = "\n".join((body, message)).lower()
     if any(
@@ -96,36 +180,30 @@ def classify_provider_failure(
             "billing_not_active",
             "payment_required",
             "exceeded your current quota",
+            "requires more credits",
+            "can only afford",
         )
     ):
         return ProviderFailureClassification(
-            ProviderFailureKind.INCONCLUSIVE,
-            "quota_or_billing",
-            status,
+            ProviderFailureKind.INCONCLUSIVE, "quota_or_billing", status,
         )
     if status == 429:
         return ProviderFailureClassification(
-            ProviderFailureKind.INCONCLUSIVE,
-            "rate_limit_429",
-            status,
+            ProviderFailureKind.INCONCLUSIVE, "rate_limit_429", status,
         )
     if status is not None and 500 <= status < 600:
         return ProviderFailureClassification(
-            ProviderFailureKind.INCONCLUSIVE,
-            "provider_5xx",
-            status,
+            ProviderFailureKind.INCONCLUSIVE, "provider_5xx", status,
         )
     if status is None and any(
-        isinstance(item, TimeoutError) or "timeout" in type(item).__name__.lower() for item in chain
+        isinstance(item, TimeoutError) or "timeout" in type(item).__name__.lower()
+        for item in chain
     ):
         return ProviderFailureClassification(
-            ProviderFailureKind.INCONCLUSIVE,
-            "transport_timeout",
+            ProviderFailureKind.INCONCLUSIVE, "transport_timeout",
         )
     return ProviderFailureClassification(
-        ProviderFailureKind.RED,
-        "provider_contract_or_unclassified",
-        status,
+        ProviderFailureKind.RED, "provider_contract_or_unclassified", status,
     )
 
 
@@ -144,38 +222,65 @@ def skip_on_provider_environmental_error(
         print(f"[{provider_id}] HTTP {status} body: {safe_body[:500]}", file=sys.stderr)
     if classification.kind is ProviderFailureKind.INCONCLUSIVE:
         detail = safe_body[:200] if safe_body else safe_message[:200]
-        pytest.skip(f"[{provider_id}] inconclusive provider alarm ({classification.reason}): {detail}")
+        pytest.skip(
+            f"[{provider_id}] inconclusive provider alarm "
+            f"({classification.reason}): {detail}"
+        )
 
 
-def official_openai_integration_job():
+def official_provider_integration_job():
     return (
         os.environ.get("GITHUB_ACTIONS", "").strip().lower() == "true"
         and os.environ.get("GITHUB_REPOSITORY", "").strip() == "razzant/ouroboros"
     )
 
 
-def require_openai_canary_key():
-    if str(os.environ.get("OPENAI_API_KEY", "") or "").strip():
+def require_provider_canary_credential(canary: ProviderCanary):
+    if str(os.environ.get(canary.credential_env, "") or "").strip():
         return
-    if official_openai_integration_job():
-        pytest.fail("OPENAI_API_KEY is required by the official integration job")
-    pytest.skip("OPENAI_API_KEY not set")
+    if canary.credential_required and official_provider_integration_job():
+        pytest.fail(
+            f"{canary.credential_env} is required by the official integration job "
+            f"for {canary.canary_id} ({canary.model})"
+        )
+    policy = "required core" if canary.credential_required else "optional"
+    pytest.skip(
+        f"{canary.credential_env} not set; {policy} provider canary "
+        f"{canary.canary_id} ({canary.model}) was not run"
+    )
 
 
-def registry_openai_canary_tool(drive_root):
-    """Take one real shipped tool schema, then request its strict custom twin."""
-    from ouroboros.tools.registry import ToolRegistry
+def full_registry_canary_tools():
+    """Return the one built-in-only catalog shared with static portability tests."""
+    from tests.provider_contract_catalog import shipped_builtin_tool_schemas
 
-    repo_dir = pathlib.Path(__file__).resolve().parents[1]
-    registered = ToolRegistry(
-        repo_dir=repo_dir,
-        drive_root=pathlib.Path(drive_root),
-    ).get_schema_by_name(OPENAI_CANARY_TOOL_NAME)
-    assert registered is not None
-    tool = copy.deepcopy(registered)
-    tool["function"]["strict"] = True
-    tool["function"]["parameters"]["additionalProperties"] = False
-    return tool
+    tools = shipped_builtin_tool_schemas()
+    names = [str((tool.get("function") or {}).get("name") or "") for tool in tools]
+    assert names == sorted(names) and len(names) == len(set(names)), names
+    assert CANARY_TOOL_NAME in names, names
+    return copy.deepcopy(tools)
+
+
+def delegate_start_canary_arguments(nonce: str):
+    return {
+        "prompt": (
+            f"Provider contract canary {nonce}. Do not perform external actions; "
+            "the returned call will be validated but never executed."
+        ),
+        "subagent_id": CANARY_SUBAGENT_ID,
+    }
+
+
+def _delegate_start_tool(tools):
+    return next(
+        tool
+        for tool in tools
+        if str((tool.get("function") or {}).get("name") or "") == CANARY_TOOL_NAME
+    )
+
+
+def _named_tool_choice():
+    return {"type": "function", "function": {"name": CANARY_TOOL_NAME}}
 
 
 def assert_openai_canary_usage(usage, model):
@@ -187,7 +292,10 @@ def assert_openai_canary_usage(usage, model):
     assert usage.get("reasoning_effort_clamped") is None, usage
 
     disclosure = usage.get("request_wire")
-    assert isinstance(disclosure, dict), f"Phase 2A public request-wire disclosure is missing from usage; usage={usage}"
+    assert isinstance(disclosure, dict), (
+        "Public direct-OpenAI request-wire disclosure is missing from usage; "
+        f"usage={usage}"
+    )
     assert disclosure["requested_effort"] == "medium"
     assert disclosure["applied_effort"] == "medium"
     assert disclosure["requested_tool_dialect"] == "function"
@@ -202,12 +310,9 @@ def assert_openai_canary_usage(usage, model):
         action = applied.get("action")
         assert isinstance(action, dict)
         assert action.get("kind") != "replace_dialect"
-        assert not (
-            action.get("kind") == "set_value" and action.get("field") == "effort"
-        )
+        assert not (action.get("kind") == "set_value" and action.get("field") == "effort")
         assert not set(action.get("fields") or ()).intersection({
-            "reasoning_effort", "thinking", "output_config",
-            "extra_body.reasoning",
+            "reasoning_effort", "thinking", "output_config", "extra_body.reasoning",
         })
     assert disclosure["attempt_id"]
     for key in (
@@ -216,16 +321,35 @@ def assert_openai_canary_usage(usage, model):
         "candidate_sha256",
     ):
         value = str(disclosure.get(key) or "")
-        assert len(value) == 64 and not (set(value.lower()) - set("0123456789abcdef"))
+        assert len(value) == 64 and not (
+            set(value.lower()) - set("0123456789abcdef")
+        )
     return disclosure
 
 
-def assert_normalized_canary_call(message, tool):
+def assert_canary_usage(usage, canary: ProviderCanary):
+    assert isinstance(usage, dict), usage
+    assert usage.get("provider") == canary.expected_provider, usage
+    assert usage.get("resolved_model") == normalize_model_identity(canary.model), usage
+    assert int(usage.get("prompt_tokens") or 0) > 0, usage
+    assert int(usage.get("completion_tokens") or 0) > 0, usage
+    if canary.reasoning_effort == "medium":
+        assert usage.get("reasoning_effort_clamped") is None, usage
+        disclosure = usage.get("request_wire")
+        assert isinstance(disclosure, dict), usage
+        assert disclosure.get("requested_effort") == "medium", disclosure
+        assert disclosure.get("applied_effort") == "medium", disclosure
+    if canary.expected_provider == "openai":
+        return assert_openai_canary_usage(usage, canary.model)
+    return usage.get("request_wire")
+
+
+def assert_normalized_canary_call(message, tools, expected_arguments):
     from jsonschema import validators
 
     calls = message.get("tool_calls") if isinstance(message, dict) else None
     assert isinstance(calls, list) and calls, message
-    schema = tool["function"]["parameters"]
+    schema = _delegate_start_tool(tools)["function"]["parameters"]
     validator_class = validators.validator_for(schema)
     validator_class.check_schema(schema)
     seen_ids = set()
@@ -238,55 +362,52 @@ def assert_normalized_canary_call(message, tool):
         seen_ids.add(call_id)
         function = call.get("function")
         assert isinstance(function, dict), call
-        assert function.get("name") == OPENAI_CANARY_TOOL_NAME, call
+        assert function.get("name") == CANARY_TOOL_NAME, call
         raw_arguments = function.get("arguments")
         assert isinstance(raw_arguments, str), call
         arguments = json.loads(raw_arguments)
-        assert arguments == OPENAI_CANARY_ARGUMENTS
         assert not list(validator_class(schema).iter_errors(arguments))
+        assert set(arguments) <= set((schema.get("properties") or {}).keys()), arguments
+        for key, expected in expected_arguments.items():
+            assert arguments.get(key) == expected, arguments
     return calls
 
 
-def run_openai_reasoning_tool_canary(
+def run_provider_contract_canary(
     client,
     *,
-    model,
-    tool,
-    nonce,
-    continue_to_final,
+    canary: ProviderCanary,
+    tools,
+    nonce: str,
 ):
-    """Exercise only the public production chat seam, never a raw SDK client."""
-    final_marker = f"PHASE2C_CONTINUED_{nonce}"
-    expected_arguments = json.dumps(OPENAI_CANARY_ARGUMENTS, sort_keys=True)
-    conversation = [
-        {
-            "role": "user",
-            "content": (
-                f"Call {OPENAI_CANARY_TOOL_NAME} exactly once with arguments "
-                f"{expected_arguments}. After its tool result, read the "
-                "expected_final_marker field and reply with exactly that value. "
-                "Do not call another tool."
-            ),
-        }
-    ]
+    """Exercise the public chat seam without executing the returned tool call."""
+    expected_arguments = delegate_start_canary_arguments(nonce)
+    arguments_json = json.dumps(expected_arguments, ensure_ascii=False, sort_keys=True)
+    conversation = [{
+        "role": "user",
+        "content": (
+            f"Call {CANARY_TOOL_NAME} exactly once with exactly this JSON object "
+            f"as its arguments: {arguments_json}. Do not add, omit, or change a field. "
+            "Return the tool call now and no prose."
+        ),
+    }]
+    tool_choice = _named_tool_choice() if canary.named_tool_choice else "auto"
     message, usage = client.chat(
         messages=conversation,
-        model=model,
-        tools=[tool],
-        tool_choice={
-            "type": "function",
-            "function": {"name": OPENAI_CANARY_TOOL_NAME},
-        },
-        reasoning_effort="medium",
-        max_tokens=OPENAI_CANARY_MAX_TOKENS,
+        model=canary.model,
+        tools=copy.deepcopy(tools),
+        tool_choice=tool_choice,
+        reasoning_effort=canary.reasoning_effort,
+        max_tokens=CANARY_MAX_TOKENS,
         no_proxy=True,
-        timeout=OPENAI_CANARY_TIMEOUT_SEC,
+        timeout=CANARY_TIMEOUT_SEC,
     )
-    calls = assert_normalized_canary_call(message, tool)
-    first_disclosure = assert_openai_canary_usage(usage, model)
-    if not continue_to_final:
+    calls = assert_normalized_canary_call(message, tools, expected_arguments)
+    first_disclosure = assert_canary_usage(usage, canary)
+    if not canary.continue_to_final:
         return message, usage, None, None
 
+    final_marker = f"FULL_REGISTRY_CONTINUED_{nonce}"
     continuation = [
         *conversation,
         message,
@@ -294,30 +415,30 @@ def run_openai_reasoning_tool_canary(
             {
                 "role": "tool",
                 "tool_call_id": call["id"],
-                "content": json.dumps(
-                    {
-                        "ok": True,
-                        "nonce": nonce,
-                        "expected_final_marker": final_marker,
-                    },
-                    sort_keys=True,
-                ),
+                "content": json.dumps({
+                    "ok": True,
+                    "nonce": nonce,
+                    "expected_final_marker": final_marker,
+                }, sort_keys=True),
             }
             for call in calls
         ],
     ]
     final_message, final_usage = client.chat(
         messages=continuation,
-        model=model,
-        tools=[tool],
+        model=canary.model,
+        tools=[copy.deepcopy(_delegate_start_tool(tools))],
         tool_choice="none",
-        reasoning_effort="medium",
-        max_tokens=OPENAI_CANARY_MAX_TOKENS,
+        reasoning_effort=canary.reasoning_effort,
+        max_tokens=CANARY_CONTINUATION_MAX_TOKENS,
         no_proxy=True,
-        timeout=OPENAI_CANARY_TIMEOUT_SEC,
+        timeout=CANARY_TIMEOUT_SEC,
     )
-    final_disclosure = assert_openai_canary_usage(final_usage, model)
-    assert final_disclosure["candidate_sha256"] != first_disclosure["candidate_sha256"]
+    final_disclosure = assert_canary_usage(final_usage, canary)
+    if isinstance(first_disclosure, dict) and isinstance(final_disclosure, dict):
+        assert final_disclosure.get("candidate_sha256") != first_disclosure.get(
+            "candidate_sha256"
+        )
     assert not final_message.get("tool_calls"), final_message
     assert str(final_message.get("content") or "").strip() == final_marker, final_message
     return message, usage, final_message, final_usage

--- a/tests/test_available_subagents_runtime.py
+++ b/tests/test_available_subagents_runtime.py
@@ -978,7 +978,7 @@ def test_api_row_is_refused_by_root_direct_exact_start_before_daemon(monkeypatch
     ctx = ToolContext(repo_dir=tmp_path, drive_root=tmp_path)
     ctx.task_id = "root1"
     schema = next(e.schema for e in delegate.get_tools() if e.name == "delegate_start")["parameters"]
-    assert schema["anyOf"] == [{"required": ["subagent_id"]}, {"required": ["retry_of"]}]
+    assert schema["required"] == ["prompt"] and not ({"anyOf", "oneOf", "allOf"} & schema.keys())
     missing = json.loads(delegate.exact_start(ctx, "bounded leaf"))
     assert missing["reason"] == "subagent_selection_required"
     out = json.loads(delegate.exact_start(

--- a/tests/test_available_subagents_runtime_review_fixes.py
+++ b/tests/test_available_subagents_runtime_review_fixes.py
@@ -385,9 +385,11 @@ def test_delegate_start_recipes_match_the_fresh_start_schema():
         entry.schema for entry in delegate.get_tools() if entry.name == "delegate_start"
     )["parameters"]
     assert schema["required"] == ["prompt"]
-    assert {tuple(row["required"]) for row in schema["anyOf"]} == {
-        ("subagent_id",), ("retry_of",),
-    }
+    assert not ({"anyOf", "oneOf", "allOf"} & schema.keys())
+    assert "Required for a fresh start" in schema["properties"]["subagent_id"]["description"]
+    assert "supplying both selectors is a typed conflict" in (
+        schema["properties"]["retry_of"]["description"]
+    )
 
     repo = pathlib.Path(__file__).parents[1]
     recipe_paths = (

--- a/tests/test_contributor_flow.py
+++ b/tests/test_contributor_flow.py
@@ -70,13 +70,54 @@ def test_pull_request_ci_is_fork_safe_and_does_not_enable_provider_jobs():
     workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
         encoding="utf-8"
     )
+    quick_job = workflow.partition("\n  quick-test:\n")[2].partition(
+        "\n  # ──────────────────────────────────────────────────────────────────"
+    )[0]
 
     assert "pull_request:\n    branches: [ouroboros]" in workflow
     assert "\n  pull_request_target:" not in workflow
+    assert "\n  schedule:" not in workflow
     assert "permissions:\n  contents: read" in workflow
     assert "github.event_name == 'pull_request' && github.base_ref == 'ouroboros'" in workflow
+    assert "secrets." not in quick_job
     assert "release:\n" in workflow
     assert "      contents: write" in workflow
+
+
+def test_trusted_provider_ci_wires_full_secret_policy_and_release_dependency():
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    integration_job = workflow.partition("\n  integration-test:\n")[2].partition(
+        "\n  # ──────────────────────────────────────────────────────────────────"
+    )[0]
+    release_preflight = workflow.partition("\n  release-preflight:\n")[2].partition(
+        "\n  build:\n"
+    )[0]
+
+    assert integration_job
+    assert "github.event_name == 'pull_request'" not in integration_job
+    assert "github.event_name == 'workflow_dispatch'" in integration_job
+    for ref in (
+        "refs/heads/main",
+        "refs/heads/ouroboros",
+        "refs/heads/ouroboros-stable",
+        "refs/tags/v",
+    ):
+        assert ref in integration_job
+
+    for secret in (
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "MINIMAX_API_KEY",
+        "CLOUDRU_FOUNDATION_MODELS_API_KEY",
+        "GIGACHAT_CREDENTIALS",
+    ):
+        assert f"{secret}: ${{{{ secrets.{secret} }}}}" in integration_job
+
+    assert " -rs " in integration_job
+    assert "needs: [full-test, integration-test]" in release_preflight
 
 
 def test_repository_has_explicit_mit_license_holder():

--- a/tests/test_provider_contract_catalog.py
+++ b/tests/test_provider_contract_catalog.py
@@ -1,0 +1,105 @@
+"""Secretless full-registry provider-schema portability gate."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.provider_contract_catalog import (
+    ROOT_SCHEMA_COMBINATORS,
+    assert_portable_tool_schemas,
+    shipped_builtin_tool_schemas,
+)
+
+
+def _function_names(tools):
+    return [tool["function"]["name"] for tool in tools]
+
+
+def test_shipped_builtin_catalog_is_complete_sorted_and_deterministic():
+    first = shipped_builtin_tool_schemas()
+    second = shipped_builtin_tool_schemas()
+
+    names = _function_names(first)
+    assert names == sorted(names)
+    assert len(names) == len(set(names))
+    assert len(names) >= 100
+    assert "delegate_start" in names
+    assert first == second
+
+
+def test_shipped_builtin_catalog_does_not_refresh_mcp_or_load_extensions(monkeypatch):
+    import ouroboros.extension_loader as extension_loader
+    import ouroboros.mcp_client as mcp_client
+    from ouroboros.tools.registry import ToolRegistry
+
+    def _dynamic_discovery_forbidden(*_args, **_kwargs):
+        raise AssertionError("dynamic extension/MCP discovery must not run")
+
+    monkeypatch.setattr(ToolRegistry, "schemas", _dynamic_discovery_forbidden)
+    monkeypatch.setattr(
+        mcp_client,
+        "ensure_configured_from_settings",
+        _dynamic_discovery_forbidden,
+    )
+    monkeypatch.setattr(
+        extension_loader,
+        "is_extension_live",
+        _dynamic_discovery_forbidden,
+    )
+    monkeypatch.setitem(extension_loader._tools, "contract_test_extension", {
+        "name": "ext_contract_test",
+        "description": "must not enter the shipped catalog",
+        "schema": {"type": "object", "properties": {}},
+        "skill": "contract_test_extension",
+    })
+
+    names = set(_function_names(shipped_builtin_tool_schemas()))
+
+    assert "ext_contract_test" not in names
+
+
+def test_every_shipped_builtin_schema_is_generally_valid_and_portable():
+    assert_portable_tool_schemas(shipped_builtin_tool_schemas())
+
+
+@pytest.mark.parametrize("keyword", ROOT_SCHEMA_COMBINATORS)
+def test_root_combinator_failure_names_tool_and_keyword(keyword):
+    bad = [{
+        "type": "function",
+        "function": {
+            "name": "bad_contract_tool",
+            "description": "bad",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                keyword: [{"required": ["selector"]}],
+            },
+        },
+    }]
+
+    with pytest.raises(
+        AssertionError,
+        match=rf"bad_contract_tool: root schema keyword '{keyword}'",
+    ):
+        assert_portable_tool_schemas(bad)
+
+
+def test_every_physical_provider_projection_preserves_the_complete_name_set():
+    from ouroboros.llm import LLMClient
+    from ouroboros.openai_chat_custom import project_function_tools_to_openai_custom
+
+    canonical = shipped_builtin_tool_schemas()
+    expected = set(_function_names(canonical))
+
+    openrouter_function = LLMClient._sanitize_chat_completion_tools(canonical)
+    anthropic = LLMClient._build_anthropic_tools(canonical)
+    gigachat = LLMClient._gigachat_functions(canonical)
+    openai_custom = project_function_tools_to_openai_custom(openrouter_function)
+
+    assert set(_function_names(openrouter_function)) == expected
+    assert {tool["name"] for tool in anthropic} == expected
+    assert {tool["name"] for tool in gigachat} == expected
+    assert set(openai_custom.tool_names) == expected
+    assert {
+        tool["custom"]["name"] for tool in openai_custom.wire_tools()
+    } == expected

--- a/tests/test_provider_contract_ci.py
+++ b/tests/test_provider_contract_ci.py
@@ -1,4 +1,4 @@
-"""Secretless CI contracts for shipped provider-wire alarms."""
+"""Secretless CI contracts for the trusted full-registry provider alarms."""
 
 from __future__ import annotations
 
@@ -16,18 +16,21 @@ from ouroboros.request_wire_receipts import (
 )
 from ouroboros.usage_accounting import PhysicalAttemptCapture
 from tests.provider_contract_ci import (
-    OPENAI_CANARY_ARGUMENTS,
-    OPENAI_CANARY_MAX_TOKENS,
-    OPENAI_CANARY_TIMEOUT_SEC,
-    OPENAI_CANARY_TOOL_NAME,
+    CANARY_CONTINUATION_MAX_TOKENS,
+    CANARY_MAX_TOKENS,
+    CANARY_TIMEOUT_SEC,
+    CANARY_TOOL_NAME,
+    ProviderCanary,
     ProviderFailureClassification,
     ProviderFailureKind,
     assert_normalized_canary_call,
     assert_openai_canary_usage,
     classify_provider_failure,
-    registry_openai_canary_tool,
-    require_openai_canary_key,
-    run_openai_reasoning_tool_canary,
+    delegate_start_canary_arguments,
+    full_registry_canary_tools,
+    provider_canary_matrix,
+    require_provider_canary_credential,
+    run_provider_contract_canary,
     skip_on_provider_environmental_error,
     unique_openai_direct_defaults,
 )
@@ -52,10 +55,10 @@ def _http_error(status_code: int, body: str):
             400,
             (
                 '{"error":{"message":"Function tools with reasoning_effort are not '
-                "supported for gpt-5.6-luna in /v1/chat/completions. To use function "
-                'tools, use /v1/responses or set reasoning_effort to none."}}'
+                'supported. Use responses or set reasoning_effort to none."}}'
             ),
         ),
+        (400, '{"error":{"message":"tools.19.custom.input_schema is invalid"}}'),
         (400, '{"error":{"message":"Unknown parameter: tools[0].custom"}}'),
         (401, '{"error":{"code":"invalid_api_key"}}'),
         (403, '{"message":"API key verification failed: key is expired"}'),
@@ -66,14 +69,13 @@ def _http_error(status_code: int, body: str):
 def test_contract_and_auth_4xx_are_red(status_code, body):
     exc = _http_error(status_code, body)
     assert classify_provider_failure(
-        "openai_direct",
-        exc,
+        "provider_canary", exc,
     ) == ProviderFailureClassification(
         ProviderFailureKind.RED,
         "provider_contract_or_unclassified",
         status_code,
     )
-    assert skip_on_provider_environmental_error("openai_direct", exc) is None
+    assert skip_on_provider_environmental_error("provider_canary", exc) is None
 
 
 @pytest.mark.parametrize(
@@ -83,6 +85,12 @@ def test_contract_and_auth_4xx_are_red(status_code, body):
         (503, '{"error":{"message":"upstream unavailable"}}', "provider_5xx"),
         (400, '{"error":{"code":"insufficient_quota"}}', "quota_or_billing"),
         (402, '{"error":{"message":"credit balance is too low"}}', "quota_or_billing"),
+        (
+            402,
+            '{"error":{"message":"This request requires more credits, or fewer '
+            'max_tokens. You can only afford 348."}}',
+            "quota_or_billing",
+        ),
     ],
 )
 def test_only_explicit_environmental_outcomes_are_inconclusive(
@@ -91,66 +99,53 @@ def test_only_explicit_environmental_outcomes_are_inconclusive(
     reason,
 ):
     classification = classify_provider_failure(
-        "openai_direct",
-        _http_error(status_code, body),
+        "provider_canary", _http_error(status_code, body),
     )
     assert classification.kind is ProviderFailureKind.INCONCLUSIVE
     assert classification.reason == reason
     assert classification.status_code == status_code
     with pytest.raises(pytest.skip.Exception, match=reason):
         skip_on_provider_environmental_error(
-            "openai_direct",
-            _http_error(status_code, body),
+            "provider_canary", _http_error(status_code, body),
         )
 
 
 def test_timeout_is_inconclusive_but_http_400_with_timeout_cause_is_red():
     timeout = TimeoutError("timed out")
     assert classify_provider_failure(
-        "openai_direct",
-        timeout,
+        "provider_canary", timeout,
     ) == ProviderFailureClassification(
         ProviderFailureKind.INCONCLUSIVE,
         "transport_timeout",
     )
     with pytest.raises(pytest.skip.Exception, match="transport_timeout"):
-        skip_on_provider_environmental_error("openai_direct", timeout)
+        skip_on_provider_environmental_error("provider_canary", timeout)
 
     http_400 = _http_error(400, '{"error":{"message":"reasoning timeout invalid"}}')
     http_400.__cause__ = TimeoutError("socket timed out")
-    assert (
-        classify_provider_failure(
-            "openai_direct",
-            http_400,
-        ).kind
-        is ProviderFailureKind.RED
-    )
+    assert classify_provider_failure(
+        "provider_canary", http_400,
+    ).kind is ProviderFailureKind.RED
 
 
-def test_cloudru_disconnect_and_generic_connection_error_are_red():
+def test_disconnect_and_generic_connection_error_are_red():
     disconnect = RuntimeError("APIConnectionError: Connection error.")
-    disconnect.__cause__ = RuntimeError("httpx.RemoteProtocolError: Server disconnected without sending a response.")
-    assert (
-        classify_provider_failure(
-            "cloudru",
-            disconnect,
-        ).kind
-        is ProviderFailureKind.RED
+    disconnect.__cause__ = RuntimeError(
+        "httpx.RemoteProtocolError: Server disconnected without sending a response."
     )
-    assert (
-        classify_provider_failure(
-            "cloudru",
-            RuntimeError("APIConnectionError: Connection error."),
-        ).kind
-        is ProviderFailureKind.RED
-    )
+    assert classify_provider_failure(
+        "provider_canary", disconnect,
+    ).kind is ProviderFailureKind.RED
+    assert classify_provider_failure(
+        "provider_canary", RuntimeError("APIConnectionError: Connection error."),
+    ).kind is ProviderFailureKind.RED
 
 
 def test_provider_alarm_output_sanitizes_token_shaped_evidence(capsys):
     sentinel = "sk-proj-" + ("A" * 40)
     exc = _http_error(429, f'{{"error":{{"token":"{sentinel}"}}}}')
     with pytest.raises(pytest.skip.Exception) as caught:
-        skip_on_provider_environmental_error("openai_direct", exc)
+        skip_on_provider_environmental_error("provider_canary", exc)
 
     assert sentinel not in capsys.readouterr().err
     assert sentinel not in str(caught.value)
@@ -158,29 +153,64 @@ def test_provider_alarm_output_sanitizes_token_shaped_evidence(capsys):
 
     with pytest.raises(pytest.skip.Exception) as caught_message:
         skip_on_provider_environmental_error(
-            "openai_direct",
+            "provider_canary",
             TimeoutError(f"timed out with token {sentinel}"),
         )
     assert sentinel not in str(caught_message.value)
     assert "***REDACTED***" in str(caught_message.value)
 
 
-def test_openai_key_is_required_only_on_official_github_job(monkeypatch):
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.setenv("GITHUB_ACTIONS", "true")
-    monkeypatch.setenv("GITHUB_REPOSITORY", "razzant/ouroboros")
-    with pytest.raises(pytest.fail.Exception, match="required"):
-        require_openai_canary_key()
+def test_exact_provider_canary_matrix_and_physical_call_count():
+    matrix = provider_canary_matrix()
+    assert [(row.canary_id, row.model) for row in matrix] == [
+        ("openrouter_gemini", "google/gemini-3.7-flash"),
+        ("openrouter_opus", "anthropic/claude-opus-5"),
+        ("openrouter_gpt", "openai/gpt-5.6-luna"),
+        ("openrouter_grok", "x-ai/grok-4.6"),
+        ("openrouter_deepseek", "deepseek/deepseek-v4-pro-0813"),
+        ("openai_direct_main", "openai::gpt-5.6-terra"),
+        ("openai_direct_light", "openai::gpt-5.6-luna"),
+        ("openai_direct_fallback", "openai::gpt-5.6-sol"),
+        ("anthropic_direct", "anthropic::claude-sonnet-5"),
+        ("minimax_direct", "minimax::MiniMax-M3"),
+        ("cloudru_direct", "cloudru::zai-org/GLM-4.7"),
+        ("gigachat_direct", "gigachat::GigaChat-2-Max"),
+    ]
+    medium_ids = {row.canary_id for row in matrix if row.reasoning_effort == "medium"}
+    assert medium_ids == {
+        "openrouter_gemini",
+        "openrouter_opus",
+        "openrouter_gpt",
+        "openrouter_grok",
+        "openrouter_deepseek",
+        "openai_direct_main",
+        "openai_direct_light",
+        "openai_direct_fallback",
+        "anthropic_direct",
+    }
+    assert [row.canary_id for row in matrix if row.continue_to_final] == [
+        "openai_direct_main"
+    ]
+    assert [row.canary_id for row in matrix if not row.named_tool_choice] == [
+        "gigachat_direct"
+    ]
+    assert sum(1 + int(row.continue_to_final) for row in matrix) == 13
+    assert sum(
+        1 + int(row.continue_to_final)
+        for row in matrix
+        if row.credential_required
+    ) == 10
 
-    monkeypatch.setenv("GITHUB_REPOSITORY", "fork/ouroboros")
-    with pytest.raises(pytest.skip.Exception, match="not set"):
-        require_openai_canary_key()
 
-    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
-    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
-    monkeypatch.setenv("OPENAI_API_KEY", "   ")
-    with pytest.raises(pytest.skip.Exception, match="not set"):
-        require_openai_canary_key()
+def test_direct_anthropic_named_tool_choice_projects_without_type_error():
+    from ouroboros.llm import LLMClient
+
+    named = {"type": "function", "function": {"name": CANARY_TOOL_NAME}}
+    assert LLMClient._build_anthropic_tool_choice(named) == {
+        "type": "tool", "name": CANARY_TOOL_NAME,
+    }
+    assert LLMClient._build_anthropic_tool_choice("required") == {"type": "any"}
+    assert LLMClient._build_anthropic_tool_choice("none") == {"type": "none"}
 
 
 def test_openai_models_follow_default_ssot_without_allowlist(monkeypatch):
@@ -195,35 +225,43 @@ def test_openai_models_follow_default_ssot_without_allowlist(monkeypatch):
     monkeypatch.setitem(OPENAI_DIRECT_DEFAULTS, "future_ci_duplicate", future)
     assert unique_openai_direct_defaults()[-1] == future
     assert unique_openai_direct_defaults().count(future) == 1
+    assert [
+        row.model
+        for row in provider_canary_matrix()
+        if row.expected_provider == "openai"
+    ][-1] == future
 
 
-def test_registry_canary_lookup_never_refreshes_mcp(monkeypatch, tmp_path):
-    import ouroboros.mcp_client as mcp_client
+def test_required_and_optional_credential_policy(monkeypatch):
+    required = next(row for row in provider_canary_matrix() if row.canary_id == "openrouter_gemini")
+    optional = next(row for row in provider_canary_matrix() if row.canary_id == "minimax_direct")
+    monkeypatch.delenv(required.credential_env, raising=False)
+    monkeypatch.delenv(optional.credential_env, raising=False)
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "razzant/ouroboros")
 
-    refreshes = []
+    with pytest.raises(pytest.fail.Exception, match="required"):
+        require_provider_canary_credential(required)
+    with pytest.raises(pytest.skip.Exception, match="optional provider canary"):
+        require_provider_canary_credential(optional)
 
-    def record_refresh(*_args, **kwargs):
-        refreshes.append(kwargs.get("refresh"))
+    monkeypatch.setenv("GITHUB_REPOSITORY", "fork/ouroboros")
+    with pytest.raises(pytest.skip.Exception, match="required core"):
+        require_provider_canary_credential(required)
 
-    monkeypatch.setattr(
-        mcp_client,
-        "ensure_configured_from_settings",
-        record_refresh,
-    )
-    tool = registry_openai_canary_tool(tmp_path)
-    assert tool["function"]["name"] == OPENAI_CANARY_TOOL_NAME
-    assert refreshes == []
+    monkeypatch.setenv(required.credential_env, "test-present")
+    assert require_provider_canary_credential(required) is None
 
 
-def _bind_candidate(model, tool, messages, tool_choice):
+def _bind_candidate(model, tools, messages, tool_choice):
     prefix, separator, resolved_model = model.partition("::")
     assert (prefix, separator) == ("openai", "::")
     source = {
         "model": resolved_model,
         "messages": copy.deepcopy(messages),
         "reasoning_effort": "medium",
-        "max_completion_tokens": OPENAI_CANARY_MAX_TOKENS,
-        "tools": [copy.deepcopy(tool)],
+        "max_completion_tokens": CANARY_MAX_TOKENS,
+        "tools": copy.deepcopy(tools),
         "tool_choice": copy.deepcopy(tool_choice),
     }
     return bind_wire_candidate(
@@ -236,30 +274,30 @@ def _bind_candidate(model, tool, messages, tool_choice):
         api_surface="chat.completions",
         source_payload=source,
         candidate_spec=WireCandidateSpec(
-            "openai_chat_custom",
-            "medium",
-            "requested_wire_form",
+            "openai_chat_custom", "medium", "requested_wire_form",
         ),
         requested_effort="medium",
         ladder_ordinal=1,
     )
 
 
-def test_shipped_defaults_bind_registry_strict_custom_medium_shape(tmp_path):
-    tool = registry_openai_canary_tool(tmp_path)
-    choice = {
-        "type": "function",
-        "function": {"name": OPENAI_CANARY_TOOL_NAME},
-    }
+def test_shipped_defaults_bind_full_registry_custom_medium_shape():
+    tools = full_registry_canary_tools()
+    names = [tool["function"]["name"] for tool in tools]
+    choice = {"type": "function", "function": {"name": CANARY_TOOL_NAME}}
+    delegate_schema = next(
+        tool["function"]["parameters"]
+        for tool in tools
+        if tool["function"]["name"] == CANARY_TOOL_NAME
+    )
     for model in unique_openai_direct_defaults():
         candidate = _bind_candidate(
             model,
-            tool,
-            [{"role": "user", "content": "Call read_file exactly once."}],
+            tools,
+            [{"role": "user", "content": "Call delegate_start exactly once."}],
             choice,
         )
         physical = candidate.physical_payload()
-        assert candidate.source_profile.function_strictness == "strict"
         assert candidate.source_profile.tool_dialect == "function"
         assert candidate.accepted_profile.tool_dialect == "openai_chat_custom"
         assert candidate.accepted_profile.reasoning_carrier == "reasoning_effort"
@@ -267,65 +305,66 @@ def test_shipped_defaults_bind_registry_strict_custom_medium_shape(tmp_path):
         assert candidate.physical_model == normalize_model_identity(model)
         assert physical["model"] == model.split("::", 1)[-1]
         assert physical["reasoning_effort"] == "medium"
-        assert physical["max_completion_tokens"] == OPENAI_CANARY_MAX_TOKENS
+        assert physical["max_completion_tokens"] == CANARY_MAX_TOKENS
         assert "max_tokens" not in physical
         assert physical["tool_choice"] == {
-            "type": "custom",
-            "custom": {"name": OPENAI_CANARY_TOOL_NAME},
+            "type": "custom", "custom": {"name": CANARY_TOOL_NAME},
         }
-        assert physical["tools"][0]["custom"]["format"]["type"] == "grammar"
-        assert (
-            candidate.custom_catalog.schema_binding(OPENAI_CANARY_TOOL_NAME).schema() == tool["function"]["parameters"]
-        )
+        assert [tool["custom"]["name"] for tool in physical["tools"]] == names
+        assert candidate.custom_catalog.tool_names == tuple(names)
+        assert candidate.custom_catalog.schema_binding(
+            CANARY_TOOL_NAME
+        ).schema() == delegate_schema
 
 
-def test_custom_call_normalizes_and_replays_role_tool_continuation(tmp_path):
-    from ouroboros.openai_chat_custom import normalize_openai_custom_tool_calls
-
-    model = unique_openai_direct_defaults()[0]
-    tool = registry_openai_canary_tool(tmp_path)
-    user = {"role": "user", "content": "Call read_file exactly once."}
-    first = _bind_candidate(
-        model,
-        tool,
-        [user],
-        {
-            "type": "function",
-            "function": {"name": OPENAI_CANARY_TOOL_NAME},
-        },
-    )
-    raw_arguments = json.dumps(OPENAI_CANARY_ARGUMENTS, sort_keys=True)
-    canonical_calls, receipts = normalize_openai_custom_tool_calls(
-        [
-            {
-                "id": "call_phase2c",
-                "type": "custom",
-                "custom": {"name": OPENAI_CANARY_TOOL_NAME, "input": raw_arguments},
-            }
-        ],
-        first,
-    )
-    assert receipts[0].allows_execution
-    assert canonical_calls[0] == {
-        "id": "call_phase2c",
+def _canonical_canary_call(call_id, arguments):
+    return {
+        "id": call_id,
         "type": "function",
         "function": {
-            "name": OPENAI_CANARY_TOOL_NAME,
-            "arguments": raw_arguments,
+            "name": CANARY_TOOL_NAME,
+            "arguments": json.dumps(arguments, sort_keys=True),
         },
     }
 
-    nonce = "deterministic-phase2c-nonce"
+
+def test_custom_call_normalizes_and_replays_role_tool_continuation():
+    from ouroboros.openai_chat_custom import normalize_openai_custom_tool_calls
+
+    model = unique_openai_direct_defaults()[0]
+    tools = full_registry_canary_tools()
+    expected = delegate_start_canary_arguments("deterministic-custom")
+    user = {"role": "user", "content": "Call delegate_start exactly once."}
+    first = _bind_candidate(
+        model,
+        tools,
+        [user],
+        {"type": "function", "function": {"name": CANARY_TOOL_NAME}},
+    )
+    raw_arguments = json.dumps(expected, sort_keys=True)
+    canonical_calls, receipts = normalize_openai_custom_tool_calls(
+        [{
+            "id": "call_full_registry",
+            "type": "custom",
+            "custom": {"name": CANARY_TOOL_NAME, "input": raw_arguments},
+        }],
+        first,
+    )
+    assert receipts[0].allows_execution
+    assert canonical_calls[0] == _canonical_canary_call(
+        "call_full_registry", expected,
+    )
+
     continuation = _bind_candidate(
         model,
-        tool,
+        tools,
         [
             user,
             {"role": "assistant", "content": None, "tool_calls": canonical_calls},
             {
                 "role": "tool",
-                "tool_call_id": "call_phase2c",
-                "content": json.dumps({"nonce": nonce}),
+                "tool_call_id": "call_full_registry",
+                "content": json.dumps({"nonce": "deterministic-custom"}),
             },
         ],
         "none",
@@ -334,43 +373,51 @@ def test_custom_call_normalizes_and_replays_role_tool_continuation(tmp_path):
     assert physical["messages"][1]["tool_calls"][0]["type"] == "custom"
     assert physical["messages"][1]["tool_calls"][0]["custom"]["input"] == raw_arguments
     assert physical["messages"][2]["role"] == "tool"
-    assert physical["messages"][2]["tool_call_id"] == "call_phase2c"
-    assert nonce in physical["messages"][2]["content"]
+    assert physical["messages"][2]["tool_call_id"] == "call_full_registry"
     assert physical["tool_choice"] == "none"
     assert physical["reasoning_effort"] == "medium"
 
 
-def _fake_usage(model, ordinal):
-    return {
-        "provider": "openai",
-        "resolved_model": normalize_model_identity(model),
-        "prompt_tokens": 12,
-        "completion_tokens": 4,
-        "request_wire": {
-            "requested_effort": "medium",
-            "applied_effort": "medium",
-            "requested_tool_dialect": "function",
-            "applied_tool_dialect": "openai_chat_custom",
-            "reason_code": "requested_wire_form",
-            "source_profile_fingerprint": "a" * 64,
-            "accepted_profile_fingerprint": "b" * 64,
-            "attempt_id": f"attempt-{ordinal}",
-            "candidate_sha256": ("c" if ordinal == 1 else "d") * 64,
-            "ladder_ordinal": 1,
-            "applied_actions": [],
-            "task_local": False,
-        },
+def _fake_usage(canary: ProviderCanary, ordinal: int):
+    usage = {
+        "provider": canary.expected_provider,
+        "resolved_model": normalize_model_identity(canary.model),
+        "prompt_tokens": 120,
+        "completion_tokens": 12,
     }
+    if canary.expected_provider != "openai":
+        if canary.reasoning_effort == "medium":
+            usage["request_wire"] = {
+                "requested_effort": "medium",
+                "applied_effort": "medium",
+            }
+        return usage
+    usage["request_wire"] = {
+        "requested_effort": "medium",
+        "applied_effort": "medium",
+        "requested_tool_dialect": "function",
+        "applied_tool_dialect": "openai_chat_custom",
+        "reason_code": "requested_wire_form",
+        "source_profile_fingerprint": "a" * 64,
+        "accepted_profile_fingerprint": "b" * 64,
+        "attempt_id": f"attempt-{ordinal}",
+        "candidate_sha256": ("c" if ordinal == 1 else "d") * 64,
+        "ladder_ordinal": 1,
+        "applied_actions": [],
+        "task_local": False,
+    }
+    return usage
 
 
 def test_reasoning_integrity_canary_rejects_explicit_none_and_clamp():
     model = unique_openai_direct_defaults()[0]
-    explicit_none = _fake_usage(model, 1)
+    canary = next(row for row in provider_canary_matrix() if row.model == model)
+    explicit_none = _fake_usage(canary, 1)
     explicit_none["request_wire"]["applied_effort"] = "none"
     with pytest.raises(AssertionError):
         assert_openai_canary_usage(explicit_none, model)
 
-    clamped = _fake_usage(model, 1)
+    clamped = _fake_usage(canary, 1)
     clamped["reasoning_effort_clamped"] = {
         "requested": "medium",
         "applied": "none",
@@ -379,7 +426,7 @@ def test_reasoning_integrity_canary_rejects_explicit_none_and_clamp():
     with pytest.raises(AssertionError):
         assert_openai_canary_usage(clamped, model)
 
-    neutral_repair = _fake_usage(model, 1)
+    neutral_repair = _fake_usage(canary, 1)
     neutral_repair["request_wire"]["applied_actions"] = [{
         "source": "pending",
         "profile_fingerprint": "e" * 64,
@@ -392,38 +439,51 @@ def test_reasoning_integrity_canary_rejects_explicit_none_and_clamp():
     assert_openai_canary_usage(neutral_repair, model)
 
 
-def _canonical_canary_call(call_id):
-    return {
-        "id": call_id,
-        "type": "function",
-        "function": {
-            "name": OPENAI_CANARY_TOOL_NAME,
-            "arguments": json.dumps(OPENAI_CANARY_ARGUMENTS, sort_keys=True),
-        },
+def test_normalized_calls_require_unique_schema_valid_delegate_start():
+    tools = full_registry_canary_tools()
+    expected = delegate_start_canary_arguments("normalized-call")
+    assert assert_normalized_canary_call(
+        {"tool_calls": [_canonical_canary_call("call-ok", expected)]},
+        tools,
+        expected,
+    )[0]["id"] == "call-ok"
+
+    provider_defaults = {
+        **expected,
+        "root": "skill_payload",
+        "bucket": "",
+        "skill_name": "",
+        "retry_of": "",
+        "max_seconds": 0,
     }
+    assert assert_normalized_canary_call(
+        {"tool_calls": [_canonical_canary_call("call-defaults", provider_defaults)]},
+        tools,
+        expected,
+    )[0]["id"] == "call-defaults"
 
-
-def test_canary_call_validation_rejects_duplicate_ids(tmp_path):
-    tool = registry_openai_canary_tool(tmp_path)
-    duplicate = _canonical_canary_call("call-duplicate")
+    wrong = dict(expected, subagent_id="other")
     with pytest.raises(AssertionError):
         assert_normalized_canary_call(
-            {
-                "tool_calls": [
-                    duplicate,
-                    copy.deepcopy(duplicate),
-                ]
-            },
-            tool,
+            {"tool_calls": [_canonical_canary_call("call-wrong", wrong)]},
+            tools,
+            expected,
+        )
+    duplicate = _canonical_canary_call("call-duplicate", expected)
+    with pytest.raises(AssertionError):
+        assert_normalized_canary_call(
+            {"tool_calls": [duplicate, copy.deepcopy(duplicate)]},
+            tools,
+            expected,
         )
 
 
-def test_production_custom_none_text_is_semantic_success(monkeypatch, tmp_path):
+def test_production_custom_none_text_is_semantic_success(monkeypatch):
     model = unique_openai_direct_defaults()[0]
-    tool = registry_openai_canary_tool(tmp_path)
+    tools = full_registry_canary_tools()
     candidate = _bind_candidate(
         model,
-        tool,
+        tools,
         [{"role": "user", "content": "Use the supplied tool result."}],
         "none",
     )
@@ -432,8 +492,8 @@ def test_production_custom_none_text_is_semantic_success(monkeypatch, tmp_path):
         "model": resolved_model,
         "messages": [{"role": "user", "content": "Use the supplied tool result."}],
         "reasoning_effort": "medium",
-        "max_completion_tokens": OPENAI_CANARY_MAX_TOKENS,
-        "tools": [copy.deepcopy(tool)],
+        "max_completion_tokens": CANARY_MAX_TOKENS,
+        "tools": copy.deepcopy(tools),
         "tool_choice": "none",
     }
     target = {
@@ -443,21 +503,17 @@ def test_production_custom_none_text_is_semantic_success(monkeypatch, tmp_path):
         "base_url": "https://api.openai.com/v1",
     }
     assert candidate.forbids_tool_call is True
-    assert candidate.applied_actions == ()
-    foundation_observation = observe_wire_semantics(
+    observation = observe_wire_semantics(
         candidate=candidate,
-        normalized_response={
-            "role": "assistant",
-            "content": "phase2c semantic text",
-        },
+        normalized_response={"role": "assistant", "content": "semantic text"},
         normalized_usage={},
     )
-    assert foundation_observation.semantic_kind == "chat_message"
+    assert observation.semantic_kind == "chat_message"
 
     import ouroboros.openai_chat_dispatch as dispatch
     import ouroboros.request_wire_recovery as recovery
 
-    attempt_id = "phase2c-custom-none-text"
+    attempt_id = "full-registry-custom-none-text"
     capture = PhysicalAttemptCapture(
         attempt_id=attempt_id,
         model=candidate.physical_model,
@@ -482,90 +538,101 @@ def test_production_custom_none_text_is_semantic_success(monkeypatch, tmp_path):
 
     monkeypatch.setattr(recovery, "bind_wire_compatibility_receipt", record_receipt)
     with recovery.request_wire_call_scope():
-        recovery.register_wire_candidate(
-            candidate, source_payload=source, target=target,
-        )
+        recovery.register_wire_candidate(candidate, source_payload=source, target=target)
         recovery.note_wire_send_succeeded(capture)
         message, usage = dispatch.normalize_direct_openai_completion(
-            {"role": "assistant", "content": "phase2c semantic text"},
+            {"role": "assistant", "content": "semantic text"},
             {
                 "provider": "openai",
                 "resolved_model": normalize_model_identity(model),
-                "prompt_tokens": 12,
-                "completion_tokens": 4,
+                "prompt_tokens": 120,
+                "completion_tokens": 12,
             },
             None,
         )
         recovery.finalize_wire_response(message, usage)
 
-    assert message == {"role": "assistant", "content": "phase2c semantic text"}
+    assert message == {"role": "assistant", "content": "semantic text"}
     assert dispatch.CUSTOM_RECEIPTS_USAGE_KEY not in usage
     assert len(issued) == 1
     assert issued[0].semantic_kind == "chat_message"
     assert_openai_canary_usage(usage, model)
 
 
-def test_public_chat_contract_consumes_nonce_continuation(tmp_path):
-    model = unique_openai_direct_defaults()[0]
-    tool = registry_openai_canary_tool(tmp_path)
-    nonce = "unit-public-chat-nonce"
+def test_public_chat_builds_full_registry_request_for_every_matrix_row():
+    tools = full_registry_canary_tools()
+    names = [tool["function"]["name"] for tool in tools]
+    for canary in provider_canary_matrix():
+        nonce = f"unit-{canary.canary_id}"
+        expected = delegate_start_canary_arguments(nonce)
 
-    class FakeClient:
-        def __init__(self):
-            self.calls = []
+        class FakeClient:
+            def __init__(self):
+                self.calls = []
 
-        def chat(self, **kwargs):
-            self.calls.append(copy.deepcopy(kwargs))
-            ordinal = len(self.calls)
-            if ordinal == 1:
+            def chat(self, **kwargs):
+                self.calls.append(copy.deepcopy(kwargs))
+                ordinal = len(self.calls)
+                if ordinal == 1:
+                    calls = [
+                        _canonical_canary_call(
+                            f"call-{canary.canary_id}-1", expected,
+                        )
+                    ]
+                    if canary.continue_to_final:
+                        calls.append(_canonical_canary_call(
+                            f"call-{canary.canary_id}-2", expected,
+                        ))
+                    return (
+                        {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": calls,
+                        },
+                        _fake_usage(canary, ordinal),
+                    )
                 return (
                     {
                         "role": "assistant",
-                        "content": None,
-                        "tool_calls": [
-                            _canonical_canary_call("call_public_contract_1"),
-                            _canonical_canary_call("call_public_contract_2"),
-                        ],
+                        "content": f"FULL_REGISTRY_CONTINUED_{nonce}",
                     },
-                    _fake_usage(model, ordinal),
+                    _fake_usage(canary, ordinal),
                 )
-            return (
-                {
-                    "role": "assistant",
-                    "content": f"PHASE2C_CONTINUED_{nonce}",
-                },
-                _fake_usage(model, ordinal),
-            )
 
-    client = FakeClient()
-    run_openai_reasoning_tool_canary(
-        client,
-        model=model,
-        tool=tool,
-        nonce=nonce,
-        continue_to_final=True,
-    )
+        client = FakeClient()
+        run_provider_contract_canary(
+            client,
+            canary=canary,
+            tools=tools,
+            nonce=nonce,
+        )
 
-    assert len(client.calls) == 2
-    first, second = client.calls
-    for call in client.calls:
-        assert call["model"] == model
-        assert call["tools"] == [tool]
-        assert call["reasoning_effort"] == "medium"
-        assert call["max_tokens"] == OPENAI_CANARY_MAX_TOKENS
-        assert call["no_proxy"] is True
-        assert call["timeout"] == OPENAI_CANARY_TIMEOUT_SEC
-    assert first["tool_choice"]["function"]["name"] == OPENAI_CANARY_TOOL_NAME
-    assert second["tool_choice"] == "none"
-    assert nonce not in first["messages"][0]["content"]
-    assert [message["role"] for message in second["messages"]] == [
-        "user",
-        "assistant",
-        "tool",
-        "tool",
-    ]
-    assert [message["tool_call_id"] for message in second["messages"][2:]] == [
-        "call_public_contract_1",
-        "call_public_contract_2",
-    ]
-    assert all(nonce in message["content"] for message in second["messages"][2:])
+        assert len(client.calls) == 1 + int(canary.continue_to_final)
+        first = client.calls[0]
+        assert first["model"] == canary.model
+        assert first["reasoning_effort"] == canary.reasoning_effort
+        assert first["max_tokens"] == CANARY_MAX_TOKENS
+        assert first["no_proxy"] is True
+        assert first["timeout"] == CANARY_TIMEOUT_SEC
+        assert [tool["function"]["name"] for tool in first["tools"]] == names
+        if canary.named_tool_choice:
+            assert first["tool_choice"] == {
+                "type": "function", "function": {"name": CANARY_TOOL_NAME},
+            }
+        else:
+            assert first["tool_choice"] == "auto"
+        if canary.continue_to_final:
+            second = client.calls[1]
+            assert second["tool_choice"] == "none"
+            assert second["max_tokens"] == CANARY_CONTINUATION_MAX_TOKENS
+            assert [tool["function"]["name"] for tool in second["tools"]] == [
+                CANARY_TOOL_NAME,
+            ]
+            assert [message["role"] for message in second["messages"]] == [
+                "user", "assistant", "tool", "tool",
+            ]
+            assert [message["tool_call_id"] for message in second["messages"][2:]] == [
+                f"call-{canary.canary_id}-1",
+                f"call-{canary.canary_id}-2",
+            ]
+            assert all(nonce in message["content"] for message in second["messages"][2:])

--- a/tests/test_provider_integration.py
+++ b/tests/test_provider_integration.py
@@ -1,239 +1,58 @@
-"""
-Provider integration tests — real API calls to verify each LLM provider works.
+"""Trusted live full-registry provider-contract canaries.
 
-These tests are marked with @pytest.mark.integration and excluded from the
-default pytest run via pyproject.toml addopts. They run only on:
-  - main / ouroboros / ouroboros-stable push (CI Tier 2.5)
-  - workflow_dispatch (manual)
-  - tag push (v*)
-
-Optional provider smokes skip when their API key is absent. The shipped-default
-OpenAI reasoning/tool canary requires ``OPENAI_API_KEY`` in the official GitHub
-job, so deleting that secret cannot turn the contract alarm into a green no-op.
+The integration marker is excluded from ordinary pull-request pytest.  These
+tests run only in the trusted target-push/manual/tag lane, where core provider
+credentials are mandatory and optional direct-provider credentials remain loud
+skips.  Every first turn sends the same complete shipped built-in catalog and
+validates a normalized ``delegate_start`` call without executing it.
 """
 
 from __future__ import annotations
 
-import os
 import uuid
 
 import pytest
 
-from ouroboros.provider_models import OPENAI_DIRECT_DEFAULTS
 from tests.provider_contract_ci import (
-    registry_openai_canary_tool,
-    require_openai_canary_key,
-    run_openai_reasoning_tool_canary,
+    full_registry_canary_tools,
+    provider_canary_matrix,
+    require_provider_canary_credential,
+    run_provider_contract_canary,
     skip_on_provider_environmental_error,
-    unique_openai_direct_defaults,
 )
 
 integration = pytest.mark.integration
-_OPENAI_REASONING_TOOL_MODELS = unique_openai_direct_defaults()
+_PROVIDER_CANARIES = provider_canary_matrix()
 
 
 def _get_llm_client():
-    """Lazy import to avoid breaking collection when ouroboros is not installed."""
+    """Lazy import keeps secretless collection independent of runtime clients."""
     from ouroboros.llm import LLMClient
 
     return LLMClient()
 
 
-def _assert_basic_response(result, expected_provider=None):
-    """Shared assertion: non-empty reply, token usage present."""
-    if isinstance(result, tuple):
-        msg, usage = result
-    else:
-        msg = result
-        usage = result.get("usage", {}) if isinstance(result, dict) else {}
-
-    text = ""
-    if isinstance(msg, dict):
-        text = msg.get("content", "") or ""
-        if isinstance(text, list):
-            text = " ".join(block.get("text", "") for block in text if isinstance(block, dict))
-        if not text and expected_provider == "cloudru" and msg.get("reasoning"):
-            pytest.skip(
-                "Cloud.ru returned reasoning-only output without final content; "
-                "provider route/auth/usage worked, but the hosted model did not "
-                "emit a final answer for this smoke prompt."
-            )
-    assert text, f"Empty response from LLM: {result}"
-    assert isinstance(usage, dict), f"Usage is not a dict: {type(usage)}"
-    assert usage.get("prompt_tokens", 0) > 0, f"No prompt_tokens in usage: {usage}"
-    assert usage.get("completion_tokens", 0) > 0, f"No completion_tokens in usage: {usage}"
-    if expected_provider:
-        resolved = usage.get("provider", "") or usage.get("resolved_model", "") or ""
-        assert expected_provider.lower() in resolved.lower(), (
-            f"Expected provider '{expected_provider}' in resolved model, got '{resolved}'"
-        )
-
-
-# The former direct-OpenAI gpt-4o-mini text row is intentionally absent. The
-# registry/default-derived canary below asserts the same direct route plus exact
-# shipped model identity, positive usage, custom+medium wire disclosure, and a
-# real continuation. Keeping the stale text row would add cost without coverage.
-_PROVIDER_MATRIX = [
-    (
-        "openrouter",
-        "OPENROUTER_API_KEY",
-        "anthropic/claude-sonnet-4.6",
-        "openrouter",
-    ),
-    (
-        "anthropic_direct",
-        "ANTHROPIC_API_KEY",
-        "anthropic::claude-sonnet-5",
-        "anthropic",
-    ),
-    (
-        "cloudru",
-        "CLOUDRU_FOUNDATION_MODELS_API_KEY",
-        "cloudru::zai-org/GLM-4.7",
-        "cloudru",
-    ),
-]
+@pytest.fixture(scope="module")
+def shipped_builtin_tools():
+    return full_registry_canary_tools()
 
 
 @integration
 @pytest.mark.parametrize(
-    "provider_id,env_key,model,expected_provider",
-    _PROVIDER_MATRIX,
-    ids=[entry[0] for entry in _PROVIDER_MATRIX],
+    "canary",
+    _PROVIDER_CANARIES,
+    ids=[canary.canary_id for canary in _PROVIDER_CANARIES],
 )
-def test_provider_basic_chat(provider_id, env_key, model, expected_provider):
-    """Verify each optional provider responds to a bounded text request."""
-    if not os.environ.get(env_key):
-        pytest.skip(f"{env_key} not set")
+def test_full_registry_provider_contract(canary, shipped_builtin_tools):
+    """Exercise one bounded public-chat canary per physical provider surface."""
+    require_provider_canary_credential(canary)
     try:
-        result = _get_llm_client().chat(
-            messages=[{"role": "user", "content": "Respond with exactly: OK"}],
-            model=model,
-            max_tokens=1024,
-        )
-    except Exception as exc:  # noqa: BLE001
-        skip_on_provider_environmental_error(provider_id, exc)
-        raise
-    _assert_basic_response(result, expected_provider=expected_provider)
-
-
-@integration
-@pytest.mark.parametrize(
-    "model",
-    _OPENAI_REASONING_TOOL_MODELS,
-    ids=[model.split("::", 1)[-1] for model in _OPENAI_REASONING_TOOL_MODELS],
-)
-def test_openai_shipped_reasoning_models_custom_tool_continuation(model, tmp_path):
-    """Alarm on the exact shipped direct-OpenAI reasoning/tool contract.
-
-    Every unique model from the provider-default SSOT must preserve requested
-    ``medium`` on the production custom-tool path. The Main row additionally
-    replays the returned canonical assistant call, submits an ordinary
-    ``role=tool`` result carrying a nonce, and requires the exact final marker
-    that was absent from the initial prompt.
-    Continuation is one provider/API/dialect protocol class, so repeating that
-    second turn for every model would add cost and flake surface without a new
-    contract; each model still gets its own first-turn wire acceptance alarm.
-    Quota/429/5xx/timeout are typed inconclusive; every contract/auth/model/tool/
-    reasoning 4xx remains red.
-    """
-    require_openai_canary_key()
-    try:
-        run_openai_reasoning_tool_canary(
+        run_provider_contract_canary(
             _get_llm_client(),
-            model=model,
-            tool=registry_openai_canary_tool(tmp_path),
+            canary=canary,
+            tools=shipped_builtin_tools,
             nonce=uuid.uuid4().hex,
-            continue_to_final=model == OPENAI_DIRECT_DEFAULTS["main"],
         )
     except Exception as exc:  # noqa: BLE001
-        skip_on_provider_environmental_error("openai_direct", exc)
+        skip_on_provider_environmental_error(canary.canary_id, exc)
         raise
-
-
-@integration
-@pytest.mark.skipif(
-    not os.environ.get("GIGACHAT_CREDENTIALS"),
-    reason="GIGACHAT_CREDENTIALS not set",
-)
-def test_gigachat_basic_chat():
-    """Verify GigaChat direct routing via the gigachat library works."""
-    result = _get_llm_client().chat(
-        messages=[{"role": "user", "content": "Respond with exactly: OK"}],
-        model="gigachat::GigaChat-3-Ultra",
-    )
-    _assert_basic_response(result, expected_provider="gigachat")
-
-
-_COMPETING_KEYS = [
-    "OPENROUTER_API_KEY",
-    "OPENAI_API_KEY",
-    "OPENAI_BASE_URL",
-    "OPENAI_COMPATIBLE_API_KEY",
-    "OPENAI_COMPATIBLE_BASE_URL",
-    "CLOUDRU_FOUNDATION_MODELS_API_KEY",
-    "GIGACHAT_CREDENTIALS",
-    "ANTHROPIC_API_KEY",
-]
-
-# Direct OpenAI needs no duplicate gpt-4o-mini isolation row: its explicit
-# ``openai::`` route and exact usage identity are asserted by the stronger canary.
-_ISOLATION_MATRIX = [
-    (
-        "openrouter",
-        "OPENROUTER_API_KEY",
-        "anthropic/claude-sonnet-4.6",
-    ),
-    (
-        "anthropic_direct",
-        "ANTHROPIC_API_KEY",
-        "anthropic::claude-sonnet-5",
-    ),
-    (
-        "cloudru",
-        "CLOUDRU_FOUNDATION_MODELS_API_KEY",
-        "cloudru::zai-org/GLM-4.7",
-    ),
-]
-
-
-@integration
-@pytest.mark.parametrize(
-    "provider_id,env_key,model",
-    _ISOLATION_MATRIX,
-    ids=[entry[0] for entry in _ISOLATION_MATRIX],
-)
-def test_provider_isolation(provider_id, env_key, model, monkeypatch):
-    """Each optional provider works when it is the only configured provider."""
-    if not os.environ.get(env_key):
-        pytest.skip(f"{env_key} not set")
-    for key in _COMPETING_KEYS:
-        if key != env_key:
-            monkeypatch.delenv(key, raising=False)
-    try:
-        result = _get_llm_client().chat(
-            messages=[{"role": "user", "content": "Say hello"}],
-            model=model,
-            max_tokens=1024,
-        )
-    except Exception as exc:  # noqa: BLE001
-        skip_on_provider_environmental_error(provider_id, exc)
-        raise
-    _assert_basic_response(result)
-
-
-@integration
-@pytest.mark.skipif(
-    not os.environ.get("GIGACHAT_CREDENTIALS"),
-    reason="GIGACHAT_CREDENTIALS not set",
-)
-def test_gigachat_isolation(monkeypatch):
-    """GigaChat works when it is the only configured provider."""
-    for key in _COMPETING_KEYS:
-        if key != "GIGACHAT_CREDENTIALS":
-            monkeypatch.delenv(key, raising=False)
-    result = _get_llm_client().chat(
-        messages=[{"role": "user", "content": "Say hello"}],
-        model="gigachat::GigaChat-3-Ultra",
-    )
-    _assert_basic_response(result)


### PR DESCRIPTION
## Summary

Fixes the full-catalog Anthropic/OpenRouter rejection introduced when `delegate_start` gained a root `anyOf`, while preserving the existing typed runtime selector checks.

Adds a deterministic shipped-builtins-only portability gate and expands the trusted provider integration lane so schema changes are checked against the complete catalog across the main provider families before release.

## Scope

In scope:

- remove only the root `anyOf` from `delegate_start` and clarify fresh-start versus retry arguments;
- validate all 109 shipped built-in schemas as JSON Schema plus the known portable root subset, without loading MCP or extensions;
- prove the complete tool-name set survives OpenRouter/function, direct Anthropic, GigaChat, and direct OpenAI custom projections;
- run bounded full-registry live canaries for OpenRouter Gemini, Opus, GPT, Grok and DeepSeek, shipped direct OpenAI models, direct Anthropic, and optional MiniMax, Cloud.ru and GigaChat;
- keep pull-request CI secretless and make confirmed integration contract failures block release preflight;
- document the provider-contract invariant briefly.

Non-goals:

- no Responses API migration;
- no reasoning redesign or provider-specific runtime schema sanitizer;
- no runtime model allowlist;
- no version bump, merge, or release.

## Verification

- [x] Focused tests for the changed behavior pass.
- [x] The default local test suite passes.
- [x] Lint/static checks relevant to this change pass.

Commands and results:

```text
App Python, fresh OUROBOROS_DATA_DIR/TMPDIR:

pytest affected provider/schema/routing/consumer files
  RC 0

pytest tests/test_provider_contract_ci.py tests/test_provider_contract_catalog.py tests/test_llm_provider_routing.py
  69 passed, RC 0

pytest tests/test_provider_contract_ci.py tests/test_provider_contract_catalog.py
  32 passed, RC 0

pytest tests/ -m "not serial and not integration and not browser and not ui_browser and not ui_browser_docker and not portable_detail and not skill_smoke" -n auto --dist loadscope --max-worker-restart=0 --timeout=300 --timeout-method=thread -q --tb=short
  RC 0

pytest tests/ -m "serial and not integration and not browser and not ui_browser and not ui_browser_docker and not portable_detail and not skill_smoke" -q --tb=short
  RC 0

pytest tests/test_repo_health_smoke.py -q
scripts/regenerate_size_ratchet.py --check
  RC 0 / RC 0

ruff check <touched Python files> --select F,E9
py_compile <touched Python files>
git diff --check
  RC 0 / RC 0 / RC 0

pytest -o addopts= -m integration tests/test_provider_integration.py -q -rs --tb=short
  7 passed, 5 skipped, RC 0
  Core inconclusive by the approved classifier: direct OpenAI Main continuation and Sol timed out.
  Optional missing-credential skips: MiniMax, Cloud.ru, GigaChat.
  Confirmed full-registry acceptance: OpenRouter Gemini/Opus/GPT/Grok/DeepSeek, direct OpenAI Luna, direct Anthropic Sonnet 5.
```

The exact final live run used public `LLMClient.chat`, sent the complete 109-tool built-in catalog on every first turn, and never executed the returned `delegate_start` call.

## Visual evidence

- [x] Not applicable; this PR has no visible UI change.
- [ ] Before/after screenshots or other rendered-flow evidence are attached below.

## Governance and documentation

- [x] The implementation/review contexts read `CONTRIBUTING.md`, `BIBLE.md`, `docs/ARCHITECTURE.md`, `docs/DEVELOPMENT.md`, and `docs/CHECKLISTS.md` in full.
- [x] I updated tests and documentation where behavior or architecture changed.
- [x] I did not include secrets, local settings, runtime state, logs, caches, or generated review artifacts in the commit.
- [x] I did **not** bump `VERSION` or release-only version carriers.

## Review evidence

- Review status: `PASS` from both required independent reviewers.
- Authoring agent/context: Codex root agent with parallel implementation subagents, isolated worktree.
- Separate review agent/context: Claudexor Claude harness and a separate collaboration subagent, both read-only on the detached exact candidate.
- Reviewer model and effort: `claude-fable-5`, high requested (effective effort unavailable); `gpt-5.6-sol`, high requested (post-run model/effort telemetry unavailable from the collaboration interface).
- Reviewed base SHA: `7de26338b78b3abb3242757458794bba2605e53f`
- Reviewed head SHA: `8cc6d609725a1c12139f16ef15982a3016a11181`
- Reviewed tree SHA: `87ee9433cff7743febcffeb03a4d0c0efde48b26`
- Binary diff SHA-256: `a358f370ffbdd0615164d329d78a22d7d8b4a50b7a69ce687879a49c53f40186`
- Findings and disposition: no material normal-path findings. Fable noted wording precision around “empty enum” and the deliberate tolerance for provider-added declared optional fields; both are advisory and required no source change.
- Checks and limitations: both reviewers inspected the touched provider/schema/CI surfaces. The Sol reviewer independently bound the exact base/head/tree/diff and ran 40 focused tests plus Ruff/diff checks. The Fable reviewer observed the exact model but lacked shell diff enumeration and did not read all of ARCHITECTURE line by line; this was covered by the independent Sol review and root exact-hash evidence.
- Full review output: Claudexor run `run-56ba472ff87d`; collaboration review output is recorded in the authoring task.

## Final checklist

- [x] The PR base branch is `ouroboros`.
- [x] The branch is based on a current `ouroboros` revision.
- [x] The PR is one coherent change and is ready for maintainer integration.
- [x] The description explains limitations and compatibility impact.
