### PR TITLE
Fix cross-platform CI contract assertions

### DIFF
--- a/tests/test_skill_smoke_official.py
+++ b/tests/test_skill_smoke_official.py
@@ -707,7 +707,11 @@ def test_review_grants_and_enable(slug, review_secret, install_skill, review_env
     review = json.loads((_skill_state_dir(name) / "review.json").read_text(encoding="utf-8"))
     assert review.get("content_hash") == loaded.content_hash
     models = list(review.get("reviewer_models") or [])
-    assert len(models) == 1 and models[0].rsplit("#", 1)[0] == _REVIEW_MODEL, models
+    assert len(models) == 1, models
+    # Reviewer identity may carry the stable slot attribution suffix introduced
+    # by the shared review substrate, while the model id remains the contract.
+    model_id = models[0].split(" [", 1)[0].rsplit("#", 1)[0]
+    assert model_id == _REVIEW_MODEL, models
     # Hash-verified official payloads get the official_hub profile (the
     # severity-downgrade that stabilizes verdicts); losing it silently would
     # change what this lane proves.

--- a/web/tests/cancel_run.test.js
+++ b/web/tests/cancel_run.test.js
@@ -42,7 +42,11 @@ test('the cancel click shows the honest interim, not an instant Cancelled', () =
     // interim for a nonterminal record with cancel_state=pending instead of
     // finishing the card — through the SHARED taskCancelPending helper (AR2-8:
     // one consumer path for the typed projection, never an inline status peek).
-    const chat = readFileSync(new URL('../modules/chat.js', import.meta.url), 'utf8');
+    // Git's Windows checkout may expose CRLF even though the committed blob is
+    // LF. Normalize the source before asserting the cross-file wiring so the
+    // contract tests check behavior, not the platform's line-ending policy.
+    const chat = readFileSync(new URL('../modules/chat.js', import.meta.url), 'utf8')
+        .replace(/\r\n/g, '\n');
     assert.match(chat, /function markLiveCardCancelPending\(/);
     assert.match(chat, /markLiveCardCancelPending\(taskId, soft\);\n[\s\S]{0,600}await requestStop\(/);
     assert.match(chat, /taskCancelPending\(stored\)[\s\S]{0,400}markLiveCardCancelPending\(taskId[,)]/);
@@ -221,7 +225,8 @@ test('a failed cancel reconciles through the shared helper before touching the b
     // cancel_state=pending, finish the card for a terminal record — and only
     // a genuinely-live, non-pending task gets its prior phase restored and
     // the button re-enabled.
-    const chat = readFileSync(new URL('../modules/chat.js', import.meta.url), 'utf8');
+    const chat = readFileSync(new URL('../modules/chat.js', import.meta.url), 'utf8')
+        .replace(/\r\n/g, '\n');
     assert.match(chat, /const priorPhase = captureLiveCardPhaseState\(record\);\n\s*markLiveCardCancelPending\(taskId, soft\);/);
     const failure = chat.slice(chat.indexOf('showToast(`Cancel failed:'));
     const branch = failure.slice(0, 2200);


### PR DESCRIPTION
This fix-forward repairs the two post-merge CI failures on the already-promoted nested-coordination release.

The Windows Node lane checked source text with LF-sensitive regular expressions while the checkout exposed CRLF, so the two failing assertions now normalize line endings before inspecting the source. The Ubuntu skill-smoke lane receives the existing stable reviewer slot suffix, so it now compares the model id while retaining the single-reviewer invariant.

No Ouroboros runtime, product behavior, provider configuration, or release version changed. The exact commit is 357d8446dcb1f16065efc94758f40f704b7da740. Local Python syntax and diff checks are green; local Node execution was attempted but the host killed Node under concurrent process pressure, so the CI lane is the authoritative execution check. The provider-backed integration-test failures on the promoted release are pre-existing OpenRouter/Cloudru configuration failures and are unrelated to this test-only PR.