### PR TITLE
Repair strict provider-contract diagnostics

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1018,6 +1018,22 @@ Direct Anthropic tool turns retain a private route-bound receipt containing the 
 
 Retry budgets are failure-class specific. Empty/incomplete responses and transient 429/5xx/overload failures may retry the same model with deadline-bounded backoff; auth, quota, permanent bad requests, and already-confirmed oversize fail fast. Same-route request-wire recovery stays under the existing physical-attempt authority, and exhausted compatibility returns to the already configured model fallback chain rather than becoming a second router. `LLMClient` keeps leading system messages authoritative and demotes later notices to visibly marked user notices while preserving assistant-tool-result adjacency.
 
+OpenAI-compatible response choices keep their outer `finish_reason` as the
+bounded per-call usage fact `response_finish_reason` (and may retain a bounded
+upstream `response_provider` label when the response supplies one). These are
+observational fields only: their reserved usage keys are host-owned and any
+provider-supplied values are discarded unless the designated outer response
+field supplies them; they never enter canonical assistant history and do not
+change the empty-response classifier or retry policy. The trusted provider
+canary accepts a schema-valid native tool call even when the assistant also
+returns text, recording only its length and hash as warning telemetry; the
+trusted integration consumer emits that bounded record through the test
+warning stream so it remains visible on a passing CI run; that list is
+host-owned and provider extension fields are discarded before emission. A
+malformed native argument, invalid schema, or missing call remains a red
+contract failure; no prose parser, salvage, provider hop, or unbounded retry is
+introduced, and diagnostics omit raw provider content and reasoning payloads.
+
 Prompt caching is stable-first. Governance and task-stable contracts precede mutable evidence; review builders disclose the stable/dynamic boundary and keep untrusted payloads outside the governance cache block. Provider-specific cache hints are sent only where supported and receive one exact retry without the rejected hint. Rejection evidence is durable and route-specific. Cache identity must not weaken exact review bindings or create a second review authority.
 
 Gateway response-cache recovery is narrower and reactive. The first call remains
@@ -2556,7 +2572,11 @@ inconclusive, while contract/auth/model/tool/reasoning 4xx are red. One logical 
 turn may make one same-route second physical send only when the normalized response is
 runtime-classified semantic-empty; the second send bypasses response caches where the
 route supports that control. A repeated empty response, a permanent body/context error,
-or any non-empty malformed/schema response remains red.
+or any non-empty malformed/schema response remains red. The outer choice
+termination marker is retained in host-owned usage as `response_finish_reason`
+for bounded diagnostics only. A valid native call may carry assistant text, which is a
+bounded warning rather than a failure; malformed raw arguments are reported by
+type/position and argument hash without copying the provider payload.
 
 Quick pull-request jobs are read-only, receive no provider secrets, and never use
 `pull_request_target`; there is no scheduled paid run. `release-preflight` depends on

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -300,6 +300,19 @@ complete registry; trusted integration CI sends that same registry in one bounde
 tool canary per supported provider family/API surface, while pull-request CI
 remains secretless.
 
+The trusted canary keeps the response choice's outer `finish_reason` as the
+bounded per-call usage fact `response_finish_reason`; it is observational and
+the reserved usage keys are host-owned, so provider-supplied extensions are
+discarded unless the designated outer response supplies the value. It must not
+be copied into canonical assistant history or used to change retry
+classification. A schema-valid native call remains usable when a provider also
+returns assistant text, with only a length/hash warning emitted on the trusted
+integration test's warning stream; the warning list is host-owned and provider
+extension fields are discarded before emission. Malformed native
+arguments and invalid schemas stay red, with diagnostics limited to structural
+facts, hashes, and parse position. Do not add a prose parser, provider hop, or
+unbounded retry to make that contract green.
+
 When adding or changing a provider, update one coherent route contract:
 
 1. credential/readiness detection and exact model-id migration;

--- a/ouroboros/llm.py
+++ b/ouroboros/llm.py
@@ -48,7 +48,7 @@ from ouroboros.usage_accounting import (
     last_physical_attempt_capture,
     usage_scope,
 )
-from ouroboros.utils import in_worker_process
+from ouroboros.utils import in_worker_process, sanitize_tool_result_for_log
 
 log = logging.getLogger(__name__)
 
@@ -59,10 +59,29 @@ _VALID_CACHE_TTLS = frozenset({"5m", "1h"})
 
 # Only explicit wire tiers have a knowable horizon; bare "default" does not.
 _CACHE_TTL_SECONDS = {"5m": 300, "1h": 3600}
+
 from ouroboros.context_budget import (
     CONTEXT_OVERFLOW_CODES,
     context_overflow_message,
 )
+
+# Response-only labels are diagnostic facts, not canonical assistant fields. Keep
+# provider-supplied values bounded and printable before they enter usage custody.
+_RESPONSE_METADATA_LABEL_MAX_CHARS = 160
+
+
+def _bounded_response_metadata_label(value: Any) -> Optional[str]:
+    """Return a small printable response label, or omit an unsafe/unknown value."""
+    if not isinstance(value, str):
+        return None
+    label = value.strip()
+    if not label or len(label) > _RESPONSE_METADATA_LABEL_MAX_CHARS:
+        return None
+    if not label.isprintable():
+        return None
+    if sanitize_tool_result_for_log(label) != label:
+        return None
+    return label
 
 
 def _structured_error_values(payload: Any) -> Set[str]:
