### PR TITLE
Fix Windows continuity and byte-faithful identity checks

### DIFF
--- a/ouroboros/consciousness.py
+++ b/ouroboros/consciousness.py
@@ -1349,11 +1349,10 @@ class BackgroundConsciousness:
             path = self._identity_source_requirements.get(topic)
             if path is not None:
                 try:
+                    raw = path.read_bytes()
                     current = path.read_text(encoding="utf-8")
                     if str(result) == current and result_str == current:
-                        self._identity_source_reads[topic] = hashlib.sha256(
-                            path.read_bytes()
-                        ).hexdigest()
+                        self._identity_source_reads[topic] = hashlib.sha256(raw).hexdigest()
                 except Exception:
                     pass
 

--- a/ouroboros/consciousness.py
+++ b/ouroboros/consciousness.py
@@ -1350,7 +1350,7 @@ class BackgroundConsciousness:
             if path is not None:
                 try:
                     raw = path.read_bytes()
-                    current = path.read_text(encoding="utf-8")
+                    current = raw.decode("utf-8").replace("\r\n", "\n").replace("\r", "\n")
                     if str(result) == current and result_str == current:
                         self._identity_source_reads[topic] = hashlib.sha256(raw).hexdigest()
                 except Exception:

--- a/ouroboros/consciousness.py
+++ b/ouroboros/consciousness.py
@@ -1352,7 +1352,7 @@ class BackgroundConsciousness:
                     current = path.read_text(encoding="utf-8")
                     if str(result) == current and result_str == current:
                         self._identity_source_reads[topic] = hashlib.sha256(
-                            current.encode("utf-8")
+                            path.read_bytes()
                         ).hexdigest()
                 except Exception:
                     pass

--- a/tests/test_attachment_staging.py
+++ b/tests/test_attachment_staging.py
@@ -320,8 +320,10 @@ class TestStageTaskAttachments:
             "id": "child", "objective": "inspect input", "task_contract": contract,
         })
         assert "INHERITED TASK INPUTS" in work_order
-        assert child_path in work_order
-        assert parent_path not in work_order
+        # The canonical work-order renderer serializes the manifest with
+        # Python's repr; Windows paths therefore carry escaped backslashes.
+        assert repr(child_path) in work_order
+        assert repr(parent_path) not in work_order
 
 
 class TestComposeTaskTextManifestLines:

--- a/tests/test_durable_learning_completeness.py
+++ b/tests/test_durable_learning_completeness.py
@@ -355,7 +355,9 @@ def test_bgc_direct_identity_update_requires_complete_named_omission(tmp_path):
         # completeness guard binds the source's raw bytes.  Keep the fixture
         # platform-independent and prove the guard accepts a CRLF source.
         backlog = tmp_path / "memory" / "knowledge" / "improvement-backlog.md"
-        backlog.write_bytes(backlog.read_bytes().replace(b"\n", b"\r\n"))
+        backlog.write_bytes(
+            backlog.read_bytes().replace(b"\r\n", b"\n").replace(b"\n", b"\r\n")
+        )
         context = bc._build_context()
         assert "knowledge_read" in context and "improvement-backlog" in context
         content = "I remain directly self-authoring after complete source materialization."

--- a/tests/test_durable_learning_completeness.py
+++ b/tests/test_durable_learning_completeness.py
@@ -351,6 +351,11 @@ def _write_schedules(tmp_path, count):
 def test_bgc_direct_identity_update_requires_complete_named_omission(tmp_path):
     bc = _bg_fixture(tmp_path)
     try:
+        # ``knowledge_read`` returns universal-newline text, while the
+        # completeness guard binds the source's raw bytes.  Keep the fixture
+        # platform-independent and prove the guard accepts a CRLF source.
+        backlog = tmp_path / "memory" / "knowledge" / "improvement-backlog.md"
+        backlog.write_bytes(backlog.read_bytes().replace(b"\n", b"\r\n"))
         context = bc._build_context()
         assert "knowledge_read" in context and "improvement-backlog" in context
         content = "I remain directly self-authoring after complete source materialization."

