### PR TITLE
Polish Settings action rows and neutral buttons

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -167,6 +167,11 @@ a server entry):
    secondary ink reads as disabled; if the owner can click it, it is
    `--text-primary`.
 
+For a row with one action and a durable result, the result occupies the flexible
+left side and the neutral action stays docked on the right. Field-level actions
+(for example Show/Clear) keep the field's control height; they are not reused as
+the compact result-row action.
+
 Rows of the same kind are equivalent: no row gets extra visual weight for
 being first, default, or native. Grouping and section-level actions express
 which family a row belongs to, and a section-level action (add, connect)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1804,7 +1804,11 @@ commit.
   `style=""` markup and `.style.<property>` assignments are review debt.
   Dynamic measured values may update a narrowly named CSS custom property when
   that is the actual runtime data flow.
-- One semantic button variant expresses one action role. Notifications use the
+- One semantic button variant expresses one action role. Neutral Settings and
+  onboarding controls use the existing `.btn.btn-default` role; do not add a
+  parallel `settings-ghost-btn` variant. A one-action result row uses the
+  named `.settings-action-row` contract (status first, action docked right),
+  while multi-action toolbars retain their own grouping. Notifications use the
   shared toast host unless status belongs to a permanently reserved control
   row. Working, warning, error, and destructive states keep consistent meaning
   across Chat, Logs, Settings, and Skills.