@@ -3707,6 +3726,11 @@ class LLMClient:
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         """Normalize an OpenAI-compatible response; skip_cost_fetch keeps no_proxy pure."""
         usage = resp_dict.get("usage") or {}
+        if isinstance(usage, dict):
+            # These keys are host-owned projections of designated outer fields;
+            # provider usage extensions must not spoof their provenance.
+            usage.pop("response_finish_reason", None)
+            usage.pop("response_provider", None)
         # An HTTP-200 that carried a provider body-error (OpenRouter passes
         # 429/5xx through the body) reaches here only when a same-model reroute
         # was unavailable or also errored. Surface it as a typed marker so the
@@ -3722,7 +3746,22 @@ class LLMClient:
                 else ("provider_transient" if self._is_transient_body_error(_body_err) else "provider_error"),
             }
         choices = resp_dict.get("choices") or [{}]
-        msg = dict((choices[0] if choices else {}).get("message") or {})
+        first_choice = choices[0] if choices and isinstance(choices[0], dict) else {}
+        msg = dict(first_choice.get("message") or {})
+        # ``finish_reason`` belongs to the response choice, not the assistant
+        # message. Preserve it as an observational usage fact so diagnostics can
+        # distinguish a provider-selected stop/length from an absent marker. Do
+        # not put it into canonical history: strict providers reject response-only
+        # fields when that history is replayed.
+        if "finish_reason" in first_choice:
+            usage["response_finish_reason"] = _bounded_response_metadata_label(
+                first_choice.get("finish_reason"),
+            )
+        response_provider = _bounded_response_metadata_label(resp_dict.get("provider"))
+        if response_provider is not None:
+            # This optional upstream serving label never replaces the accounting
+            # provider assigned below.
+            usage["response_provider"] = response_provider
         if resp_dict.get("id") and "response_id" not in msg:
             msg["response_id"] = resp_dict["id"]
 

--- a/tests/provider_contract_ci.py
+++ b/tests/provider_contract_ci.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 import os
 import time
@@ -286,62 +287,183 @@ def _named_tool_choice():
     return {"type": "function", "function": {"name": CANARY_TOOL_NAME}}
 
 
+_CANARY_DIAGNOSTIC_MAX_CHARS = 160
+_CANARY_DIAGNOSTIC_MAX_KEYS = 32
+
+
+def _bounded_diagnostic_label(value, limit=_CANARY_DIAGNOSTIC_MAX_CHARS):
+    if value is None or not isinstance(value, (str, int, float, bool)):
+        return None
+    try:
+        value = str(value).strip()
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not value or len(value) > limit or not value.isprintable():
+        return None
+    return value if sanitize_tool_result_for_log(value) == value else None
+
+
+def _safe_nonnegative_int(value, maximum=10**12):
+    try:
+        return max(0, min(int(value or 0), maximum))
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _text_facts(value):
+    encoded = value.encode("utf-8", errors="replace")
+    return len(encoded), hashlib.sha256(encoded).hexdigest()
+
+
+def _canary_evidence(canary_or_model, message, usage, *, call=None, call_index=None, parse_error=None):
+    """Return bounded structural evidence; never copy provider payloads."""
+    canary_id = canary_or_model.canary_id if isinstance(canary_or_model, ProviderCanary) else ""
+    model = canary_or_model.model if isinstance(canary_or_model, ProviderCanary) else canary_or_model
+    message = message if isinstance(message, dict) else {}
+    usage = usage if isinstance(usage, dict) else {}
+    keys = []
+    message_keys_omitted = max(0, len(message) - _CANARY_DIAGNOSTIC_MAX_KEYS)
+    for index, key in enumerate(message):
+        if index >= _CANARY_DIAGNOSTIC_MAX_KEYS:
+            break
+        safe_key = _bounded_diagnostic_label(key)
+        if safe_key is None:
+            message_keys_omitted += 1
+            continue
+        keys.append(safe_key)
+    keys.sort()
+    message_finish = message.get("finish_reason") or message.get("stop_reason")
+    response_finish_present = "response_finish_reason" in usage
+    response_finish = usage.get("response_finish_reason") if response_finish_present else None
+    finish = message_finish if message_finish is not None else response_finish
+    evidence = {
+        "canary_id": _bounded_diagnostic_label(canary_id),
+        "model": _bounded_diagnostic_label(model),
+        "response_id": _bounded_diagnostic_label(message.get("response_id")),
+        "provider": _bounded_diagnostic_label(usage.get("provider")),
+        "resolved_model": _bounded_diagnostic_label(usage.get("resolved_model")),
+        "response_provider": _bounded_diagnostic_label(usage.get("response_provider")),
+        "finish_reason": _bounded_diagnostic_label(finish),
+        "response_finish_reason": _bounded_diagnostic_label(response_finish),
+        "stop_reason": _bounded_diagnostic_label(message.get("stop_reason")),
+        "message_keys": keys,
+        "message_keys_omitted": message_keys_omitted,
+        "prompt_tokens": _safe_nonnegative_int(usage.get("prompt_tokens")),
+        "completion_tokens": _safe_nonnegative_int(usage.get("completion_tokens")),
+        "ledger_attempts": len(usage.get("ledger_attempt_ids")) if isinstance(usage.get("ledger_attempt_ids"), list) else 0,
+    }
+    content = message.get("content")
+    if isinstance(content, str):
+        evidence["content_bytes"], evidence["content_sha256"] = _text_facts(content)
+    elif content is not None:
+        evidence["content_type"] = type(content).__name__
+    if call_index is not None:
+        evidence["call_index"] = _safe_nonnegative_int(call_index, 10**6)
+    if isinstance(call, dict):
+        function = call.get("function")
+        if isinstance(function, dict):
+            evidence["call_name"] = _bounded_diagnostic_label(function.get("name"))
+            raw_arguments = function.get("arguments")
+            if isinstance(raw_arguments, str):
+                evidence["arguments_bytes"], evidence["arguments_sha256"] = _text_facts(raw_arguments)
+            elif raw_arguments is not None:
+                evidence["arguments_type"] = type(raw_arguments).__name__
+        else:
+            evidence["function_type"] = type(function).__name__
+    if parse_error is not None:
+        evidence["parse_error"] = {"type": type(parse_error).__name__}
+        for field in ("pos", "lineno", "colno"):
+            value = getattr(parse_error, field, None)
+            if isinstance(value, int) and value >= 0:
+                evidence["parse_error"][field] = min(value, 10**12)
+    provider_error = usage.get("provider_error")
+    if isinstance(provider_error, dict):
+        evidence["provider_error"] = {
+            key: _bounded_diagnostic_label(provider_error.get(key))
+            for key in ("kind", "code", "type") if provider_error.get(key) is not None
+        }
+        if provider_error.get("message"):
+            raw_provider_message = str(provider_error["message"])
+            safe_provider_message = sanitize_tool_result_for_log(raw_provider_message)
+            evidence["provider_error_message_bytes"], evidence["provider_error_message_sha256"] = (
+                _text_facts(raw_provider_message)
+            )
+            if safe_provider_message != raw_provider_message:
+                evidence["provider_error_message"] = "***REDACTED***"
+    return evidence
+
+
+def _canary_failure_payload(canary_or_model, message, usage, violation, **kwargs):
+    evidence = _canary_evidence(canary_or_model, message, usage, **kwargs)
+    evidence["violation"] = violation
+    return {"provider_contract_violation": evidence}
+
+
+def _canary_failure(canary_or_model, message, usage, violation, **kwargs):
+    return AssertionError(_canary_failure_payload(
+        canary_or_model, message, usage, violation, **kwargs,
+    ))
+
+
 def assert_openai_canary_usage(usage, model):
