### PR TITLE
chore: pin Claudexor runtime 3.8.4

### DIFF
--- a/ouroboros/claudexor_runtime_pin.json
+++ b/ouroboros/claudexor_runtime_pin.json
@@ -1,12 +1,12 @@
 {
  "schema_version": 1,
  "release": {
-  "version": "3.8.2",
-  "build_sha": "9e5705fdc85d8f27b539837b948845838aca7b79",
+  "version": "3.8.4",
+  "build_sha": "0c37684420b006b3726034421ffbf73c8b382a5f",
   "protocol_major": 3,
-  "archive_url": "https://github.com/razzant/claudexor/releases/download/v3.8.2/claudexor-runtime-3.8.2.tar.gz",
-  "sha256": "e536745f42a5e41ee7c510963eaedcbd31e2b17bd47a9053e764cee17d830bed",
-  "size_bytes": 21948257,
+  "archive_url": "https://github.com/razzant/claudexor/releases/download/v3.8.4/claudexor-runtime-3.8.4.tar.gz",
+  "sha256": "d33b71ffa2984137307633044d6adc25cf096a903e240480504b4fbd39d947d9",
+  "size_bytes": 21950061,
   "node_version": "24.16.0",
   "node_artifacts": {
    "darwin-arm64": {

--- a/tests/test_claudexor_runtime_delivery.py
+++ b/tests/test_claudexor_runtime_delivery.py
@@ -154,7 +154,7 @@ def test_tracked_pin_names_a_cli_capable_release():
     of this proposal converged on while the pin was still pre-CLI 3.6.0)."""
     pin = runtime.load_runtime_pin()
     assert pin is not None
-    assert pin.version == "3.8.2"
+    assert pin.version == "3.8.4"
     assert pin.cli_entrypoint == "claudexor.bundle.cjs"
 
 


### PR DESCRIPTION
Обновил единственный runtime pin Ouroboros на опубликованный Claudexor 3.8.4. Pin привязан к commit 0c37684420b006b3726034421ffbf73c8b382a5f и архиву claudexor-runtime-3.8.4.tar.gz с проверенными размером 21950061 и SHA256 d33b71ffa2984137307633044d6adc25cf096a903e240480504b4fbd39d947d9. Версия в assertion обновлена синхронно. Проверки прошли: tests/test_claudexor_runtime_delivery.py, tests/test_claudexor_owned_daemon.py, tests/test_public_site_metadata.py.