### PR TITLE
Fix full-registry provider canary semantics

### DIFF
--- a/tests/provider_contract_ci.py
+++ b/tests/provider_contract_ci.py
@@ -344,7 +344,7 @@ def assert_canary_usage(usage, canary: ProviderCanary):
     return usage.get("request_wire")
 
 
-def assert_normalized_canary_call(message, tools, expected_arguments):
+def assert_normalized_canary_call(message, tools, required_arguments):
     from jsonschema import validators
 
     calls = message.get("tool_calls") if isinstance(message, dict) else None
@@ -368,7 +368,7 @@ def assert_normalized_canary_call(message, tools, expected_arguments):
         arguments = json.loads(raw_arguments)
         assert not list(validator_class(schema).iter_errors(arguments))
         assert set(arguments) <= set((schema.get("properties") or {}).keys()), arguments
-        for key, expected in expected_arguments.items():
+        for key, expected in required_arguments.items():
             assert arguments.get(key) == expected, arguments
     return calls
 
@@ -381,13 +381,22 @@ def run_provider_contract_canary(
     nonce: str,
 ):
     """Exercise the public chat seam without executing the returned tool call."""
-    expected_arguments = delegate_start_canary_arguments(nonce)
-    arguments_json = json.dumps(expected_arguments, ensure_ascii=False, sort_keys=True)
+    requested_arguments = delegate_start_canary_arguments(nonce)
+    required_arguments = {"prompt": requested_arguments["prompt"]}
+    arguments_json = json.dumps(requested_arguments, ensure_ascii=False, sort_keys=True)
+    final_marker = f"FULL_REGISTRY_CONTINUED_{nonce}"
+    continuation_instruction = (
+        "After its tool result, read the expected_final_marker field and reply "
+        "with exactly that value. "
+        if canary.continue_to_final
+        else ""
+    )
     conversation = [{
         "role": "user",
         "content": (
             f"Call {CANARY_TOOL_NAME} exactly once with exactly this JSON object "
             f"as its arguments: {arguments_json}. Do not add, omit, or change a field. "
+            f"{continuation_instruction}"
             "Return the tool call now and no prose."
         ),
     }]
@@ -402,12 +411,15 @@ def run_provider_contract_canary(
         no_proxy=True,
         timeout=CANARY_TIMEOUT_SEC,
     )
-    calls = assert_normalized_canary_call(message, tools, expected_arguments)
+    # This is a provider schema-admission canary, not a duplicate of the
+    # runtime selector gate.  The provider must preserve the nonce-bearing
+    # prompt and return only declared, schema-valid fields; subagent_id versus
+    # retry_of is enforced by the existing typed runtime refusal tests.
+    calls = assert_normalized_canary_call(message, tools, required_arguments)
     first_disclosure = assert_canary_usage(usage, canary)
     if not canary.continue_to_final:
         return message, usage, None, None
 
-    final_marker = f"FULL_REGISTRY_CONTINUED_{nonce}"
     continuation = [
         *conversation,
         message,

--- a/tests/test_provider_contract_ci.py
+++ b/tests/test_provider_contract_ci.py
@@ -442,10 +442,11 @@ def test_reasoning_integrity_canary_rejects_explicit_none_and_clamp():
 def test_normalized_calls_require_unique_schema_valid_delegate_start():
     tools = full_registry_canary_tools()
     expected = delegate_start_canary_arguments("normalized-call")
+    required = {"prompt": expected["prompt"]}
     assert assert_normalized_canary_call(
         {"tool_calls": [_canonical_canary_call("call-ok", expected)]},
         tools,
-        expected,
+        required,
     )[0]["id"] == "call-ok"
 
     provider_defaults = {
@@ -459,22 +460,34 @@ def test_normalized_calls_require_unique_schema_valid_delegate_start():
     assert assert_normalized_canary_call(
         {"tool_calls": [_canonical_canary_call("call-defaults", provider_defaults)]},
         tools,
-        expected,
+        required,
     )[0]["id"] == "call-defaults"
 
-    wrong = dict(expected, subagent_id="other")
+    provider_selector = {
+        "prompt": expected["prompt"],
+        "retry_of": "provider-contract-canary",
+        "root": "skill_payload",
+        "bucket": "external",
+    }
+    assert assert_normalized_canary_call(
+        {"tool_calls": [_canonical_canary_call("call-selector", provider_selector)]},
+        tools,
+        required,
+    )[0]["id"] == "call-selector"
+
+    wrong = dict(expected, prompt="different nonce-bearing prompt")
     with pytest.raises(AssertionError):
         assert_normalized_canary_call(
             {"tool_calls": [_canonical_canary_call("call-wrong", wrong)]},
             tools,
-            expected,
+            required,
         )
     duplicate = _canonical_canary_call("call-duplicate", expected)
     with pytest.raises(AssertionError):
         assert_normalized_canary_call(
             {"tool_calls": [duplicate, copy.deepcopy(duplicate)]},
             tools,
-            expected,
+            required,
         )
 
 
@@ -622,6 +635,8 @@ def test_public_chat_builds_full_registry_request_for_every_matrix_row():
         else:
             assert first["tool_choice"] == "auto"
         if canary.continue_to_final:
+            assert "After its tool result" in first["messages"][0]["content"]
+            assert "expected_final_marker" in first["messages"][0]["content"]
             second = client.calls[1]
             assert second["tool_choice"] == "none"
             assert second["max_tokens"] == CANARY_CONTINUATION_MAX_TOKENS
@@ -636,3 +651,5 @@ def test_public_chat_builds_full_registry_request_for_every_matrix_row():
                 f"call-{canary.canary_id}-2",
             ]
             assert all(nonce in message["content"] for message in second["messages"][2:])
+        else:
+            assert "After its tool result" not in first["messages"][0]["content"]


### PR DESCRIPTION
This fixes the two post-merge full-registry canary failures from #274. The Direct OpenAI Main continuation again receives its standing instruction before the tool result, and the schema-admission assertion now requires the exact nonce-bearing prompt while leaving selector validity to the existing typed runtime refusals. The patch is test-only; runtime, schemas, workflow, docs, protected files, and version carriers are unchanged. Verification: 77 focused tests passed, Ruff F,E9 passed, py_compile passed, git diff --check passed, the exact 12-row integration matrix collected, and the live openai_direct_main and cloudru_direct rows passed 2/2. Claudexor Claude Code claude-opus-5 at high effort reviewed exact head 1ee2ef71b8ea55b020742da9d09f6806db3747a8 in run-70f8418074ad and returned SAFE_TO_OPEN_PR.