-    assert isinstance(usage, dict), usage
-    assert usage.get("provider") == "openai", usage
-    assert usage.get("resolved_model") == normalize_model_identity(model), usage
-    assert int(usage.get("prompt_tokens") or 0) > 0, usage
-    assert int(usage.get("completion_tokens") or 0) > 0, usage
-    assert usage.get("reasoning_effort_clamped") is None, usage
+    def failure(code):
+        return _canary_failure_payload(model, None, usage, code)
+    assert isinstance(usage, dict), failure("usage_not_mapping")
+    assert usage.get("provider") == "openai", failure("unexpected_accounting_provider")
+    assert usage.get("resolved_model") == normalize_model_identity(model), failure("unexpected_accounting_model")
+    assert _safe_nonnegative_int(usage.get("prompt_tokens")) > 0, failure("missing_prompt_tokens")
+    assert _safe_nonnegative_int(usage.get("completion_tokens")) > 0, failure("missing_completion_tokens")
+    assert usage.get("reasoning_effort_clamped") is None, failure("reasoning_effort_clamped")
 
     disclosure = usage.get("request_wire")
-    assert isinstance(disclosure, dict), (
-        "Public direct-OpenAI request-wire disclosure is missing from usage; "
-        f"usage={usage}"
-    )
-    assert disclosure["requested_effort"] == "medium"
-    assert disclosure["applied_effort"] == "medium"
-    assert disclosure["requested_tool_dialect"] == "function"
-    assert disclosure["applied_tool_dialect"] == "openai_chat_custom"
-    assert disclosure["reason_code"] == "requested_wire_form"
-    assert disclosure["ladder_ordinal"] == 1
-    assert disclosure["task_local"] is False
+    assert isinstance(disclosure, dict), failure("missing_request_wire_disclosure")
+    for key, expected in (("requested_effort", "medium"), ("applied_effort", "medium"),
+                          ("requested_tool_dialect", "function"), ("applied_tool_dialect", "openai_chat_custom"),
+                          ("reason_code", "requested_wire_form"), ("ladder_ordinal", 1)):
+        assert disclosure.get(key) == expected, failure(f"request_wire_{key}")
+    assert disclosure.get("task_local") is False, failure("request_wire_task_local")
     actions = disclosure.get("applied_actions")
-    assert isinstance(actions, list)
+    assert isinstance(actions, list), failure("request_wire_actions_not_list")
     for applied in actions:
-        assert isinstance(applied, dict) and applied.get("source") != "task_local"
+        assert isinstance(applied, dict) and applied.get("source") != "task_local", failure(
+            "request_wire_task_local_action",
+        )
         action = applied.get("action")