--- a/web/modules/harness_accounts.js
+++ b/web/modules/harness_accounts.js
@@ -880,7 +880,7 @@ export function renderAgentAccountsSection() {
             <div id="harness-accounts-groups" class="agent-family-list"></div>
             <div id="harness-login-card"></div>
             <div class="settings-toolbar">
-                <button type="button" class="settings-ghost-btn" id="btn-harness-refresh">Refresh</button>
+                <button type="button" class="btn btn-default" id="btn-harness-refresh">Refresh</button>
             </div>
         </div>
     `;
@@ -918,8 +918,8 @@ function rowHtml(row, payload, facets = {}) {
     // native pseudo-row has neither, because that engine has no route for
     // either and a dead button would claim an effect this app cannot have.
     const rowActions = row.kind === 'native' ? '' : `
-                <button type="button" class="settings-ghost-btn" data-harness-toggle data-enabled="${row.enabled === false ? '0' : '1'}" title="${row.enabled === false ? 'Let rotation use this account again' : 'Keep the login, take this account out of rotation'}">${row.enabled === false ? 'Enable' : 'Disable'}</button>
-                <button type="button" class="settings-ghost-btn" data-harness-remove title="Ask the agent service to forget this account">Remove</button>`;
+                <button type="button" class="btn btn-default" data-harness-toggle data-enabled="${row.enabled === false ? '0' : '1'}" title="${row.enabled === false ? 'Let rotation use this account again' : 'Keep the login, take this account out of rotation'}">${row.enabled === false ? 'Enable' : 'Disable'}</button>
+                <button type="button" class="btn btn-default" data-harness-remove title="Ask the agent service to forget this account">Remove</button>`;
     return `
         <div class="harness-account-row${quota.exhausted ? ' harness-exhausted' : ''}" data-harness="${escapeHtml(row.harness)}" data-profile="${escapeHtml(row.profile_id)}" data-kind="${escapeHtml(row.kind)}">
             <div class="harness-account-main">
@@ -928,7 +928,7 @@ function rowHtml(row, payload, facets = {}) {
             </div>
             <div class="harness-account-meta muted">${escapeHtml(meta)}</div>
             <div class="harness-account-actions">
-                <button type="button" class="settings-ghost-btn" data-harness-login>${escapeHtml(rowActionLabel(row, payload))}</button>${rowActions}
+                <button type="button" class="btn btn-default" data-harness-login>${escapeHtml(rowActionLabel(row, payload))}</button>${rowActions}
             </div>
         </div>
     `;
@@ -949,7 +949,7 @@ function groupHtml(group, payload, facets) {
                     <span class="ui-status" data-tone="${group.status.tone}">${escapeHtml(group.status.label)}</span>
                     ${nextUp ? `<span class="ui-status" data-tone="muted" data-next-up>${escapeHtml(nextUp)}</span>` : ''}
                 </div>
-                <button type="button" class="settings-ghost-btn" data-family-add>${escapeHtml(familyActionLabel(group, payload))}</button>
+                <button type="button" class="btn btn-default" data-family-add>${escapeHtml(familyActionLabel(group, payload))}</button>
             </div>
             <div class="agent-family-rows">${body}</div>
         </section>

--- a/web/modules/harness_login_cards.js
+++ b/web/modules/harness_login_cards.js
@@ -519,7 +519,7 @@ export function loginCardHtml(active, nowMs = Date.now(), { mode = LOGIN_CARD_FU
         bits.push(href ? `
             <div class="harness-signin-actions">
                 <a class="btn btn-primary" data-open-signin href="${href}" target="_blank" rel="noopener">Open sign-in link</a>
-                <button type="button" class="settings-ghost-btn" data-copy-signin-link>Copy link</button>
+                <button type="button" class="btn btn-default" data-copy-signin-link>Copy link</button>
             </div>
         ` : `
             <div class="settings-inline-note" data-tone="error" data-unsafe-signin-link>
@@ -533,7 +533,7 @@ export function loginCardHtml(active, nowMs = Date.now(), { mode = LOGIN_CARD_FU
                 <div class="harness-device-code">
                     <p>Enter this one-time code on that page:</p>
                     <div class="harness-code" data-device-code>${escapeHtml(disclosure.code)}</div>
-                    <button type="button" class="settings-ghost-btn" data-copy-device-code>Copy code</button>
+                    <button type="button" class="btn btn-default" data-copy-device-code>Copy code</button>
                 </div>
             `);
         }
@@ -566,7 +566,7 @@ export function loginCardHtml(active, nowMs = Date.now(), { mode = LOGIN_CARD_FU
                 <div class="harness-code-entry-row">
                     <input type="text" id="harness-code-input" data-login-code-input autocomplete="off" spellcheck="false"
                         placeholder="sign-in code" value="${escapeHtml(active.inputValue || '')}"${active.inputSent ? ' disabled' : ''}>
-                    <button type="button" class="settings-ghost-btn" data-login-code-submit${busy ? ' disabled' : ''}>${active.inputBusy ? 'Sending…' : (active.inputSent ? 'Code sent' : 'Submit code')}</button>
+                    <button type="button" class="btn btn-default" data-login-code-submit${busy ? ' disabled' : ''}>${active.inputBusy ? 'Sending…' : (active.inputSent ? 'Code sent' : 'Submit code')}</button>
                 </div>
                 ${active.inputError ? `<div class="settings-inline-note" data-tone="error">${escapeHtml(active.inputError)}</div>` : ''}
                 ${active.inputSent ? `<div class="settings-inline-status" data-tone="muted">${escapeHtml(active.inputNote || 'Code sent — finishing the sign-in…')}</div>` : ''}
@@ -648,7 +648,7 @@ export function loginCardHtml(active, nowMs = Date.now(), { mode = LOGIN_CARD_FU
                 <p>Continue this sign-in in your own terminal (outside Ouroboros).</p>
                 <p><strong>Command for ${escapeHtml(commandLabel)}:</strong></p>
                 <pre class="harness-attach-command" data-attach-command>${escapeHtml(active.attachCommand)}</pre>
-                <button type="button" class="settings-ghost-btn" data-copy-attach>Copy command</button>
+                <button type="button" class="btn btn-default" data-copy-attach>Copy command</button>
             </div>
         `);
     }
@@ -667,12 +667,12 @@ export function loginCardHtml(active, nowMs = Date.now(), { mode = LOGIN_CARD_FU
         : 'No sign-in link arrived yet. You can run this in your own terminal (outside Ouroboros) instead; the card follows the progress automatically:'}</p>
                 <p><strong>Command for ${escapeHtml(commandLabel)}:</strong></p>
                 <pre class="harness-attach-command" data-attach-command>${escapeHtml(active.attachCommand)}</pre>
-                <button type="button" class="settings-ghost-btn" data-copy-attach>Copy command</button>
+                <button type="button" class="btn btn-default" data-copy-attach>Copy command</button>
             </details>
         `);
     }
     if (!compact) {
-        bits.push('<button type="button" class="settings-ghost-btn" data-login-dismiss>Close</button>');
+        bits.push('<button type="button" class="btn btn-default" data-login-dismiss>Close</button>');
     }
     bits.push('</div>');
     return bits.join('');

--- a/web/modules/mcp_settings.js
+++ b/web/modules/mcp_settings.js
@@ -105,9 +105,9 @@ function renderServerCard(server, index) {
                         <input type="checkbox" data-mcp-field="enabled" ${enabled ? 'checked' : ''}>
                         <span>Enabled</span>
                     </label>
-                    <button type="button" class="settings-ghost-btn" data-mcp-test>Test</button>
-                    <button type="button" class="settings-ghost-btn" data-mcp-refresh>Refresh tools</button>
-                    <button type="button" class="settings-ghost-btn mcp-server-remove" data-mcp-remove>Remove</button>
+                    <button type="button" class="btn btn-default" data-mcp-test>Test</button>
+                    <button type="button" class="btn btn-default" data-mcp-refresh>Refresh tools</button>
+                    <button type="button" class="btn btn-default mcp-server-remove" data-mcp-remove>Remove</button>
                 </div>
             </header>
             <div class="form-grid two">
@@ -149,8 +149,8 @@ function renderServerCard(server, index) {
                     <label>Auth token (optional)</label>
                     <div class="secret-input-row">
                         <input type="password" data-mcp-field="auth_token" value="${escapeHtml(authToken)}" placeholder="${escapeHtml(authPlaceholder)}" autocomplete="off" spellcheck="false">
-                        <button type="button" class="settings-ghost-btn" data-mcp-token-toggle>Show</button>
-                        <button type="button" class="settings-ghost-btn" data-mcp-token-clear>Clear</button>
+                        <button type="button" class="btn btn-default" data-mcp-token-toggle>Show</button>
+                        <button type="button" class="btn btn-default" data-mcp-token-clear>Clear</button>
                     </div>
                 </div>
             </div>`}

--- a/web/modules/reviewer_slots.js
+++ b/web/modules/reviewer_slots.js
@@ -325,7 +325,7 @@ export function renderReviewerSlotsSection() {
             <h4 class="reviewer-slots-heading">Triad slots <span class="muted" id="reviewer-triad-limit" title="The commit gate's real ceiling"></span></h4>
             <div id="reviewer-triad-rows" class="reviewer-slot-rows"></div>
             <div class="settings-toolbar">
-                <button type="button" class="settings-ghost-btn" id="btn-add-triad-slot">Add triad slot</button>
+                <button type="button" class="btn btn-default" id="btn-add-triad-slot">Add triad slot</button>
             </div>
             <h4 class="reviewer-slots-heading">Scope slots <span class="muted" id="reviewer-scope-limit" title="The scope pool's real width"></span></h4>
             <div class="settings-inline-note">An agent row reads the repository with its own read-only tools instead of
@@ -333,7 +333,7 @@ export function renderReviewerSlotsSection() {
                 confirmed at 200K or more; Ouroboros does not attest which files the agent opened.</div>
             <div id="reviewer-scope-rows" class="reviewer-slot-rows"></div>
             <div class="settings-toolbar">
-                <button type="button" class="settings-ghost-btn" id="btn-add-scope-slot">Add scope slot</button>
+                <button type="button" class="btn btn-default" id="btn-add-scope-slot">Add scope slot</button>
             </div>
             <h4 class="reviewer-slots-heading">Advisory pre-reviewer</h4>
             <div id="reviewer-advisory-row" class="reviewer-slot-rows"></div>
@@ -391,7 +391,7 @@ function rowHtml(row, group) {
                 ${session ? selectHtml('data-slot-model aria-label="Harness model"', [{ label: '', options: modelOptions }], split.model) : ''}
                 ${session && profileOptions.length > 1 ? selectHtml('data-slot-profile aria-label="Credential account"', [{ label: '', options: profileOptions }], row.route.profile_id || '') : ''}
                 ${effortSelectHtml('data-slot-effort aria-label="Reasoning effort"', row.effort, surfaceDefault)}
-                <button type="button" class="settings-ghost-btn" data-slot-remove title="Remove this slot">Remove</button>
+                <button type="button" class="btn btn-default" data-slot-remove title="Remove this slot">Remove</button>
             </div>
             <div class="reviewer-slot-meta muted"${last ? ` title="${escapeHtml(lastRunMetaTitle(last))}"` : ''}>${escapeHtml(metaParts.join(' · '))}</div>
         </div>

--- a/web/modules/settings.js
+++ b/web/modules/settings.js
@@ -610,7 +610,7 @@ export function initSettings({ state, setBeforePageLeave, ws } = {}) {
         Object.keys(PROVIDER_TEST_INPUTS).forEach((provider) => {
             providerTestGenerations.set(provider, (providerTestGenerations.get(provider) || 0) + 1);
         });
-        page.querySelectorAll('[data-provider-test-status]').forEach((el) => { el.textContent = ''; });
+        page.querySelectorAll('[data-provider-test-status]').forEach((el) => setInlineStatus(el, '', 'muted'));
         applySecretInputs(page, s);
         INPUT_FIELDS.forEach(([id, key, fallback = '']) => applyInputValue(id, fallback && !s[key] ? fallback : s[key]));
         VALUE_FIELDS.forEach(([id, key, fallback]) => { byId(id).value = s[key] || fallback; });
@@ -762,7 +762,7 @@ export function initSettings({ state, setBeforePageLeave, ws } = {}) {
         try {
             await loadSettings();
             try {
-                await refreshModelCatalog();
+                await refreshModelCatalog({ button: byId('btn-refresh-model-catalog') });
                 setStatus('Settings loaded', 'ok');
             } catch (error) {
                 setStatus(

--- a/web/modules/settings.js
+++ b/web/modules/settings.js
@@ -97,6 +97,13 @@ function setStatus(text, tone = 'ok') {
     status.dataset.tone = tone;
 }
 
+function setButtonBusy(button, busy) {
+    if (!button) return;
+    button.disabled = busy;
+    if (busy) button.setAttribute('aria-busy', 'true');
+    else button.removeAttribute('aria-busy');
+}
+
 function readInt(id, fallback) {
     const value = parseInt(byId(id).value, 10);
     return Number.isNaN(value) ? fallback : value;
@@ -144,10 +151,10 @@ function customSecretRow(key = '', value = '') {
         <div class="form-field settings-custom-secret-key"><label>Key</label><input data-custom-secret-key value="${escapeHtml(key)}" placeholder="SLACK_WEBHOOK_URL" spellcheck="false"></div>
         <div class="form-field settings-custom-secret-value"><label>Value</label><div class="secret-input-row">
             <input id="${id}" data-custom-secret-value class="secret-input" type="password" value="${escapeHtml(value || '')}" placeholder="Secret value">
-            <button type="button" class="settings-ghost-btn" data-row-secret-toggle>Show</button>
-            <button type="button" class="settings-ghost-btn" data-row-secret-clear>Clear</button>
+            <button type="button" class="btn btn-default" data-row-secret-toggle>Show</button>
+            <button type="button" class="btn btn-default" data-row-secret-clear>Clear</button>
         </div><div class="settings-inline-note" data-custom-secret-error hidden></div></div>
-        <button type="button" class="settings-ghost-btn settings-custom-secret-remove" data-custom-secret-remove>Remove</button>`;
+        <button type="button" class="btn btn-default settings-custom-secret-remove" data-custom-secret-remove>Remove</button>`;
     wireSecretRow(row);
     row.querySelector('[data-custom-secret-remove]')?.addEventListener('click', () => { row.dataset.removeCustomSecret = '1'; row.hidden = true; markSettingsDirty(); });
     return row;
@@ -181,8 +188,8 @@ function renderRequestedSkillSecrets(root, skills, settings) {
         el.className = 'settings-requested-secret-row';
         el.innerHTML = `<div class="form-field"><label>${escapeHtml(key)}</label><div class="secret-input-row">
             <input id="${id}" data-secret-setting="${escapeHtml(key)}" class="secret-input" type="password" value="${escapeHtml(settings[key] || '')}" placeholder="Secret value">
-            <button type="button" class="settings-ghost-btn" data-row-secret-toggle>Show</button>
-            <button type="button" class="settings-ghost-btn" data-row-secret-clear>Clear</button>
+            <button type="button" class="btn btn-default" data-row-secret-toggle>Show</button>
+            <button type="button" class="btn btn-default" data-row-secret-clear>Clear</button>
         </div></div>`;
         wireSecretRow(el); host.appendChild(el);
     });
@@ -544,14 +551,13 @@ export function initSettings({ state, setBeforePageLeave, ws } = {}) {
             || (ready ? 'Claude runtime ready.' : (installed ? 'Claude runtime available but not ready.' : 'Claude runtime not available.'));
         const tone = ready ? 'ok' : (error ? 'error' : (installed ? 'muted' : 'error'));
         if (status) {
-            status.textContent = message;
-            status.dataset.tone = tone;
+            setInlineStatus(status, message, tone);
         }
         if (button) {
             button.dataset.busy = busy ? '1' : '0';
             button.dataset.ready = ready ? '1' : '0';
             button.dataset.installed = installed ? '1' : '0';
-            button.disabled = busy;
+            setButtonBusy(button, busy);
             button.textContent = busy ? 'Repairing...' : (ready ? 'Runtime OK' : 'Repair Runtime');
         }
         renderClaudeCodeUi();
@@ -1224,8 +1230,8 @@ export function initSettings({ state, setBeforePageLeave, ws } = {}) {
         const sentFingerprint = JSON.stringify(overrides);
         const sentGeneration = providerTestGenerations.get(provider) || 0;
         providerTestsInFlight.add(provider);
-        button.disabled = true;
-        if (status) status.textContent = 'Testing…';
+        setButtonBusy(button, true);
+        if (status) setInlineStatus(status, 'Testing…', 'muted');
         const resultIsCurrent = () => providerTestResultIsCurrent({
             sentGeneration,
             currentGeneration: providerTestGenerations.get(provider) || 0,
@@ -1234,14 +1240,16 @@ export function initSettings({ state, setBeforePageLeave, ws } = {}) {
         });
         try {
             const data = await apiClient.providerTest({ provider_id: provider, overrides });
-            if (status && resultIsCurrent()) status.textContent = providerTestStatusText(data);
+            if (status && resultIsCurrent()) {
+                setInlineStatus(status, providerTestStatusText(data), data?.ok ? 'ok' : 'danger');
+            }
         } catch (_error) {
             if (status && resultIsCurrent()) {
-                status.textContent = providerTestNetworkErrorStatus();
+                setInlineStatus(status, providerTestNetworkErrorStatus(), 'danger');
             }
         } finally {
             providerTestsInFlight.delete(provider);
-            button.disabled = false;
+            setButtonBusy(button, false);
         }
     });
 
@@ -1258,7 +1266,7 @@ export function initSettings({ state, setBeforePageLeave, ws } = {}) {
                     (providerTestGenerations.get(provider) || 0) + 1,
                 );
                 const status = page.querySelector(`[data-provider-test-status="${provider}"]`);
-                if (status) status.textContent = '';
+                if (status) setInlineStatus(status, '', 'muted');
                 break;
             }
         }
@@ -1291,8 +1299,8 @@ export function initSettings({ state, setBeforePageLeave, ws } = {}) {
         }
     });
 
-    byId('btn-refresh-model-catalog').addEventListener('click', async () => {
-        await refreshModelCatalog();
+    byId('btn-refresh-model-catalog').addEventListener('click', async (event) => {
+        await refreshModelCatalog({ button: event.currentTarget });
     });
 
     byId('btn-reload-settings')?.addEventListener('click', async () => {

--- a/web/modules/settings_catalog.js
+++ b/web/modules/settings_catalog.js
@@ -1,11 +1,10 @@
 import { apiFetch } from './api_client.js';
+import { setInlineStatus } from './ui_helpers.js';
 const MODEL_CATALOG_TIMEOUT_MS = 25000;
 let catalogRefreshSeq = 0;
 
 function setCatalogStatus(statusEl, text, tone = 'muted') {
-    if (!statusEl) return;
-    statusEl.textContent = text;
-    statusEl.dataset.tone = tone;
+    setInlineStatus(statusEl, text, tone);
 }
 
 function broadcastCatalog(items) {

--- a/web/modules/settings_catalog.js
+++ b/web/modules/settings_catalog.js
@@ -28,10 +28,14 @@ function fillCatalogDatalist(items) {
     broadcastCatalog(items);
 }
 
-export async function refreshModelCatalog() {
+export async function refreshModelCatalog({ button } = {}) {
     const refreshSeq = ++catalogRefreshSeq;
     const statusEl = document.getElementById('settings-model-catalog-status');
     setCatalogStatus(statusEl, 'Refreshing model catalog...', 'muted');
+    if (button) {
+        button.disabled = true;
+        button.setAttribute('aria-busy', 'true');
+    }
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), MODEL_CATALOG_TIMEOUT_MS);
 
@@ -84,5 +88,9 @@ export async function refreshModelCatalog() {
         return { items: [], errors: [{ provider_id: 'catalog', error: String(message) }] };
     } finally {
         clearTimeout(timeoutId);
+        if (button && refreshSeq === catalogRefreshSeq) {
+            button.disabled = false;
+            button.removeAttribute('aria-busy');
+        }
     }
 }

--- a/web/modules/settings_ui.js
+++ b/web/modules/settings_ui.js
@@ -59,8 +59,8 @@ function secretField({ id, settingKey, label, placeholder }) {
             <label>${label}</label>
             <div class="secret-input-row">
                 <input id="${id}" data-secret-setting="${settingKey}" class="secret-input" type="password" placeholder="${placeholder}">
-                <button type="button" class="settings-ghost-btn secret-toggle" data-target="${id}">Show</button>
-                <button type="button" class="settings-ghost-btn secret-clear" data-target="${id}">Clear</button>
+                <button type="button" class="btn btn-default secret-toggle" data-target="${id}">Show</button>
+                <button type="button" class="btn btn-default secret-clear" data-target="${id}">Clear</button>
             </div>
         </div>
     `;
@@ -149,9 +149,9 @@ const PROVIDER_CARDS = [
         testProvider: 'anthropic', testInputs: { 's-anthropic': 'ANTHROPIC_API_KEY' },
         note: 'Use model values like <code>anthropic::claude-sonnet-5</code> in the Models tab to route models directly through Anthropic. Claude tooling still reuses this key.',
         extra: `
-            <div class="settings-toolbar" id="settings-claude-code-panel" hidden>
-                <button type="button" class="settings-ghost-btn" id="btn-claude-code-install">Repair Runtime</button>
-                <span id="settings-claude-code-status" class="settings-inline-status">Checking Claude runtime...</span>
+            <div class="settings-action-row" id="settings-claude-code-panel" hidden>
+                <span id="settings-claude-code-status" class="settings-inline-status" role="status" aria-live="polite" aria-atomic="true">Checking Claude runtime...</span>
+                <button type="button" class="btn btn-default" id="btn-claude-code-install">Repair Runtime</button>
             </div>
             <div class="settings-inline-note" id="settings-claude-code-copy" hidden>Claude runtime powers the advisory pre-review on the API route. It is managed automatically by the app.</div>
         `,
@@ -169,9 +169,9 @@ function providerSettingsCard(spec) {
         .map((field) => field.settingKey ? secretField(field) : plainField(field))
         .join('');
     const test = spec.testProvider ? `
-            <div class="settings-toolbar">
-                <button type="button" class="settings-ghost-btn" data-provider-test="${spec.testProvider}" title="Sends one short model request. Provider charges may apply.">Test</button>
-                <span class="settings-inline-status" data-provider-test-status="${spec.testProvider}"></span>
+            <div class="settings-action-row">
+                <span class="settings-inline-status" data-provider-test-status="${spec.testProvider}" role="status" aria-live="polite" aria-atomic="true"></span>
+                <button type="button" class="btn btn-default" data-provider-test="${spec.testProvider}" title="Sends one short model request. Provider charges may apply.">Test</button>
             </div>
         ` : '';
     return providerCard({
@@ -369,9 +369,9 @@ export function renderSettingsPage() {
                             These fields are cloud model IDs. Enable <code>Local</code> to route that model
                             through the GGUF server configured in Advanced.
                         </div>
-                        <div class="settings-toolbar">
-                            <button type="button" class="settings-ghost-btn" id="btn-refresh-model-catalog">Refresh Model Catalog</button>
-                            <span id="settings-model-catalog-status" class="settings-inline-status">Model catalog is optional and failure-tolerant.</span>
+                        <div class="settings-action-row">
+                            <span id="settings-model-catalog-status" class="settings-inline-status" role="status" aria-live="polite" aria-atomic="true">Model catalog is optional and failure-tolerant.</span>
+                            <button type="button" class="btn btn-default" id="btn-refresh-model-catalog">Refresh Model Catalog</button>
                         </div>
                         <div class="settings-model-grid">
                             ${MODEL_CARDS.map(([title, copy, inputId, toggleId, defaultValue]) => modelCard({ title, copy, inputId, toggleId, defaultValue })).join('')}

--- a/web/modules/subagents_settings.js
+++ b/web/modules/subagents_settings.js
@@ -382,8 +382,8 @@ export function availableSubagentRowMarkup(row, state, index = 0) {
             </div>
             <div class="available-subagent-meta">${escapeHtml(meta)}</div>
             <div class="available-subagent-actions">
-                <button type="button" class="settings-ghost-btn" data-subagent-duplicate aria-label="Duplicate Subagent ${ordinal}">Duplicate</button>
-                <button type="button" class="settings-ghost-btn" data-subagent-remove aria-label="Remove Subagent ${ordinal}">Remove</button>
+                <button type="button" class="btn btn-default" data-subagent-duplicate aria-label="Duplicate Subagent ${ordinal}">Duplicate</button>
+                <button type="button" class="btn btn-default" data-subagent-remove aria-label="Remove Subagent ${ordinal}">Remove</button>
             </div>
         </article>`;
 }
@@ -578,7 +578,7 @@ export function createAvailableSubagentsEditor({
                     Enabled
                 </label>
                 <span class="available-subagents-count">${state.setting.items.length}/${MAX_AVAILABLE_SUBAGENTS}</span>
-                <button type="button" class="settings-ghost-btn" data-subagent-add
+                <button type="button" class="btn btn-default" data-subagent-add
                     ${!state.loaded || state.setting.items.length >= MAX_AVAILABLE_SUBAGENTS ? 'disabled' : ''}>Add subagent</button>
             </div>
             <div class="available-subagents-source">${escapeHtml([source, readProblem].filter(Boolean).join(' '))}</div>

--- a/web/modules/ui_helpers.js
+++ b/web/modules/ui_helpers.js
@@ -108,7 +108,10 @@ export function formatRelativeAge(time, freshLabel = 'Just installed') {
 }
 
 export function setInlineStatus(el, text, tone = 'muted') {
-    if (el) { el.textContent = text || ''; el.dataset.tone = normalizeTone(tone); }
+    if (!el) return;
+    const next = text || '';
+    if (el.textContent !== next) el.textContent = next;
+    el.dataset.tone = normalizeTone(tone);
 }
 
 export async function openViaHostBridge(url, filename = 'file') {

--- a/web/onboarding.css
+++ b/web/onboarding.css
@@ -57,6 +57,12 @@
   --status-error-bg: var(--red-dim);
   --status-neutral-fg: var(--text-meta);
   --status-neutral-bg: rgba(255, 255, 255, 0.08);
+  --radius-sm: 8px;
+  --button-padding-y: 8px;
+  --button-padding-x: 16px;
+  --button-font-size: 13px;
+  --button-min-height: 34px;
+  --focus-accent-border: rgba(232, 93, 111, 0.4);
 }
 
 * {
@@ -653,10 +659,15 @@ textarea:focus {
 
 .btn {
   border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  padding: var(--button-padding-y) var(--button-padding-x);
   cursor: pointer;
-  font-size: var(--type-body);
+  font-size: var(--button-font-size);
+  min-height: var(--button-min-height);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   transition: transform 120ms ease, border-color 120ms ease, background 120ms ease;
 }
 
@@ -676,6 +687,22 @@ textarea:focus {
 .btn-ghost {
   background: rgba(255, 255, 255, 0.03);
   color: var(--text);
+}
+
+.btn-default {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  border-color: rgba(255, 255, 255, 0.10);
+}
+
+.btn-default:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.07);
+  border-color: var(--border-strong);
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--focus-accent-border);
+  outline-offset: 2px;
 }
 
 .btn:disabled {
@@ -910,7 +937,7 @@ textarea:focus {
   gap: 8px;
 }
 
-.available-subagents-toolbar .settings-ghost-btn { margin-left: auto; }
+.available-subagents-toolbar .btn-default { margin-left: auto; }
 
 .available-subagents-count,
 .available-subagents-source,
@@ -971,7 +998,7 @@ textarea:focus {
 
 .available-subagent-actions { justify-content: flex-end; }
 
-.available-subagent-actions .settings-ghost-btn {
+.available-subagent-actions .btn-default {
   min-height: 34px;
   padding: 0 11px;
 }
@@ -1123,20 +1150,6 @@ textarea:focus {
   vertical-align: middle;
   position: relative;
   top: -1px;
-}
-
-.settings-ghost-btn {
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 10px;
-  padding: 8px 14px;
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--text);
-  font-size: var(--type-body);
-  cursor: pointer;
-}
-
-.settings-ghost-btn:hover {
-  border-color: var(--border-strong);
 }
 
 @media (max-height: 820px), (max-width: 900px) {
@@ -1291,7 +1304,7 @@ textarea:focus {
     grid-template-columns: 1fr;
   }
 
-  .available-subagents-toolbar .settings-ghost-btn {
+  .available-subagents-toolbar .btn-default {
     margin-left: 0;
   }
 }

--- a/web/settings.css
+++ b/web/settings.css
@@ -123,6 +123,9 @@
 }
 
 .settings-provider-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
     padding: 0 18px 18px;
 }
 
@@ -447,6 +450,25 @@
     gap: 10px;
 }
 
+/* A single action with a durable result belongs to one row: the result stays
+   readable on the left while the action keeps a stable right edge. */
+.settings-action-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: var(--space-3);
+    min-width: 0;
+}
+
+.settings-action-row > .settings-inline-status {
+    min-width: 0;
+}
+
+.settings-action-row > .btn-default {
+    justify-self: end;
+    flex: 0 0 auto;
+}
+
 .settings-footer {
     flex-shrink: 0;
     display: flex;
@@ -492,20 +514,9 @@
     min-width: 0;
 }
 
-.settings-ghost-btn {
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    background: rgba(255, 255, 255, 0.04);
-    color: var(--text-primary);
-    border-radius: 12px;
-    padding: 0 14px;
+.secret-input-row .btn-default,
+.settings-custom-secret-remove {
     min-height: 42px;
-    cursor: pointer;
-    font-size: var(--button-font-size);
-}
-
-.settings-ghost-btn:hover {
-    color: var(--text-primary);
-    border-color: rgba(232, 93, 111, 0.35);
 }
 
 .available-subagents-editor {
@@ -523,7 +534,7 @@
     gap: 8px;
 }
 
-.available-subagents-toolbar .settings-ghost-btn {
+.available-subagents-toolbar .btn-default {
     margin-left: auto;
 }
 
@@ -592,7 +603,7 @@
     justify-content: flex-end;
 }
 
-.available-subagent-actions .settings-ghost-btn {
+.available-subagent-actions .btn-default {
     min-height: 34px;
     padding: 0 11px;
 }
@@ -882,8 +893,17 @@
         grid-template-columns: 1fr;
     }
 
-    .available-subagents-toolbar .settings-ghost-btn {
+    .available-subagents-toolbar .btn-default {
         margin-left: 0;
+    }
+
+    .settings-action-row {
+        grid-template-columns: 1fr;
+        align-items: start;
+    }
+
+    .settings-action-row > .btn-default {
+        justify-self: end;
     }
 
     .settings-effort-group {

--- a/web/settings.css
+++ b/web/settings.css
@@ -464,9 +464,12 @@
     min-width: 0;
 }
 
+.settings-action-row > .settings-inline-status:empty {
+    display: none;
+}
+
 .settings-action-row > .btn-default {
     justify-self: end;
-    flex: 0 0 auto;
 }
 
 .settings-footer {
@@ -627,7 +630,6 @@
 }
 
 .settings-custom-secret-remove {
-    min-height: 40px;
     padding: 0 12px;
 }
 

--- a/web/settings.css
+++ b/web/settings.css
@@ -464,10 +464,6 @@
     min-width: 0;
 }
 
-.settings-action-row > .settings-inline-status:empty {
-    display: none;
-}
-
 .settings-action-row > .btn-default {
     justify-self: end;
 }
@@ -902,6 +898,10 @@
     .settings-action-row {
         grid-template-columns: 1fr;
         align-items: start;
+    }
+
+    .settings-action-row > .settings-inline-status:empty {
+        display: none;
     }
 
     .settings-action-row > .btn-default {

--- a/web/style.css
+++ b/web/style.css
@@ -2980,6 +2980,11 @@ textarea.chat-input::placeholder { color: var(--text-muted); }
     transition: transform 0.15s ease, border-color 0.15s ease, background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
 
+.btn:focus-visible {
+    outline: 2px solid var(--focus-accent-border);
+    outline-offset: 2px;
+}
+
 .btn:hover {
     transform: scale(1.02);
 }

--- a/web/tests/provider_test.test.js
+++ b/web/tests/provider_test.test.js
@@ -53,3 +53,18 @@ test('every provider test button warns that one charged request is sent', () => 
         );
     }
 });
+
+test('provider actions use the shared status-first action row contract', () => {
+    const html = renderSettingsPage();
+    const rows = [...html.matchAll(/<div class="settings-action-row(?:"|\s)[\s\S]*?<\/div>/g)]
+        .map(([row]) => row);
+    assert.equal(rows.length, 9, 'seven provider probes plus Claude and catalog actions');
+    assert.doesNotMatch(html, /settings-ghost-btn/);
+    for (const row of rows) {
+        const statusAt = row.indexOf('role="status"');
+        const actionAt = row.indexOf('class="btn btn-default"');
+        assert.ok(statusAt >= 0, 'each action row exposes a live status');
+        assert.ok(actionAt > statusAt, 'the action is docked after the status in source order');
+        assert.match(row, /aria-live="polite"/);
+    }
+});

--- a/web/tests/settings_action_row.test.js
+++ b/web/tests/settings_action_row.test.js
@@ -7,6 +7,7 @@ const onboardingCss = await readFile(new URL('../onboarding.css', import.meta.ur
 const styleCss = await readFile(new URL('../style.css', import.meta.url), 'utf8');
 const settingsJs = await readFile(new URL('../modules/settings.js', import.meta.url), 'utf8');
 const catalogJs = await readFile(new URL('../modules/settings_catalog.js', import.meta.url), 'utf8');
+const uiHelpersJs = await readFile(new URL('../modules/ui_helpers.js', import.meta.url), 'utf8');
 
 test('neutral controls have one shared button role in both UI shells', () => {
     assert.match(styleCss, /\.btn-default\s*\{/);
@@ -20,6 +21,7 @@ test('neutral controls have one shared button role in both UI shells', () => {
 test('single-action settings rows reserve a flexible status and responsive action edge', () => {
     assert.match(settingsCss, /\.settings-action-row\s*\{[\s\S]*grid-template-columns:\s*minmax\(0, 1fr\) auto/);
     assert.match(settingsCss, /\.settings-action-row\s*>\s*\.btn-default\s*\{[\s\S]*justify-self:\s*end/);
+    assert.match(settingsCss, /\.settings-action-row\s*>\s*\.settings-inline-status:empty\s*\{[\s\S]*display:\s*none/);
     assert.match(settingsCss, /@media \(max-width: 760px\)[\s\S]*\.settings-action-row\s*\{[\s\S]*grid-template-columns:\s*1fr/);
 });
 
@@ -28,6 +30,9 @@ test('async actions expose the same busy and status semantics', () => {
     assert.match(settingsJs, /setAttribute\('aria-busy', 'true'\)/);
     assert.match(settingsJs, /setInlineStatus\(status, 'Testing…', 'muted'\)/);
     assert.match(settingsJs, /providerTestStatusText\(data\), data\?\.ok \? 'ok' : 'danger'/);
+    assert.match(settingsJs, /refreshModelCatalog\(\{ button: byId\('btn-refresh-model-catalog'\) \}\)/);
+    assert.match(settingsJs, /setInlineStatus\(el, '', 'muted'\)/);
+    assert.match(uiHelpersJs, /if \(el\.textContent !== next\) el\.textContent = next/);
     assert.match(catalogJs, /refreshModelCatalog\(\{ button \} = \{\}\)/);
     assert.match(catalogJs, /refreshSeq === catalogRefreshSeq/);
 });

--- a/web/tests/settings_action_row.test.js
+++ b/web/tests/settings_action_row.test.js
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const settingsCss = await readFile(new URL('../settings.css', import.meta.url), 'utf8');
+const onboardingCss = await readFile(new URL('../onboarding.css', import.meta.url), 'utf8');
+const styleCss = await readFile(new URL('../style.css', import.meta.url), 'utf8');
+const settingsJs = await readFile(new URL('../modules/settings.js', import.meta.url), 'utf8');
+const catalogJs = await readFile(new URL('../modules/settings_catalog.js', import.meta.url), 'utf8');
+
+test('neutral controls have one shared button role in both UI shells', () => {
+    assert.match(styleCss, /\.btn-default\s*\{/);
+    assert.match(styleCss, /\.btn:focus-visible\s*\{/);
+    assert.match(onboardingCss, /\.btn-default\s*\{/);
+    assert.match(onboardingCss, /--button-min-height:\s*34px/);
+    assert.doesNotMatch(settingsCss, /settings-ghost-btn/);
+    assert.doesNotMatch(onboardingCss, /settings-ghost-btn/);
+});
+
+test('single-action settings rows reserve a flexible status and responsive action edge', () => {
+    assert.match(settingsCss, /\.settings-action-row\s*\{[\s\S]*grid-template-columns:\s*minmax\(0, 1fr\) auto/);
+    assert.match(settingsCss, /\.settings-action-row\s*>\s*\.btn-default\s*\{[\s\S]*justify-self:\s*end/);
+    assert.match(settingsCss, /@media \(max-width: 760px\)[\s\S]*\.settings-action-row\s*\{[\s\S]*grid-template-columns:\s*1fr/);
+});
+
+test('async actions expose the same busy and status semantics', () => {
+    assert.match(settingsJs, /function setButtonBusy\(button, busy\)/);
+    assert.match(settingsJs, /setAttribute\('aria-busy', 'true'\)/);
+    assert.match(settingsJs, /setInlineStatus\(status, 'Testing…', 'muted'\)/);
+    assert.match(settingsJs, /providerTestStatusText\(data\), data\?\.ok \? 'ok' : 'danger'/);
+    assert.match(catalogJs, /refreshModelCatalog\(\{ button \} = \{\}\)/);
+    assert.match(catalogJs, /refreshSeq === catalogRefreshSeq/);
+});

--- a/web/tests/settings_action_row.test.js
+++ b/web/tests/settings_action_row.test.js
@@ -19,10 +19,10 @@ test('neutral controls have one shared button role in both UI shells', () => {
 });
 
 test('single-action settings rows reserve a flexible status and responsive action edge', () => {
-    assert.match(settingsCss, /\.settings-action-row\s*\{[\s\S]*grid-template-columns:\s*minmax\(0, 1fr\) auto/);
-    assert.match(settingsCss, /\.settings-action-row\s*>\s*\.btn-default\s*\{[\s\S]*justify-self:\s*end/);
-    assert.match(settingsCss, /\.settings-action-row\s*>\s*\.settings-inline-status:empty\s*\{[\s\S]*display:\s*none/);
-    assert.match(settingsCss, /@media \(max-width: 760px\)[\s\S]*\.settings-action-row\s*\{[\s\S]*grid-template-columns:\s*1fr/);
+    assert.match(settingsCss, /\.settings-action-row\s*\{[^}]*grid-template-columns:\s*minmax\(0, 1fr\) auto/);
+    assert.match(settingsCss, /\.settings-action-row\s*>\s*\.btn-default\s*\{[^}]*justify-self:\s*end/);
+    assert.match(settingsCss, /\.settings-action-row\s*>\s*\.settings-inline-status:empty\s*\{[^}]*display:\s*none/);
+    assert.match(settingsCss, /@media \(max-width: 760px\)[\s\S]*?\.settings-action-row\s*\{[^}]*grid-template-columns:\s*1fr/);
 });
 
 test('async actions expose the same busy and status semantics', () => {

--- a/web/tests/settings_action_row.test.js
+++ b/web/tests/settings_action_row.test.js
@@ -21,7 +21,7 @@ test('neutral controls have one shared button role in both UI shells', () => {
 test('single-action settings rows reserve a flexible status and responsive action edge', () => {
     assert.match(settingsCss, /\.settings-action-row\s*\{[^}]*grid-template-columns:\s*minmax\(0, 1fr\) auto/);
     assert.match(settingsCss, /\.settings-action-row\s*>\s*\.btn-default\s*\{[^}]*justify-self:\s*end/);
-    assert.match(settingsCss, /\.settings-action-row\s*>\s*\.settings-inline-status:empty\s*\{[^}]*display:\s*none/);
+    assert.match(settingsCss, /@media \(max-width: 760px\)[\s\S]*?\.settings-action-row\s*>\s*\.settings-inline-status:empty\s*\{[^}]*display:\s*none/);
     assert.match(settingsCss, /@media \(max-width: 760px\)[\s\S]*?\.settings-action-row\s*\{[^}]*grid-template-columns:\s*1fr/);
 });
 
@@ -33,6 +33,8 @@ test('async actions expose the same busy and status semantics', () => {
     assert.match(settingsJs, /refreshModelCatalog\(\{ button: byId\('btn-refresh-model-catalog'\) \}\)/);
     assert.match(settingsJs, /setInlineStatus\(el, '', 'muted'\)/);
     assert.match(uiHelpersJs, /if \(el\.textContent !== next\) el\.textContent = next/);
+    assert.match(catalogJs, /import \{ setInlineStatus \} from '\.\/ui_helpers\.js'/);
+    assert.match(catalogJs, /setInlineStatus\(statusEl, text, tone\)/);
     assert.match(catalogJs, /refreshModelCatalog\(\{ button \} = \{\}\)/);
     assert.match(catalogJs, /refreshSeq === catalogRefreshSeq/);
 });


### PR DESCRIPTION
This PR aligns the provider action rows and establishes a compact shared rule for future Settings and onboarding controls. Single-action rows now keep the status first and dock the neutral action to the right, with a responsive mobile layout. Neutral controls use the existing btn-default role, field-level secret actions retain the 42px control height, and busy/live status behavior is consistent across provider tests, Claude runtime repair, and model-catalog refresh.

The sweep covers sibling Settings/onboarding neutral controls while leaving intentionally grouped multi-action toolbars unchanged. The catalog reload path now preserves button ownership during overlap, identical live-region text is not rewritten, and the CSS contracts are rule-scoped. No provider request contract or version carrier changed.

Verification completed on the exact candidate: 463/463 web Node tests, 26 Python static/typography tests, 7/7 Deno contract tests, JavaScript syntax checks, CSS parsing, diff check, and isolated desktop/narrow visual QA for idle and Testing states. The official Playwright smoke fixture was attempted but its local server did not become healthy; this remains an infrastructure limitation, not a code result. Read-only reviews by Claude Opus 5, Cursor Grok 4.6, and a gpt-5.6 subagent converged with no accepted P0-P2 findings.