--- a/tests/test_durable_learning_completeness.py
+++ b/tests/test_durable_learning_completeness.py
@@ -378,27 +378,61 @@ def test_bgc_source_mutation_after_read_cannot_authorize_identity_rewrite(tmp_pa
     try:
         bc._build_context()
         backlog = tmp_path / "memory" / "knowledge" / "improvement-backlog.md"
-        real_read_text = pathlib.Path.read_text
+        changed = backlog.read_bytes() + (
+            b"\n### ibl-concurrent\n- summary: changed after materialization\n"
+        )
+        real_read_bytes = pathlib.Path.read_bytes
         target_reads = 0
 
-        def mutate_after_read(self, *args, **kwargs):
+        def mutate_before_snapshot(self, *args, **kwargs):
             nonlocal target_reads
-            text = real_read_text(self, *args, **kwargs)
             if self == backlog:
                 target_reads += 1
-                if target_reads == 2:
-                    self.write_text(
-                        text + "\n### ibl-concurrent\n- summary: changed after materialization\n",
-                        encoding="utf-8",
-                    )
-            return text
+                if target_reads == 1:
+                    self.write_bytes(changed)
+            return real_read_bytes(self, *args, **kwargs)
 
-        monkeypatch.setattr(pathlib.Path, "read_text", mutate_after_read)
+        monkeypatch.setattr(pathlib.Path, "read_bytes", mutate_before_snapshot)
         bc._execute_tool(_tool_call("knowledge_read", {"topic": "improvement-backlog"}, "r1"), [])
         result = bc._execute_tool(
             _tool_call("update_identity", {"content": "must remain blocked"}, "u1"), [],
         )
         assert target_reads == 2
+        assert "IDENTITY_UPDATE_ABSTAINED" in result
+    finally:
+        bc._tool_executor.shutdown(wait=False, cancel_futures=True)
+
+
+def test_bgc_source_snapshot_cannot_mix_text_and_digest(tmp_path, monkeypatch):
+    bc = _bg_fixture(tmp_path)
+    try:
+        bc._build_context()
+        backlog = tmp_path / "memory" / "knowledge" / "improvement-backlog.md"
+        original = backlog.read_bytes()
+        changed = original + b"\n### ibl-concurrent\n- summary: changed bytes\n"
+        real_read_bytes = pathlib.Path.read_bytes
+        target_reads = 0
+
+        def oscillate_during_validation(self, *args, **kwargs):
+            nonlocal target_reads
+            if self == backlog:
+                target_reads += 1
+                if target_reads == 1:
+                    self.write_bytes(changed)
+                    raw = real_read_bytes(self, *args, **kwargs)
+                    self.write_bytes(original)
+                    return raw
+            return real_read_bytes(self, *args, **kwargs)
+
+        monkeypatch.setattr(pathlib.Path, "read_bytes", oscillate_during_validation)
+        materialized = bc._execute_tool(
+            _tool_call("knowledge_read", {"topic": "improvement-backlog"}, "r1"), [],
+        )
+        assert materialized == original.decode("utf-8")
+        backlog.write_bytes(changed)
+        result = bc._execute_tool(
+            _tool_call("update_identity", {"content": "must remain blocked"}, "u1"), [],
+        )
         assert "IDENTITY_UPDATE_ABSTAINED" in result
     finally:
         bc._tool_executor.shutdown(wait=False, cancel_futures=True)

--- a/tests/test_durable_learning_completeness.py
+++ b/tests/test_durable_learning_completeness.py
@@ -406,10 +406,13 @@ def test_bgc_source_mutation_after_read_cannot_authorize_identity_rewrite(tmp_pa
 def test_bgc_source_snapshot_cannot_mix_text_and_digest(tmp_path, monkeypatch):
     bc = _bg_fixture(tmp_path)
     try:
-        bc._build_context()
         backlog = tmp_path / "memory" / "knowledge" / "improvement-backlog.md"
+        backlog.write_bytes(
+            backlog.read_bytes().replace(b"\r\n", b"\n").replace(b"\n", b"\r\n")
+        )
+        bc._build_context()
         original = backlog.read_bytes()
-        changed = original + b"\n### ibl-concurrent\n- summary: changed bytes\n"
+        changed = original + b"\r\n### ibl-concurrent\r\n- summary: changed bytes\r\n"
         real_read_bytes = pathlib.Path.read_bytes
         target_reads = 0
 
@@ -428,7 +431,7 @@ def test_bgc_source_snapshot_cannot_mix_text_and_digest(tmp_path, monkeypatch):
         materialized = bc._execute_tool(
             _tool_call("knowledge_read", {"topic": "improvement-backlog"}, "r1"), [],
         )
-        assert materialized == original.decode("utf-8")
+        assert materialized == original.decode("utf-8").replace("\r\n", "\n")
         backlog.write_bytes(changed)
         result = bc._execute_tool(
             _tool_call("update_identity", {"content": "must remain blocked"}, "u1"), [],

--- a/tests/test_durable_learning_completeness.py
+++ b/tests/test_durable_learning_completeness.py
@@ -371,6 +371,37 @@ def test_bgc_direct_identity_update_requires_complete_named_omission(tmp_path):
         bc._tool_executor.shutdown(wait=False, cancel_futures=True)
 
 
+def test_bgc_source_mutation_after_read_cannot_authorize_identity_rewrite(tmp_path, monkeypatch):
+    bc = _bg_fixture(tmp_path)
+    try:
+        bc._build_context()
+        backlog = tmp_path / "memory" / "knowledge" / "improvement-backlog.md"
+        real_read_text = pathlib.Path.read_text
+        target_reads = 0
+
+        def mutate_after_read(self, *args, **kwargs):
+            nonlocal target_reads
+            text = real_read_text(self, *args, **kwargs)
+            if self == backlog:
+                target_reads += 1
+                if target_reads == 2:
+                    self.write_text(
+                        text + "\n### ibl-concurrent\n- summary: changed after materialization\n",
+                        encoding="utf-8",
+                    )
+            return text
+
+        monkeypatch.setattr(pathlib.Path, "read_text", mutate_after_read)
+        bc._execute_tool(_tool_call("knowledge_read", {"topic": "improvement-backlog"}, "r1"), [])
+        result = bc._execute_tool(
+            _tool_call("update_identity", {"content": "must remain blocked"}, "u1"), [],
+        )
+        assert target_reads == 2
+        assert "IDENTITY_UPDATE_ABSTAINED" in result
+    finally:
+        bc._tool_executor.shutdown(wait=False, cancel_futures=True)
+
+
 def test_bgc_unavailable_named_omission_abstains_without_approval_flow(tmp_path):
     bc = _bg_fixture(tmp_path)
     try:

--- a/tests/test_phase4_plan_review_continuity.py
+++ b/tests/test_phase4_plan_review_continuity.py
@@ -47,8 +47,6 @@ def test_exact_evidence_selectors_return_the_requested_slice(tmp_path) -> None:
     from ouroboros.tools.plan_evidence import resolve_evidence
 
     source = tmp_path / "evidence.txt"
-    # The resolver's exact-byte contract must not depend on the host newline
-    # translation performed by Path.write_text on Windows.
     source.write_bytes(b"one\ntwo\nthree\nfour\nfive\n")
     manifest = resolve_evidence(
         ["evidence.txt::lines=3-4", "evidence.txt::tail=5"],

--- a/tests/test_phase4_plan_review_continuity.py
+++ b/tests/test_phase4_plan_review_continuity.py
@@ -46,7 +46,9 @@ def test_exact_evidence_selectors_return_the_requested_slice(tmp_path) -> None:
     from ouroboros.tools.plan_evidence import resolve_evidence
 
     source = tmp_path / "evidence.txt"
-    source.write_text("one\ntwo\nthree\nfour\nfive\n", encoding="utf-8")
+    # The resolver's exact-byte contract must not depend on the host newline
+    # translation performed by Path.write_text on Windows.
+    source.write_bytes(b"one\ntwo\nthree\nfour\nfive\n")
     manifest = resolve_evidence(
         ["evidence.txt::lines=3-4", "evidence.txt::tail=5"],
         active_root=tmp_path,

--- a/tests/test_task_status_flow.py
+++ b/tests/test_task_status_flow.py
@@ -403,9 +403,11 @@ def test_configured_session_child_materializes_initial_and_steered_attachments(t
         child_ctx, child_manifest[1]["relpath"], root="artifact_store",
     )
     work_order = compile_external_work_order(event)
-    assert all(row["abs_path"] in work_order for row in child_manifest)
-    assert str(parent_manifest[0]["abs_path"]) not in work_order
-    assert str(steered_manifest[0]["abs_path"]) not in work_order
+    # The canonical work-order renderer serializes the manifest with Python's
+    # repr; assert the exact serialized value on both POSIX and Windows.
+    assert all(repr(row["abs_path"]) in work_order for row in child_manifest)
+    assert repr(parent_manifest[0]["abs_path"]) not in work_order
+    assert repr(steered_manifest[0]["abs_path"]) not in work_order
 
 
 def test_schedule_task_rejects_legacy_description_schema(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Fix Windows continuity regressions in the v6.110.0 release candidate and bind background-consciousness identity authority to one raw-byte snapshot.

The recorder now derives universal-newline comparison text and the stored digest from the same captured bytes. This keeps CRLF sources usable on Windows and prevents a B→A→B race from pairing materialized text with a digest from different bytes. The accompanying test-only changes make path serialization and byte-exact fixtures host-independent.

## Scope

In scope:

- use one raw-byte snapshot for background-consciousness source verification;
- cover one-way mutation and B→A→B mixed-snapshot regressions;
- make CRLF, serialized Windows paths, and exact-byte fixtures deterministic across platforms.

Non-goals:

- provider routing, parser, retry, canary-budget, or release-policy changes;
- version or release metadata changes;
- new locks, schedulers, ledgers, or broader concurrency hardening.

## Verification

- [x] Focused tests for the changed behavior pass.
- [x] The default local test suite passes.
- [x] Lint/static checks relevant to this change pass.

Commands and results:

```text
OUROBOROS_DATA_DIR=<fresh temp dir> python -m pytest tests/test_durable_learning_completeness.py tests/test_phase4_plan_review_continuity.py tests/test_attachment_staging.py tests/test_task_status_flow.py -q --tb=short
166 passed, RC 0

LC_ALL=C LANG=C OUROBOROS_DATA_DIR=<fresh temp dir> python -m pytest tests/ -q --tb=short
100%, RC 0; live data/settings.json SHA-256 unchanged before/after

python -m pytest tests/test_size_ratchet.py -q
passed, RC 0

python scripts/regenerate_size_ratchet.py --check
RC 0

ruff check . --select F
RC 0

python -m py_compile ouroboros/consciousness.py
RC 0

git diff --check
RC 0
```

## Visual evidence

- [x] Not applicable; this PR has no visible UI change.
- [ ] Before/after screenshots or other rendered-flow evidence are attached below.

Evidence: not applicable.

## Governance and documentation

- [x] I read `CONTRIBUTING.md`; for this substantive change I also read `BIBLE.md`, `docs/ARCHITECTURE.md`, `docs/DEVELOPMENT.md`, and `docs/CHECKLISTS.md` in full.
- [x] I updated tests where behavior changed; the canonical architecture descriptions remain accurate.
- [x] I did not include secrets, local settings, runtime state, logs, caches, or generated build/review artifacts in the commit.
- [x] I did not bump `VERSION` or release-only version carriers.

## Review evidence

- Review status: PASS
- Authoring context: isolated Codex source worktree
- Reviewed base SHA: `8eae615aeec400ce629e888219985c13448e4225`
- Reviewed head SHA: `d1f32a7408955e573cd64e31dc2916c8a68328ce`
- Separate exact-SHA reviewers: GPT-5.6-Sol high, Grok 4.6 high (`run-77902959acfb`), Fable-5 Thinking high (`run-f5ba691c1c59`), and Opus-5 high (`run-ff771870c82d`)
- Findings and disposition: all reviewers returned `SAFE_TO_PUBLISH_SOURCE_PR`; LOW/INFO suggestions concerned redundant negative assertions, a non-tip size-band state, optional comments, and fixture-only lone-CR coverage. They were independently checked and rejected as non-material scope expansion.
- Checks performed and limitations: Fable independently ran the 166-test gate, size ratchet, compile, and Ruff. Opus independently verified source, tests, history, trailers, and ratchet state; its model-side Python calls were denied by the envelope, while Claudexor's configured post-turn gate passed RC 0. All final event streams were read to EOF and all reviewer patches were empty.

A separate Development provider-canary run currently has a repeated strict Grok tool-call miss. This PR does not touch that provider path or weaken its contract; the landed exact SHA will receive the normal provider gate before release.

## Final checklist

- [x] The PR base branch is `ouroboros`.
- [x] The branch is based on the current `ouroboros` revision.
- [x] The PR is one coherent change and is ready for maintainer integration.
- [x] The description explains the known limitation and compatibility impact.