-        assert isinstance(action, dict)
-        assert action.get("kind") != "replace_dialect"
-        assert not (action.get("kind") == "set_value" and action.get("field") == "effort")
+        assert isinstance(action, dict), failure("request_wire_action_not_mapping")
+        assert action.get("kind") != "replace_dialect", failure("request_wire_dialect_replaced")
+        assert not (
+            action.get("kind") == "set_value" and action.get("field") == "effort"
+        ), failure("request_wire_effort_changed")
         assert not set(action.get("fields") or ()).intersection({
             "reasoning_effort", "thinking", "output_config", "extra_body.reasoning",
-        })
-    assert disclosure["attempt_id"]
+        }), failure("request_wire_reasoning_changed")
+    assert disclosure.get("attempt_id"), failure("request_wire_attempt_missing")
     for key in (
         "source_profile_fingerprint",
         "accepted_profile_fingerprint",
         "candidate_sha256",
     ):
         value = str(disclosure.get(key) or "")
-        assert len(value) == 64 and not (
-            set(value.lower()) - set("0123456789abcdef")
+        assert len(value) == 64 and not set(value.lower()) - set("0123456789abcdef"), failure(
+            f"request_wire_{key}",
         )
     return disclosure
 
 
 def assert_canary_usage(usage, canary: ProviderCanary):
-    assert isinstance(usage, dict), usage
-    assert usage.get("provider") == canary.expected_provider, usage
-    assert usage.get("resolved_model") == normalize_model_identity(canary.model), usage
-    assert int(usage.get("prompt_tokens") or 0) > 0, usage
-    assert int(usage.get("completion_tokens") or 0) > 0, usage
+    def failure(code):
+        return _canary_failure_payload(canary, None, usage, code)
+    assert isinstance(usage, dict), failure("usage_not_mapping")
+    assert usage.get("provider") == canary.expected_provider, failure("unexpected_accounting_provider")
+    assert usage.get("resolved_model") == normalize_model_identity(canary.model), failure("unexpected_accounting_model")
+    assert _safe_nonnegative_int(usage.get("prompt_tokens")) > 0, failure("missing_prompt_tokens")
+    assert _safe_nonnegative_int(usage.get("completion_tokens")) > 0, failure("missing_completion_tokens")
     if canary.reasoning_effort == "medium":
-        assert usage.get("reasoning_effort_clamped") is None, usage
+        assert usage.get("reasoning_effort_clamped") is None, failure("reasoning_effort_clamped")
         disclosure = usage.get("request_wire")
-        assert isinstance(disclosure, dict), usage
-        assert disclosure.get("requested_effort") == "medium", disclosure
-        assert disclosure.get("applied_effort") == "medium", disclosure
+        assert isinstance(disclosure, dict), failure("missing_request_wire_disclosure")
+        assert disclosure.get("requested_effort") == "medium", failure("request_wire_requested_effort")
+        assert disclosure.get("applied_effort") == "medium", failure("request_wire_applied_effort")
     if canary.expected_provider == "openai":
         return assert_openai_canary_usage(usage, canary.model)
     return usage.get("request_wire")
@@ -356,32 +478,50 @@ def _semantic_empty_canary_message(message) -> bool:
 
 
 def _safe_empty_canary_diagnostic(canary: ProviderCanary, message, usage, attempts: int):
-    provider_error = usage.get("provider_error") if isinstance(usage, dict) else None
-    safe_provider_error = ""
-    if provider_error:
-        try:
-            raw_provider_error = json.dumps(
-                provider_error, ensure_ascii=False, sort_keys=True,
-            )
-        except (TypeError, ValueError):
-            raw_provider_error = str(provider_error)
-        safe_provider_error = sanitize_tool_result_for_log(
-            raw_provider_error,
-        )[:500]
-    return {
-        "canary_id": canary.canary_id,
-        "model": canary.model,
-        "attempts": attempts,
-        "message_keys": sorted(str(key) for key in message) if isinstance(message, dict) else [],
-        "finish_reason": message.get("finish_reason") if isinstance(message, dict) else None,
-        "stop_reason": message.get("stop_reason") if isinstance(message, dict) else None,
-        "provider": usage.get("provider") if isinstance(usage, dict) else None,
-        "resolved_model": usage.get("resolved_model") if isinstance(usage, dict) else None,
-        "prompt_tokens": int(usage.get("prompt_tokens") or 0) if isinstance(usage, dict) else 0,
-        "completion_tokens": int(usage.get("completion_tokens") or 0) if isinstance(usage, dict) else 0,
-        "provider_error": safe_provider_error,
-        "ledger_attempts": len(usage.get("ledger_attempt_ids") or []) if isinstance(usage, dict) else 0,
-    }
+    diagnostic = _canary_evidence(canary, message, usage)
+    diagnostic["attempts"] = _safe_nonnegative_int(attempts, 10**6)
+    return diagnostic
+
+
+def _record_canary_response_warnings(canary: ProviderCanary, message, usage):
+    """Record tolerated response-shape drift without copying provider text."""
+    if not isinstance(usage, dict):
+        return
+    # The usage mapping can contain provider-controlled extension fields. Never
+    # preserve a provider-supplied warning list for the host-owned CI emitter.
+    warnings = []
+    usage["canary_warnings"] = warnings
+    if not isinstance(message, dict):
+        return
+    calls = message.get("tool_calls")
+    content = message.get("content")
+    if not isinstance(calls, list) or not calls or not isinstance(content, str) or not content.strip():
+        return
+    warning = _canary_evidence(canary, message, usage)
+    warning["code"] = "native_tool_call_with_assistant_text"
+    if len(warnings) < 4:
+        warnings.append(warning)
+
+
+def _emit_canary_response_warnings(usage):
+    """Expose bounded mixed-content warnings on the trusted CI test surface."""
+    import warnings
+
+    if not isinstance(usage, dict):
+        return
+    entries = usage.get("canary_warnings")
+    if not isinstance(entries, list):
+        return
+    for warning in entries[:4]:
+        if not isinstance(warning, dict):
+            continue
+        warnings.warn(
+            "provider_canary_warning " + json.dumps(
+                warning, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+            ),
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
 
 def _chat_canary_turn(client, *, canary: ProviderCanary, chat_kwargs):
@@ -414,32 +554,93 @@ def _chat_canary_turn(client, *, canary: ProviderCanary, chat_kwargs):
     })
 
 
-def assert_normalized_canary_call(message, tools, required_arguments):
+def assert_normalized_canary_call(
+    message,
+    tools,
+    required_arguments,
+    *,
+    canary=None,
+    usage=None,
+):
     from jsonschema import validators
 
     calls = message.get("tool_calls") if isinstance(message, dict) else None
-    assert isinstance(calls, list) and calls, message
+    if not isinstance(calls, list) or not calls:
+        raise _canary_failure(canary or "", message, usage, "missing_tool_calls")
     schema = _delegate_start_tool(tools)["function"]["parameters"]
     validator_class = validators.validator_for(schema)
     validator_class.check_schema(schema)
     seen_ids = set()
-    for call in calls:
-        assert isinstance(call, dict), call
-        assert call.get("type") == "function", call
+    for call_index, call in enumerate(calls):
+        if not isinstance(call, dict):
+            raise _canary_failure(
+                canary or "", message, usage, "tool_call_not_mapping",
+                call_index=call_index,
+            )
+        if call.get("type") != "function":
+            raise _canary_failure(
+                canary or "", message, usage, "tool_call_type",
+                call=call, call_index=call_index,
+            )
         call_id = call.get("id")
-        assert isinstance(call_id, str) and call_id and call_id == call_id.strip(), call
-        assert call_id not in seen_ids, calls
+        if not isinstance(call_id, str) or not call_id or call_id != call_id.strip():
+            raise _canary_failure(
+                canary or "", message, usage, "tool_call_id",
+                call=call, call_index=call_index,
+            )
+        if call_id in seen_ids:
+            raise _canary_failure(
+                canary or "", message, usage, "duplicate_tool_call_id",
+                call=call, call_index=call_index,
+            )
         seen_ids.add(call_id)
         function = call.get("function")
-        assert isinstance(function, dict), call
-        assert function.get("name") == CANARY_TOOL_NAME, call
+        if not isinstance(function, dict):
+            raise _canary_failure(
+                canary or "", message, usage, "function_not_mapping",
+                call=call, call_index=call_index,
+            )
+        if function.get("name") != CANARY_TOOL_NAME:
+            raise _canary_failure(
+                canary or "", message, usage, "unexpected_tool_name",
+                call=call, call_index=call_index,
+            )
         raw_arguments = function.get("arguments")
-        assert isinstance(raw_arguments, str), call
-        arguments = json.loads(raw_arguments)
-        assert not list(validator_class(schema).iter_errors(arguments))
-        assert set(arguments) <= set((schema.get("properties") or {}).keys()), arguments
+        if not isinstance(raw_arguments, str):
+            raise _canary_failure(
+                canary or "", message, usage, "arguments_not_string",
+                call=call, call_index=call_index,
+            )
+        try:
+            arguments = json.loads(raw_arguments)
+        except (TypeError, ValueError) as error:
+            raise _canary_failure(
+                canary or "", message, usage, "malformed_arguments_json",
+                call=call, call_index=call_index, parse_error=error,
+            ) from error
+        schema_errors = list(validator_class(schema).iter_errors(arguments))
+        if schema_errors:
+            raise _canary_failure(
+                canary or "", message, usage, "arguments_schema",
+                call=call, call_index=call_index,
+            )
+        if not isinstance(arguments, dict):
+            raise _canary_failure(
+                canary or "", message, usage, "arguments_not_object",
+                call=call, call_index=call_index,
+            )
+        unknown_keys = set(arguments) - set((schema.get("properties") or {}).keys())
+        if unknown_keys:
+            raise _canary_failure(
+                canary or "", message, usage, "arguments_unknown_keys",
+                call=call, call_index=call_index,
+            )
         for key, expected in required_arguments.items():
-            assert arguments.get(key) == expected, arguments
+            if arguments.get(key) != expected:
+                raise _canary_failure(
+                    canary or "", message, usage, f"arguments_{key}",
+                    call=call, call_index=call_index,
+                )
     return calls
 
 
@@ -486,10 +687,18 @@ def run_provider_contract_canary(
         },
     )
     # This is a provider schema-admission canary, not a duplicate of the
-    # runtime selector gate.  The provider must preserve the nonce-bearing
-    # prompt and return only declared, schema-valid fields; subagent_id versus
-    # retry_of is enforced by the existing typed runtime refusal tests.
-    calls = assert_normalized_canary_call(message, tools, required_arguments)
+    # runtime selector gate. The provider must preserve the nonce-bearing prompt
+    # and return declared, schema-valid native calls. Valid assistant text beside
+    # those calls is tolerated and recorded as bounded warning telemetry;
+    # subagent_id versus retry_of is enforced by the existing typed runtime tests.
+    calls = assert_normalized_canary_call(
+        message,
+        tools,
+        required_arguments,
+        canary=canary,
+        usage=usage,
+    )
+    _record_canary_response_warnings(canary, message, usage)
     first_disclosure = assert_canary_usage(usage, canary)
     if not canary.continue_to_final:
         return message, usage, None, None
@@ -526,9 +735,27 @@ def run_provider_contract_canary(
     )
     final_disclosure = assert_canary_usage(final_usage, canary)
     if isinstance(first_disclosure, dict) and isinstance(final_disclosure, dict):
-        assert final_disclosure.get("candidate_sha256") != first_disclosure.get(
+        if final_disclosure.get("candidate_sha256") == first_disclosure.get(
             "candidate_sha256"
+        ):
+            raise _canary_failure(
+                canary,
+                final_message,
+                final_usage,
+                "continuation_candidate_binding",
+            )
+    if not isinstance(final_message, dict) or final_message.get("tool_calls"):
+        raise _canary_failure(
+            canary,
+            final_message,
+            final_usage,
+            "unexpected_continuation_tool_calls",
         )
-    assert not final_message.get("tool_calls"), final_message
-    assert str(final_message.get("content") or "").strip() == final_marker, final_message
+    if str(final_message.get("content") or "").strip() != final_marker:
+        raise _canary_failure(
+            canary,
+            final_message,
+            final_usage,
+            "continuation_marker",
+        )
     return message, usage, final_message, final_usage

--- a/tests/provider_contract_ci.py
+++ b/tests/provider_contract_ci.py
@@ -216,6 +216,8 @@ def skip_on_provider_environmental_error(
     exc: BaseException,
 ) -> None:
     """Skip only classifier-approved typed inconclusive provider outcomes."""
+    if isinstance(exc, AssertionError):
+        return
     import sys
 
     classification = classify_provider_failure(provider_id, exc)

--- a/tests/test_llm_provider_routing.py
+++ b/tests/test_llm_provider_routing.py
@@ -867,7 +867,12 @@ def test_normalize_remote_response_preserves_reasoning_and_response_id():
                     "reasoning_details": [{"type": "reasoning.text", "text": "look up the file"}],
                 },
             }],
-            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+            "usage": {
+                "prompt_tokens": 1,
+                "completion_tokens": 1,
+                "response_finish_reason": "provider-fake",
+                "response_provider": "provider-secret",
+            },
         },
         target,
         skip_cost_fetch=True,
@@ -877,6 +882,8 @@ def test_normalize_remote_response_preserves_reasoning_and_response_id():
     assert message["reasoning"] == "look up the file"
     assert message["reasoning_details"] == [{"type": "reasoning.text", "text": "look up the file"}]
     assert usage["provider"] == "openrouter"
+    assert "response_finish_reason" not in usage
+    assert "response_provider" not in usage
 
 
 def test_build_anthropic_messages_rejects_tool_result_without_tool_call_id(monkeypatch):

--- a/tests/test_provider_contract_ci.py
+++ b/tests/test_provider_contract_ci.py
@@ -382,7 +382,7 @@ def test_malformed_native_arguments_fail_closed_with_bounded_evidence():
                     "type": "function",
                     "function": {"name": CANARY_TOOL_NAME, "arguments": raw},
                 }],
-            }, _fake_usage(canary, self.sends)
+            }, {**_fake_usage(canary, self.sends), "provider_error": {"code": "insufficient_quota"}}
 
     client = MalformedNativeClient()
     with pytest.raises(AssertionError) as caught:
@@ -396,6 +396,7 @@ def test_malformed_native_arguments_fail_closed_with_bounded_evidence():
     assert evidence["arguments_bytes"] == len(("{\"prompt\":\"" + secret).encode())
     assert len(evidence["arguments_sha256"]) == 64
     assert secret not in str(caught.value)
+    assert skip_on_provider_environmental_error(canary.canary_id, caught.value) is None
     assert client.sends == 1
 
 

--- a/tests/test_provider_contract_ci.py
+++ b/tests/test_provider_contract_ci.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import contextlib
 import copy
+import io
 import json
 
 import pytest
@@ -24,6 +26,7 @@ from tests.provider_contract_ci import (
     ProviderCanary,
     ProviderFailureClassification,
     ProviderFailureKind,
+    _emit_canary_response_warnings,
     assert_normalized_canary_call,
     assert_openai_canary_usage,
     classify_provider_failure,
@@ -329,6 +332,197 @@ def _canonical_canary_call(call_id, arguments):
             "arguments": json.dumps(arguments, sort_keys=True),
         },
     }
+
+
+@pytest.mark.parametrize("finish_reason", ["stop", "length", None])
+def test_remote_normalizer_keeps_outer_finish_reason_as_usage_fact(finish_reason):
+    from ouroboros.llm import LLMClient
+
+    client = LLMClient(api_key="test")
+    message, usage = client._normalize_remote_response(
+        {
+            "id": "response-finish-fact",
+            "provider": "openrouter/upstream-a",
+            "choices": [{
+                "finish_reason": finish_reason,
+                "message": {"role": "assistant", "content": "ok"},
+            }],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 2},
+        },
+        {
+            "provider": "openrouter",
+            "usage_model": "x-ai/grok-4.6",
+            "supports_openrouter_extensions": False,
+        },
+        skip_cost_fetch=True,
+    )
+
+    assert usage["response_finish_reason"] == finish_reason
+    assert usage["response_provider"] == "openrouter/upstream-a"
+    assert message["response_id"] == "response-finish-fact"
+    assert "finish_reason" not in message
+
+
+def test_malformed_native_arguments_fail_closed_with_bounded_evidence():
+    canary = next(row for row in provider_canary_matrix() if row.canary_id == "openrouter_grok")
+    nonce = "malformed-native"
+    secret = "sk-or-v1-" + "A" * 40
+
+    class MalformedNativeClient:
+        def __init__(self):
+            self.sends = 0
+
+        def chat(self, **kwargs):
+            self.sends += 1
+            raw = '{"prompt":"' + secret
+            return {
+                "content": "provider explanation",
+                "tool_calls": [{
+                    "id": "bad-native",
+                    "type": "function",
+                    "function": {"name": CANARY_TOOL_NAME, "arguments": raw},
+                }],
+            }, _fake_usage(canary, self.sends)
+
+    client = MalformedNativeClient()
+    with pytest.raises(AssertionError) as caught:
+        run_provider_contract_canary(
+            client, canary=canary, tools=full_registry_canary_tools(), nonce=nonce,
+        )
+
+    evidence = caught.value.args[0]["provider_contract_violation"]
+    assert evidence["violation"] == "malformed_arguments_json"
+    assert evidence["parse_error"]["type"] == "JSONDecodeError"
+    assert evidence["arguments_bytes"] == len(("{\"prompt\":\"" + secret).encode())
+    assert len(evidence["arguments_sha256"]) == 64
+    assert secret not in str(caught.value)
+    assert client.sends == 1
+
+
+def test_native_call_with_text_is_tolerated_and_warns_without_copying_text():
+    canary = next(row for row in provider_canary_matrix() if row.canary_id == "openrouter_grok")
+    nonce = "mixed-native-text"
+    expected = delegate_start_canary_arguments(nonce)
+    prose = "provider explanation " + ("P" * 5000)
+
+    class MixedClient:
+        def chat(self, **kwargs):
+            return {
+                "content": prose,
+                "tool_calls": [_canonical_canary_call("mixed-native", expected)],
+            }, _fake_usage(canary, 1)
+
+    _message, usage, _final, _final_usage = run_provider_contract_canary(
+        MixedClient(), canary=canary, tools=full_registry_canary_tools(), nonce=nonce,
+    )
+    warning = usage["canary_warnings"][0]
+    assert warning["code"] == "native_tool_call_with_assistant_text"
+    assert warning["content_bytes"] == len(prose.encode())
+    assert warning["content_sha256"]
+    assert prose not in str(warning)
+
+
+def test_empty_canary_diagnostic_uses_usage_finish_reason():
+    import tests.provider_contract_ci as contract
+
+    canary = next(row for row in provider_canary_matrix() if row.canary_id == "openrouter_grok")
+    diagnostic = contract._safe_empty_canary_diagnostic(
+        canary,
+        {"content": "", "tool_calls": []},
+        {**_fake_usage(canary, 1), "response_finish_reason": "length"},
+        1,
+    )
+    assert diagnostic["finish_reason"] == "length"
+    assert diagnostic["response_finish_reason"] == "length"
+    distinct = contract._safe_empty_canary_diagnostic(
+        canary,
+        {"content": "", "tool_calls": [], "finish_reason": "message-stop"},
+        {**_fake_usage(canary, 1), "response_finish_reason": "outer-length"},
+        1,
+    )
+    assert (distinct["finish_reason"], distinct["response_finish_reason"]) == ("message-stop", "outer-length")
+
+
+def test_canary_diagnostics_redact_labels_and_omit_provider_prose():
+    import tests.provider_contract_ci as contract
+
+    canary = next(row for row in provider_canary_matrix() if row.canary_id == "openrouter_grok")
+    secret = "sk-or-v1-" + "B" * 40
+    diagnostic = contract._safe_empty_canary_diagnostic(
+        canary,
+        {
+            "content": "",
+            "tool_calls": [],
+            secret: "provider-controlled key name",
+            "safe_extra": "provider-controlled but safe key",
+        },
+        {
+            **_fake_usage(canary, 1),
+            "response_provider": secret,
+            "provider_error": {
+                "kind": "provider_error",
+                "code": "400",
+                "message": "ordinary provider detail " + ("Q" * 500),
+            },
+        },
+        1,
+    )
+    assert diagnostic["response_provider"] is None
+    assert "provider_error_message" not in diagnostic
+    assert diagnostic["provider_error_message_bytes"] > 200
+    assert len(diagnostic["provider_error_message_sha256"]) == 64
+    assert secret not in str(diagnostic)
+    assert secret not in diagnostic["message_keys"]
+    assert "safe_extra" in diagnostic["message_keys"]
+    assert diagnostic["message_keys_omitted"] == 1
+
+
+def test_canary_warning_emission_is_bounded_and_observable():
+    warning = {
+        "code": "native_tool_call_with_assistant_text",
+        "content_bytes": 5000,
+        "content_sha256": "a" * 64,
+    }
+    with pytest.warns(RuntimeWarning, match="provider_canary_warning") as caught:
+        _emit_canary_response_warnings({"canary_warnings": [warning]})
+    assert len(caught) == 1 and "5000" in str(caught[0].message)
+    assert "provider explanation" not in str(caught[0].message)
+
+
+def test_provider_warning_extension_is_not_emitted_as_host_telemetry():
+    import tests.provider_contract_ci as contract
+
+    canary = next(row for row in provider_canary_matrix() if row.canary_id == "openrouter_grok")
+    secret = "provider-secret-" + ("X" * 600)
+    usage = {"canary_warnings": [{"raw": secret}]}
+    contract._record_canary_response_warnings(
+        canary,
+        {"content": "", "tool_calls": []},
+        usage,
+    )
+    output = io.StringIO()
+    with contextlib.redirect_stderr(output):
+        _emit_canary_response_warnings(usage)
+    assert secret not in output.getvalue()
+    assert usage["canary_warnings"] == []
+
+
+def test_malformed_openai_usage_assertions_keep_bounded_violation_evidence():
+    canary = next(row for row in provider_canary_matrix() if row.expected_provider == "openai")
+    usage = _fake_usage(canary, 1)
+    usage["request_wire"]["applied_actions"] = [{
+        "source": "task_local",
+        "action": {"kind": "drop_field", "fields": []},
+    }]
+    with pytest.raises(AssertionError) as caught:
+        assert_openai_canary_usage(usage, canary.model)
+    evidence = caught.value.args[0]["provider_contract_violation"]
+    assert evidence["violation"] == "request_wire_task_local_action"
+    usage["request_wire"]["task_local"] = 0
+    with pytest.raises(AssertionError) as caught:
+        assert_openai_canary_usage(usage, canary.model)
+    evidence = caught.value.args[0]["provider_contract_violation"]
+    assert evidence["violation"] == "request_wire_task_local"
 
 
 def test_custom_call_normalizes_and_replays_role_tool_continuation():

--- a/tests/test_provider_integration.py
+++ b/tests/test_provider_integration.py
@@ -14,6 +14,7 @@ import uuid
 import pytest
 
 from tests.provider_contract_ci import (
+    _emit_canary_response_warnings,
     full_registry_canary_tools,
     provider_canary_matrix,
     require_provider_canary_credential,
@@ -47,12 +48,13 @@ def test_full_registry_provider_contract(canary, shipped_builtin_tools):
     """Exercise one bounded public-chat canary per physical provider surface."""
     require_provider_canary_credential(canary)
     try:
-        run_provider_contract_canary(
+        _message, usage, _final_message, _final_usage = run_provider_contract_canary(
             _get_llm_client(),
             canary=canary,
             tools=shipped_builtin_tools,
             nonce=uuid.uuid4().hex,
         )
+        _emit_canary_response_warnings(usage)
     except Exception as exc:  # noqa: BLE001
         skip_on_provider_environmental_error(canary.canary_id, exc)
         raise


### PR DESCRIPTION
This PR repairs the trusted provider-contract diagnostics and closes a real strict-RED downgrade on the integration seam.

Candidate: `a743a388d6192072c9a9022b2f1e79108006ddd7`
Parent: `fdfa18e8718dd120272b229b55ea0e1c0cc78ea3`
Development base: `87c8636366ea462b7f445e5adb2941d345119fcc`

What changed:

- Preserve the outer response finish marker and provider identity as bounded, host-owned observational facts without putting them into the canonical assistant message.
- Keep malformed non-empty native tool arguments strict RED with bounded, secret-safe evidence, one physical send, and no prose parser, salvage, provider hop, or retry expansion.
- Treat a valid native call plus assistant text as a passing interoperability case with bounded host-owned warning telemetry.
- Discard provider-supplied reserved metadata and warning extensions before trusted diagnostics.
- Add the final class fix: host-raised `AssertionError` contract failures can contain provider text such as `insufficient_quota`; the environmental-skip helper now refuses to downgrade those failures to `pytest.skip`. Real raised quota/429/5xx/timeout exceptions retain their existing typed-inconclusive path.

The canary remains capped at 1024 tokens. Direct/custom DeepSeek `reasoning_content` continuity remains the explicitly deferred follow-up. All version carriers are byte-identical to the Development base.

Verification on the exact candidate tree:

- Full isolated Python 3.11 pytest with a fresh `OUROBOROS_DATA_DIR`: producer exit code 0.
- Focused provider/routing/integration suites, `py_compile`, Ruff F, `git diff --check`, and size-ratchet: exit code 0.
- `ouroboros/llm.py` remains below the 200,000-byte cap; live `data/settings.json` SHA stayed `c354e0129b3694d1c585a9ce8c84232d955d4169c651a701ec5a89c43efb57bc`.
- Exact-SHA read-only agentic review through the embedded Claudexor daemon: Grok/Cursor (`run-081190f85246`, profile `koshakcot`), Opus (`run-1ee8aaaa2d0c`, profile `mironov`), and Fable (`run-64df54af1d82`, profile `proton5`) all observed the requested models and returned `SAFE_TO_COMMIT`.
- Two earlier Grok attempts through registered profile `valintine` failed before model output with typed `PING timed out`; they are disclosed infrastructure receipts, not verdicts. No login or authentication mutation was performed.

This is a version-neutral contributor PR targeting `ouroboros`. PR #292 is already merged at the Development base, so this candidate is published on a new branch. Release metadata, tag, and promotion must be allocated and gated on the final landing tree by the maintainer.
