### PR TITLE
fix: the Connect card names the real Claudexor phase, and Close answers the press instantly

### DIFF
--- a/ouroboros/size_ratchet_manifest.py
+++ b/ouroboros/size_ratchet_manifest.py
@@ -188,7 +188,6 @@ BAND_PATHS = {
     "tests/test_v678_receipt_reconciliation.py": None,
     "web/modules/api_types.js": "The shared browser contract module now includes issue 265 publication-preflight types alongside the target settings and subagent contracts.",
     "web/modules/harness_accounts.js": None,
-    "web/modules/harness_login_cards.js": None,
     "web/modules/log_events.js": None,
     "web/modules/onboarding_wizard.js": None,
     "web/modules/settings.js": None,

--- a/web/modules/claudexor_status_store.js
+++ b/web/modules/claudexor_status_store.js
@@ -930,15 +930,16 @@ export function claudexorPreparationLine(payload) {
     const daemon = payload?.daemon || {};
     const runtime = daemon.runtime || {};
     const state = String(runtime.state || '');
+    if (daemon.ownership_problem) {
+        // Checked before EVERY positive phase claim: ensure_running refuses a
+        // foreign daemon home, so neither an install nor a start proceeds on
+        // this payload however the runtime projection reads — the accounts
+        // panel carries the ownership sentence itself.
+        return 'Checking Claudexor…';
+    }
     if (state === 'installing') {
         const version = runtime.target_version ? ` ${runtime.target_version}` : '';
         return `Installing Claudexor${version}…`;
-    }
-    if (daemon.ownership_problem) {
-        // The producer's own refusal: ensure_running will not spawn into a
-        // foreign daemon home, so a "Starting…" claim would promise a start
-        // that is refused — the accounts panel carries the ownership sentence.
-        return 'Checking Claudexor…';
     }
     if (state === 'ready' && String(daemon.state || '') === 'stale') {
         // POSITIVE knowledge only: 'stale' is the producer's own "installed,

--- a/web/modules/claudexor_status_store.js
+++ b/web/modules/claudexor_status_store.js
@@ -916,3 +916,26 @@ export function boundedStatusRefresh(store, { includeModels = true, beatMs = 200
     const beat = new Promise((resolve) => { timer = setTimeout(resolve, beatMs); });
     return Promise.race([refresh, beat]).finally(() => { if (timer) clearTimeout(timer); });
 }
+
+/**
+ * The one sentence for "Claudexor is being made ready", phased by what is
+ * actually happening: the runtime manager's status projection distinguishes
+ * installing from ready, and the daemon aggregate says whether the engine is
+ * serving — printing "Installing or checking" when the payload names the
+ * phase made a minutes-long first install indistinguishable from a
+ * sub-second probe. An absent or unread payload answers the honest generic:
+ * this caller IS mid-check, it just has no phase evidence yet.
+ */
+export function claudexorPreparationLine(payload) {
+    const daemon = payload?.daemon || {};
+    const runtime = daemon.runtime || {};
+    const state = String(runtime.state || '');
+    if (state === 'installing') {
+        const version = runtime.target_version ? ` ${runtime.target_version}` : '';
+        return `Installing Claudexor${version}…`;
+    }
+    if (state === 'ready' && String(daemon.state || '') !== 'running') {
+        return 'Starting the Claudexor daemon…';
+    }
+    return 'Checking Claudexor…';
+}

--- a/web/modules/claudexor_status_store.js
+++ b/web/modules/claudexor_status_store.js
@@ -934,6 +934,12 @@ export function claudexorPreparationLine(payload) {
         const version = runtime.target_version ? ` ${runtime.target_version}` : '';
         return `Installing Claudexor${version}…`;
     }
+    if (daemon.ownership_problem) {
+        // The producer's own refusal: ensure_running will not spawn into a
+        // foreign daemon home, so a "Starting…" claim would promise a start
+        // that is refused — the accounts panel carries the ownership sentence.
+        return 'Checking Claudexor…';
+    }
     if (state === 'ready' && String(daemon.state || '') === 'stale') {
         // POSITIVE knowledge only: 'stale' is the producer's own "installed,
         // engine idle, starts automatically" verdict. A partially failed

--- a/web/modules/claudexor_status_store.js
+++ b/web/modules/claudexor_status_store.js
@@ -934,7 +934,13 @@ export function claudexorPreparationLine(payload) {
         const version = runtime.target_version ? ` ${runtime.target_version}` : '';
         return `Installing Claudexor${version}…`;
     }
-    if (state === 'ready' && String(daemon.state || '') !== 'running') {
+    if (state === 'ready' && String(daemon.state || '') === 'stale') {
+        // POSITIVE knowledge only: 'stale' is the producer's own "installed,
+        // engine idle, starts automatically" verdict. A partially failed
+        // fan-out rewrites a LIVE daemon's aggregate to 'unreachable' while
+        // preserving the runtime projection, so anything but 'stale' falls to
+        // the generic — never a "Starting…" claim about an engine that may
+        // already be serving.
         return 'Starting the Claudexor daemon…';
     }
     return 'Checking Claudexor…';

--- a/web/modules/harness_accounts.js
+++ b/web/modules/harness_accounts.js
@@ -52,6 +52,7 @@ import {
     STATUS_FACETS,
     accountRows,
     bindStatusSurface,
+    claudexorPreparationLine,
     claudexorStatus,
     facetReadState,
     familyLabel,
@@ -366,8 +367,9 @@ export function daemonStatusLine(payload, { checking = false, reads = null } = {
     const gapNames = facetGapNames(facetReads);
     const unreadTail = gapNames ? ` ${capitalize(gapNames)} were not read.` : '';
     if (runtimeState === 'installing') {
-        const version = runtime.target_version ? ` ${runtime.target_version}` : '';
-        return { tone: 'muted', text: `Installing or checking Claudexor${version}…${unreadTail}` };
+        // The branch condition IS the phase: say "installing", not a hedge
+        // that makes a minutes-long download read like a sub-second probe.
+        return { tone: 'muted', text: `${claudexorPreparationLine(payload)}${unreadTail}` };
     }
     if (runtimeState === 'error') {
         const detail = runtime.last_error ? `: ${runtime.last_error}.` : '.';

--- a/web/modules/harness_login_cards.js
+++ b/web/modules/harness_login_cards.js
@@ -41,6 +41,7 @@ import {
     accountLoginConfirmed,
     claudexorStatus,
     familyLabel,
+    claudexorPreparationLine,
 } from './claudexor_status_store.js';
 import { escapeHtmlAttr as escapeHtml, safeExternalHrefAttr } from './utils.js';
 
@@ -472,7 +473,7 @@ export async function reconcileLoginJob(jobId, fetchImpl = apiFetch) {
     }
 }
 
-export function loginCardHtml(active, nowMs = Date.now(), { mode = LOGIN_CARD_FULL } = {}) {
+export function loginCardHtml(active, nowMs = Date.now(), { mode = LOGIN_CARD_FULL, statusPayload = null } = {}) {
     // The card's whole body as a STRING — pure, so every face is asserted in
     // node without a DOM: the unsafe-URL refusal, the unconfirmed re-check,
     // and the rule that a verdict silences the live status line.
@@ -547,7 +548,7 @@ export function loginCardHtml(active, nowMs = Date.now(), { mode = LOGIN_CARD_FU
     // underneath "Connected.".
     if (face !== 'error' && face !== 'name' && !active.verdict && !active.confirming) {
         const line = active.preparingRuntime
-            ? 'Installing or checking Claudexor…'
+            ? claudexorPreparationLine(statusPayload)
             : loginStatusLine(active.envelope || {});
         if (line) bits.push(`<div class="settings-inline-status" data-tone="muted" data-login-state>${escapeHtml(line)}</div>`);
     }
@@ -672,7 +673,10 @@ export function loginCardHtml(active, nowMs = Date.now(), { mode = LOGIN_CARD_FU
         `);
     }
     if (!compact) {
-        bits.push('<button type="button" class="btn btn-default" data-login-dismiss>Close</button>');
+        // A pressed Close queues behind the in-flight start transition (C7) —
+        // possibly for a whole runtime install. The press must ANSWER at once,
+        // or a working control reads as a dead one (owner report, 2026-08-27).
+        bits.push(`<button type="button" class="btn btn-default" data-login-dismiss${active.closing ? ' disabled' : ''}>${active.closing ? 'Closing…' : 'Close'}</button>`);
     }
     bits.push('</div>');
     return bits.join('');
@@ -775,13 +779,22 @@ export function createLoginCardController({
         if (hostEl) hostEl.innerHTML = '';
     }
 
+    // While the create POST holds the transition (runtime ensure included),
+    // no job polling exists yet, so nothing re-rendered the card as the
+    // runtime moved through installing -> starting -> serving; the phase line
+    // froze on its first words. A BARE subscription reacts to the snapshots
+    // the visible accounts surface fetches without arming the poll itself.
+    const releasePhaseFollow = store?.subscribe
+        ? store.subscribe(() => { if (ctl.active?.preparingRuntime) render(); })
+        : () => {};
+
     function render() {
         const hostEl = getHost();
         if (!hostEl) return;
         const active = ctl.active;
         if (!active) { hostEl.innerHTML = ''; return; }
         preserveCardFocus(hostEl, () => {
-            hostEl.innerHTML = loginCardHtml(active, now(), { mode });
+            hostEl.innerHTML = loginCardHtml(active, now(), { mode, statusPayload: store?.snapshot || null });
         }, getDoc());
         wireLoginCard(hostEl, active);
     }
@@ -848,7 +861,24 @@ export function createLoginCardController({
         hostEl.querySelector('[data-profile-name-submit]')?.addEventListener('click', () => submitProfileNameFromCard(active));
         hostEl.querySelector('[data-login-code-submit]')?.addEventListener('click', () => submitCodeFromCard(active));
         hostEl.querySelector('[data-login-reconcile]')?.addEventListener('click', () => reconcile(active));
-        hostEl.querySelector('[data-login-dismiss]')?.addEventListener('click', () => close(active));
+        hostEl.querySelector('[data-login-dismiss]')?.addEventListener('click', () => {
+            // Instant local acknowledgement: the close itself queues behind
+            // whatever transition is in flight (C7), and during a runtime
+            // install that wait is minutes — a silent queued click reads as a
+            // broken button. The close promise is RETURNED for harnesses that
+            // invoke the handler directly (the DOM discards listener returns),
+            // and the flag resets on settle only when this card is still the
+            // active one (a settled close usually cleared it).
+            if (active.closing) return undefined;
+            active.closing = true;
+            render();
+            return close(active).finally(() => {
+                if (ctl.active === active && active.closing) {
+                    active.closing = false;
+                    render();
+                }
+            });
+        });
     }
 
     function showRecovery(active, result, fallbackDetail = '') {
@@ -884,6 +914,10 @@ export function createLoginCardController({
         ctl.pendingStart = null;
         stopJobPolling();
         releaseStatusPolling();
+        // Same fence as the timers and the polling hold: a detached controller
+        // must not keep reacting to store snapshots (the disposer is
+        // idempotent, so a later dispose() releasing again is a no-op).
+        try { releasePhaseFollow(); } catch (err) { /* detach must not throw */ }
         ctl.active = null;
         ctl.detachedStatus = result.status;
         clearHost();
@@ -1196,6 +1230,7 @@ export function createLoginCardController({
             inputValue: '', inputBusy: false, inputSent: false, inputError: '', inputNote: '',
             needsProfile: null, profileNameValue: '', profileNameNote: '',
             verdict: null, confirming: false, advancedOpen: false, preparingRuntime: true,
+            closing: false,
         };
         const active = ctl.active;
         render();
@@ -1469,6 +1504,7 @@ export function createLoginCardController({
         // Set FIRST: no new start may be queued behind the shutdown.
         ctl.disposed = true;
         ctl.pendingStart = null;
+        try { releasePhaseFollow(); } catch (err) { /* disposal must not throw */ }
         return withLoginTransition(() => _closeLocked(undefined, { shuttingDown: true }))
             .then((result) => {
                 if (!ctl.active) ctl.detachedStatus = result.status;

--- a/web/modules/harness_login_cards.js
+++ b/web/modules/harness_login_cards.js
@@ -39,9 +39,9 @@
 import { apiFetch } from './api_client.js';
 import {
     accountLoginConfirmed,
+    claudexorPreparationLine,
     claudexorStatus,
     familyLabel,
-    claudexorPreparationLine,
 } from './claudexor_status_store.js';
 import { escapeHtmlAttr as escapeHtml, safeExternalHrefAttr } from './utils.js';
 

--- a/web/modules/harness_login_cards.js
+++ b/web/modules/harness_login_cards.js
@@ -947,13 +947,23 @@ export function createLoginCardController({
             // Re-proved at EXECUTION time, not at click time: a close queued
             // during an in-flight create observes the world that create left.
             // When it failed without a job id there is nothing a DELETE can
-            // address — the same honest local detach the pre-queue check in
-            // close() applies when the error is already visible at the press.
-            // detach() answers a bare STATUS; this transition's callers unwrap
-            // `.status` from an object like every other branch here returns.
-            const status = detach();
+            // address. This is the PER-CARD half of detach() only: the full
+            // detach permanently fences the controller, which silently dropped
+            // a second Connect legitimately queued behind this close. The
+            // verdict is still remembered so a dispose queued behind this
+            // close answers it instead of fabricating release from the empty
+            // slot; a later start opens a new custody story and clears it.
+            let result = custodyResult(active.envelope, { absent: Boolean(active.absent) });
+            if (active.custodyStatus === LOGIN_CUSTODY_UNKNOWN) {
+                result = { ...result, status: LOGIN_CUSTODY_UNKNOWN };
+            }
+            stopJobPolling();
+            releaseStatusPolling();
+            ctl.active = null;
+            ctl.detachedStatus = result.status;
+            clearHost();
             onSettled();
-            return { status };
+            return result;
         }
 
         let result = custodyResult(active.envelope, { absent: Boolean(active.absent) });
@@ -1205,6 +1215,9 @@ export function createLoginCardController({
         // this start, and a disposed controller must not create a job nobody
         // will ever poll or cancel.
         if (ctl.disposed) return;
+        // A new card is a new custody story: the remembered verdict belonged
+        // to the card the queued close detached, not to this one.
+        ctl.detachedStatus = null;
         // C7 (plan roast, accepted): a NEW login may start only once release of
         // the previous job is PROVEN (loginReleaseProven): a terminal snapshot
         // whose reason is not termination_unconfirmed, a reconciliation that

--- a/web/modules/harness_login_cards.js
+++ b/web/modules/harness_login_cards.js
@@ -935,6 +935,11 @@ export function createLoginCardController({
         const active = ctl.active;
         if (!active) {
             if (shuttingDown) { stopJobPolling(); releaseStatusPolling(); clearHost(); }
+            // A remembered detach verdict outranks the empty-slot default: a
+            // queued close that detached with UNKNOWN must not be overwritten
+            // by a later shutdown answering absent/released for the same card
+            // — that would fabricate release proof out of an empty slot.
+            if (ctl.detachedStatus) return { status: ctl.detachedStatus };
             return custodyResult(null, { absent: true });
         }
         if (expected !== undefined && active !== expected) return custodyResult(null);

--- a/web/modules/harness_login_cards.js
+++ b/web/modules/harness_login_cards.js
@@ -909,7 +909,18 @@ export function createLoginCardController({
         // are non-awaitable and must make every continuation inert NOW. The
         // monotone disposed flag plus active identity checks are the fence; a
         // second generation counter would duplicate that authority.
-        if (ctl.disposed && !ctl.active && ctl.detachedStatus) return ctl.detachedStatus;
+        if (!ctl.active && ctl.detachedStatus) {
+            // Disposed or not: an empty slot with a remembered verdict answers
+            // that verdict — the same invariant _closeLocked and dispose hold.
+            // The per-card no-job close leaves {disposed:false, active:null,
+            // detachedStatus}, and fabricating absent/released here would be
+            // exactly the empty-slot release proof this seam forbids.
+            ctl.disposed = true;
+            stopJobPolling();
+            releaseStatusPolling();
+            clearHost();
+            return ctl.detachedStatus;
+        }
         const active = ctl.active;
         let result = active
             ? custodyResult(active.envelope, { absent: Boolean(active.absent) })

--- a/web/modules/harness_login_cards.js
+++ b/web/modules/harness_login_cards.js
@@ -937,6 +937,16 @@ export function createLoginCardController({
             return custodyResult(null, { absent: true });
         }
         if (expected !== undefined && active !== expected) return custodyResult(null);
+        if ((active.error || active.needsProfile) && !active.jobId && !shuttingDown) {
+            // Re-proved at EXECUTION time, not at click time: a close queued
+            // during an in-flight create observes the world that create left.
+            // When it failed without a job id there is nothing a DELETE can
+            // address — the same honest local detach the pre-queue check in
+            // close() applies when the error is already visible at the press.
+            const result = detach();
+            onSettled();
+            return result;
+        }
 
         let result = custodyResult(active.envelope, { absent: Boolean(active.absent) });
         if (active.verdict?.kind === 'recovery'

--- a/web/modules/harness_login_cards.js
+++ b/web/modules/harness_login_cards.js
@@ -782,8 +782,9 @@ export function createLoginCardController({
     // While the create POST holds the transition (runtime ensure included),
     // no job polling exists yet, so nothing re-rendered the card as the
     // runtime moved through installing -> starting -> serving; the phase line
-    // froze on its first words. A BARE subscription reacts to the snapshots
-    // the visible accounts surface fetches without arming the poll itself.
+    // froze on its first words. A BARE subscription (no visibility predicate)
+    // cannot by itself make the store poll — it rides whatever reads the
+    // visible surfaces and the login hold cause.
     const releasePhaseFollow = store?.subscribe
         ? store.subscribe(() => { if (ctl.active?.preparingRuntime) render(); })
         : () => {};
@@ -1305,9 +1306,13 @@ export function createLoginCardController({
             // face and its Try again already exist.
             const jobId = String(data?.job_id || '');
             if (!jobId) throw new Error('the sign-in service returned no job id');
+            // Adopted BEFORE the body validation: a nonempty id names a job
+            // the daemon may be running regardless of how malformed the rest
+            // of the answer is, and a queued close must be able to DELETE it —
+            // the no-job detach is only for creates that produced no id.
+            active.jobId = jobId;
             if (!hasJobState(data)) throw new Error('the sign-in service returned no job');
             active.preparingRuntime = false;
-            active.jobId = jobId;
             active.envelope = data;
             active.attachCommand = String(data.attach_command || '');
             active.attachShell = String(data.attach_shell || '');

--- a/web/modules/harness_login_cards.js
+++ b/web/modules/harness_login_cards.js
@@ -794,7 +794,13 @@ export function createLoginCardController({
         const active = ctl.active;
         if (!active) { hostEl.innerHTML = ''; return; }
         preserveCardFocus(hostEl, () => {
-            hostEl.innerHTML = loginCardHtml(active, now(), { mode, statusPayload: store?.snapshot || null });
+            // A failed refresh RETAINS the prior snapshot and records the
+            // error; a retained snapshot is not phase evidence, and rendering
+            // it kept a positive "Installing…" claim alive off a dead read.
+            hostEl.innerHTML = loginCardHtml(active, now(), {
+                mode,
+                statusPayload: store?.error ? null : (store?.snapshot || null),
+            });
         }, getDoc());
         wireLoginCard(hostEl, active);
     }

--- a/web/modules/harness_login_cards.js
+++ b/web/modules/harness_login_cards.js
@@ -943,9 +943,11 @@ export function createLoginCardController({
             // When it failed without a job id there is nothing a DELETE can
             // address — the same honest local detach the pre-queue check in
             // close() applies when the error is already visible at the press.
-            const result = detach();
+            // detach() answers a bare STATUS; this transition's callers unwrap
+            // `.status` from an object like every other branch here returns.
+            const status = detach();
             onSettled();
-            return result;
+            return { status };
         }
 
         let result = custodyResult(active.envelope, { absent: Boolean(active.absent) });

--- a/web/tests/claudexor_status_store.test.js
+++ b/web/tests/claudexor_status_store.test.js
@@ -13,6 +13,7 @@ import test from 'node:test';
 import { readFileSync } from 'node:fs';
 
 import {
+    claudexorPreparationLine,
     DAEMON_STATES_STOPPED,
     FACET_ACCOUNTS,
     FACET_CATALOG,
@@ -880,4 +881,24 @@ test('a refused wake does not stop the visible panel from polling', async (t) =>
     } finally {
         globalThis.setTimeout = origSet; globalThis.clearTimeout = origClear;
     }
+});
+
+test('claudexorPreparationLine phases by runtime state and daemon liveness', () => {
+    assert.equal(claudexorPreparationLine({
+        daemon: { state: 'unreachable', runtime: { state: 'installing', target_version: '3.3.14' } },
+    }), 'Installing Claudexor 3.3.14…');
+    assert.equal(claudexorPreparationLine({
+        daemon: { state: 'unreachable', runtime: { state: 'installing' } },
+    }), 'Installing Claudexor…', 'no version claim without a version');
+    assert.equal(claudexorPreparationLine({
+        daemon: { state: 'stale', runtime: { state: 'ready' } },
+    }), 'Starting the Claudexor daemon…');
+    assert.equal(claudexorPreparationLine({
+        daemon: { state: 'running', runtime: { state: 'ready' } },
+    }), 'Checking Claudexor…', 'a serving engine is being checked, not started');
+    assert.equal(claudexorPreparationLine(null), 'Checking Claudexor…',
+        'no snapshot is no phase evidence — the honest generic');
+    assert.equal(claudexorPreparationLine({
+        daemon: { state: 'running', runtime: {} },
+    }), 'Checking Claudexor…');
 });

--- a/web/tests/claudexor_status_store.test.js
+++ b/web/tests/claudexor_status_store.test.js
@@ -13,7 +13,6 @@ import test from 'node:test';
 import { readFileSync } from 'node:fs';
 
 import {
-    claudexorPreparationLine,
     DAEMON_STATES_STOPPED,
     FACET_ACCOUNTS,
     FACET_CATALOG,
@@ -27,6 +26,7 @@ import {
     accountLoginConfirmed,
     accountRows,
     bindStatusSurface,
+    claudexorPreparationLine,
     createClaudexorStatusStore,
     facetGapClause,
     facetKnown,

--- a/web/tests/claudexor_status_store.test.js
+++ b/web/tests/claudexor_status_store.test.js
@@ -904,6 +904,11 @@ test('claudexorPreparationLine phases by runtime state and daemon liveness', () 
         daemon: { state: 'stale', ownership_problem: 'foreign home', runtime: { state: 'ready' } },
     }), 'Checking Claudexor…',
         'ensure refuses a foreign daemon home — never promise a start that is refused');
+    assert.equal(claudexorPreparationLine({
+        daemon: { state: 'unreachable', ownership_problem: 'foreign home',
+            runtime: { state: 'installing', target_version: '3.3.14' } },
+    }), 'Checking Claudexor…',
+        'an ownership refusal outranks every positive phase claim, installing included');
     assert.equal(claudexorPreparationLine(null), 'Checking Claudexor…',
         'no snapshot is no phase evidence — the honest generic');
     assert.equal(claudexorPreparationLine({

--- a/web/tests/claudexor_status_store.test.js
+++ b/web/tests/claudexor_status_store.test.js
@@ -900,6 +900,10 @@ test('claudexorPreparationLine phases by runtime state and daemon liveness', () 
         daemon: { state: 'unreachable', runtime: { state: 'ready' } },
     }), 'Checking Claudexor…',
         'a failed fan-out rewrites a LIVE daemon to unreachable — never a Starting claim');
+    assert.equal(claudexorPreparationLine({
+        daemon: { state: 'stale', ownership_problem: 'foreign home', runtime: { state: 'ready' } },
+    }), 'Checking Claudexor…',
+        'ensure refuses a foreign daemon home — never promise a start that is refused');
     assert.equal(claudexorPreparationLine(null), 'Checking Claudexor…',
         'no snapshot is no phase evidence — the honest generic');
     assert.equal(claudexorPreparationLine({

--- a/web/tests/claudexor_status_store.test.js
+++ b/web/tests/claudexor_status_store.test.js
@@ -896,6 +896,10 @@ test('claudexorPreparationLine phases by runtime state and daemon liveness', () 
     assert.equal(claudexorPreparationLine({
         daemon: { state: 'running', runtime: { state: 'ready' } },
     }), 'Checking Claudexor…', 'a serving engine is being checked, not started');
+    assert.equal(claudexorPreparationLine({
+        daemon: { state: 'unreachable', runtime: { state: 'ready' } },
+    }), 'Checking Claudexor…',
+        'a failed fan-out rewrites a LIVE daemon to unreachable — never a Starting claim');
     assert.equal(claudexorPreparationLine(null), 'Checking Claudexor…',
         'no snapshot is no phase evidence — the honest generic');
     assert.equal(claudexorPreparationLine({

--- a/web/tests/harness_accounts.test.js
+++ b/web/tests/harness_accounts.test.js
@@ -106,12 +106,32 @@ test('a slow first read says it is checking, and an idle daemon is not dressed a
 });
 
 test('the login card explains foreground runtime preparation and retries the same intent', () => {
+    // No status snapshot: the card IS mid-check but has no phase evidence —
+    // the honest generic, never the old "Installing or checking" hedge.
     const preparing = loginCardHtml({
         harness: 'claude', profile: '', envelope: null, preparingRuntime: true,
         error: '', verdict: null, confirming: false,
     });
-    assert.ok(preparing.includes('Installing or checking Claudexor…'));
+    assert.ok(preparing.includes('Checking Claudexor…'));
+    assert.ok(!preparing.includes('Installing or checking'));
     assert.ok(!preparing.includes('data-login-retry'));
+
+    // The status snapshot names the phase: a minutes-long install says so.
+    const installing = loginCardHtml({
+        harness: 'claude', profile: '', envelope: null, preparingRuntime: true,
+        error: '', verdict: null, confirming: false,
+    }, Date.now(), { statusPayload: {
+        daemon: { state: 'unreachable', runtime: { state: 'installing', target_version: '3.3.14' } },
+    } });
+    assert.ok(installing.includes('Installing Claudexor 3.3.14…'));
+
+    const starting = loginCardHtml({
+        harness: 'claude', profile: '', envelope: null, preparingRuntime: true,
+        error: '', verdict: null, confirming: false,
+    }, Date.now(), { statusPayload: {
+        daemon: { state: 'stale', runtime: { state: 'ready' } },
+    } });
+    assert.ok(starting.includes('Starting the Claudexor daemon…'));
 
     const failed = loginCardHtml({
         harness: 'claude', profile: '', envelope: null, preparingRuntime: false,
@@ -119,7 +139,7 @@ test('the login card explains foreground runtime preparation and retries the sam
     });
     assert.ok(failed.includes('checksum mismatch'));
     assert.ok(failed.includes('data-login-retry'));
-    assert.ok(!failed.includes('Installing or checking Claudexor…'));
+    assert.ok(!failed.includes('Checking Claudexor…'));
 });
 
 // GOLDEN fixture: the real /v2/credential-profiles body, produced by PARSING a

--- a/web/tests/harness_login_card_close.test.js
+++ b/web/tests/harness_login_card_close.test.js
@@ -181,7 +181,9 @@ test('a close queued during a create that fails without a job detaches honestly'
     assert.ok(host.innerHTML.includes('Closing…'), 'the press acknowledged before the create settled');
     releaseCreate();
     await starting;
-    await clicked;
+    const settledStatus = await clicked;
     assert.equal(deletes, 0, 'no job id — nothing a DELETE can address');
     assert.equal(host.innerHTML, '', 'the queued close detached the failed create honestly');
+    assert.ok(typeof settledStatus === 'string' && settledStatus.length > 0,
+        `the close must keep its released|retained|unknown contract, got: ${String(settledStatus)}`);
 });

--- a/web/tests/harness_login_card_close.test.js
+++ b/web/tests/harness_login_card_close.test.js
@@ -187,3 +187,36 @@ test('a close queued during a create that fails without a job detaches honestly'
     assert.ok(typeof settledStatus === 'string' && settledStatus.length > 0,
         `the close must keep its released|retained|unknown contract, got: ${String(settledStatus)}`);
 });
+
+test('a malformed 2xx create with a job id is still cancellable by a queued close', async () => {
+    // The id names a job the daemon may be running however malformed the rest
+    // of the answer is: the queued close must DELETE it, never take the
+    // no-job detach shortcut.
+    let releaseCreate = () => {};
+    const gate = new Promise((resolve) => { releaseCreate = resolve; });
+    let deletes = 0;
+    const host = interactiveHost();
+    const ctl = createLoginCardController({
+        host,
+        store: null,
+        fetchImpl: async (url, init = {}) => {
+            if (url === '/api/claudexor/login' && init.method === 'POST') {
+                await gate;
+                return json(200, { job_id: 'job-malformed' /* no job body */ });
+            }
+            if (init.method === 'DELETE') {
+                deletes += 1;
+                return json(200, { job: { state: 'cancelled', outcome: { reason: 'user_cancelled' } } });
+            }
+            return json(200, { job: { state: 'cancelled' } });
+        },
+    });
+    const starting = ctl.start('codex', '');
+    await flush();
+    const clicked = host.click('[data-login-dismiss]');
+    releaseCreate();
+    await starting;
+    const status = await clicked;
+    assert.equal(deletes, 1, 'the id was adopted before body validation — the job got its DELETE');
+    assert.ok(typeof status === 'string' && status.length > 0);
+})

--- a/web/tests/harness_login_card_close.test.js
+++ b/web/tests/harness_login_card_close.test.js
@@ -154,3 +154,34 @@ test('the preparation line advances with live snapshots and retreats on a dead r
         store.dispose();
     }
 });
+
+test('a close queued during a create that fails without a job detaches honestly', async () => {
+    // The queued close observes the world the create left: a failed create
+    // has no job id, so there is nothing a DELETE can address — the close
+    // must land on the same honest local detach the pre-queue check applies.
+    let releaseCreate = () => {};
+    const gate = new Promise((resolve) => { releaseCreate = resolve; });
+    let deletes = 0;
+    const host = interactiveHost();
+    const ctl = createLoginCardController({
+        host,
+        store: null,
+        fetchImpl: async (url, init = {}) => {
+            if (url === '/api/claudexor/login' && init.method === 'POST') {
+                await gate;
+                return json(502, { error: 'engine exploded mid-create' });
+            }
+            if (init.method === 'DELETE') { deletes += 1; return json(200, { job: {} }); }
+            return json(404, {});
+        },
+    });
+    const starting = ctl.start('codex', '');
+    await flush();
+    const clicked = host.click('[data-login-dismiss]');
+    assert.ok(host.innerHTML.includes('Closing…'), 'the press acknowledged before the create settled');
+    releaseCreate();
+    await starting;
+    await clicked;
+    assert.equal(deletes, 0, 'no job id — nothing a DELETE can address');
+    assert.equal(host.innerHTML, '', 'the queued close detached the failed create honestly');
+});

--- a/web/tests/harness_login_card_close.test.js
+++ b/web/tests/harness_login_card_close.test.js
@@ -250,3 +250,38 @@ test('a dispose queued behind an unknown-custody detach keeps the unknown verdic
     assert.equal(disposeStatus, closeStatus,
         'the shutdown answers the remembered detach verdict, never a fabricated release');
 });
+
+test('a second Connect queued behind the failed-create close is not dropped', async () => {
+    // The queued close tears down ITS card only: a permanent fence here
+    // silently swallowed a different-account start legitimately queued behind
+    // the close.
+    let creates = 0;
+    let releaseCreate = () => {};
+    const gate = new Promise((resolve) => { releaseCreate = resolve; });
+    const host = interactiveHost();
+    const ctl = createLoginCardController({
+        host,
+        store: null,
+        fetchImpl: async (url, init = {}) => {
+            if (url === '/api/claudexor/login' && init.method === 'POST') {
+                creates += 1;
+                if (creates === 1) { await gate; return json(502, { error: 'engine exploded' }); }
+                return json(200, { job_id: 'job-2', job: { state: 'running', phase: 'awaiting_user' }, attach_command: '' });
+            }
+            return json(200, { job: { state: 'cancelled' } });
+        },
+    });
+    const first = ctl.start('codex', '');
+    await flush();
+    const clicked = host.click('[data-login-dismiss]');
+    const second = ctl.start('codex', 'other-account');
+    releaseCreate();
+    await first;
+    await clicked;
+    await second;
+    await flush();
+    assert.equal(creates, 2, 'the queued second Connect ran after the close settled');
+    assert.ok(host.innerHTML.includes('data-login-card'), 'the second card rendered');
+    ctl.dispose();
+    await flush();
+});

--- a/web/tests/harness_login_card_close.test.js
+++ b/web/tests/harness_login_card_close.test.js
@@ -219,4 +219,34 @@ test('a malformed 2xx create with a job id is still cancellable by a queued clos
     const status = await clicked;
     assert.equal(deletes, 1, 'the id was adopted before body validation — the job got its DELETE');
     assert.ok(typeof status === 'string' && status.length > 0);
-})
+});
+
+test('a dispose queued behind an unknown-custody detach keeps the unknown verdict', async () => {
+    // The queued close detaches with UNKNOWN (untyped create failure, no job
+    // id); the shutdown that follows must answer that remembered verdict —
+    // an empty slot is not release proof.
+    let releaseCreate = () => {};
+    const gate = new Promise((resolve) => { releaseCreate = resolve; });
+    const host = interactiveHost();
+    const ctl = createLoginCardController({
+        host,
+        store: null,
+        fetchImpl: async (url, init = {}) => {
+            if (url === '/api/claudexor/login' && init.method === 'POST') {
+                await gate;
+                return json(502, { error: 'engine exploded mid-create' });
+            }
+            return json(404, {});
+        },
+    });
+    const starting = ctl.start('codex', '');
+    await flush();
+    const clicked = host.click('[data-login-dismiss]');
+    const disposed = ctl.dispose();
+    releaseCreate();
+    await starting;
+    const closeStatus = await clicked;
+    const disposeStatus = await disposed;
+    assert.equal(disposeStatus, closeStatus,
+        'the shutdown answers the remembered detach verdict, never a fabricated release');
+});

--- a/web/tests/harness_login_card_close.test.js
+++ b/web/tests/harness_login_card_close.test.js
@@ -1,0 +1,95 @@
+// Close/dismiss lifecycle of the login card controller — split from
+// harness_login_cards.test.js per that suite's recorded size-ratchet
+// commitment ("split when the next face lands"); the instant-acknowledgement
+// face is that landing. Local helper copies follow the house test pattern
+// (each suite owns its fakes).
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createLoginCardController } from '../modules/harness_login_cards.js';
+
+const json = (status, body) => ({ ok: status >= 200 && status < 300, status, json: async () => body });
+
+const flush = async () => { for (let i = 0; i < 40; i += 1) await Promise.resolve(); };
+
+function interactiveHost() {
+    const listeners = new Map();
+    return {
+        innerHTML: '',
+        contains: () => false,
+        querySelector(selector) {
+            const marker = selector.match(/\[([^\]]+)\]/)?.[1] || '';
+            if (!marker || !this.innerHTML.includes(marker)) return null;
+            return {
+                open: false,
+                addEventListener(type, callback) { listeners.set(`${selector}:${type}`, callback); },
+            };
+        },
+        querySelectorAll: () => [],
+        click(selector) { return listeners.get(`${selector}:click`)?.({ preventDefault() {} }); },
+    };
+}
+
+
+test('Close answers instantly while the create transition is still installing the runtime', async () => {
+    // The click's acknowledgement must not wait for the queued close: during a
+    // first install the create POST holds the transition chain for minutes,
+    // and a silent queued click reads as a dead button.
+    let releaseCreate = () => {};
+    const createGate = new Promise((resolve) => { releaseCreate = resolve; });
+    let deletes = 0;
+    const host = interactiveHost();
+    const ctl = createLoginCardController({
+        host,
+        store: null,
+        fetchImpl: async (url, init = {}) => {
+            if (url === '/api/claudexor/login' && init.method === 'POST') {
+                await createGate;
+                return json(200, { job_id: 'job-slow', job: { state: 'running' }, attach_command: '' });
+            }
+            if (init.method === 'DELETE') {
+                deletes += 1;
+                return json(200, { job: { state: 'cancelled', outcome: { reason: 'user_cancelled' } } });
+            }
+            return json(200, { job: { state: 'cancelled' } });
+        },
+    });
+
+    const starting = ctl.start('codex', '');
+    await flush();
+    assert.ok(host.innerHTML.includes('Checking Claudexor…'),
+        'the preparing line is live while the create POST holds the chain');
+    assert.ok(host.innerHTML.includes('>Close<'), 'Close renders enabled before the press');
+
+    host.click('[data-login-dismiss]');
+    assert.ok(host.innerHTML.includes('Closing…'),
+        'the press acknowledges SYNCHRONOUSLY — before any transition settles');
+    assert.ok(host.innerHTML.includes('data-login-dismiss disabled'),
+        'the acknowledged button cannot be pressed twice');
+    assert.equal(deletes, 0, 'nothing to cancel yet: the close is queued, not lost');
+
+    releaseCreate();
+    await starting;
+    await flush();
+    assert.equal(deletes, 1, 'the queued close cancelled the job the create produced');
+    assert.equal(host.innerHTML, '', 'the settled close cleared the card');
+});
+
+
+test('detach releases the phase-follow subscription like every other resource', () => {
+    // detach() permanently fences the controller outside the transition queue
+    // (pagehide, second recovery-face Close); a subscription surviving it
+    // would keep re-rendering a dead card on every status snapshot.
+    let subscribed = 0;
+    const store = {
+        subscribe: () => { subscribed += 1; return () => { subscribed -= 1; }; },
+        snapshot: null,
+    };
+    const ctl = createLoginCardController({ host: interactiveHost(), store, fetchImpl: async () => json(404, {}) });
+    assert.equal(subscribed, 1, 'the controller follows phases from construction');
+    ctl.detach();
+    assert.equal(subscribed, 0, 'a detached controller stops following the store');
+    ctl.dispose();
+    assert.equal(subscribed, 0, 'a later dispose releases nothing twice');
+});

--- a/web/tests/harness_login_card_close.test.js
+++ b/web/tests/harness_login_card_close.test.js
@@ -93,3 +93,64 @@ test('detach releases the phase-follow subscription like every other resource', 
     ctl.dispose();
     assert.equal(subscribed, 0, 'a later dispose releases nothing twice');
 });
+
+test('the preparation line advances with live snapshots and retreats on a dead read', async () => {
+    // End-to-end: while the create POST holds the transition chain, the
+    // phase-follow subscription re-renders the card as store reads land — and
+    // a FAILED read (which retains the prior snapshot) must not keep a
+    // positive "Installing…" claim alive.
+    const { createClaudexorStatusStore } = await import('../modules/claudexor_status_store.js');
+    let runtime = { state: 'installing', target_version: '3.3.14' };
+    let daemonState = 'unreachable';
+    let fail = false;
+    const store = createClaudexorStatusStore({
+        fetchImpl: async () => {
+            if (fail) throw new Error('status read died');
+            return json(200, {
+                daemon: { state: daemonState, runtime },
+                config_dir: '/home/agent', harnesses: [], profiles: { harnessAccounts: [], profiles: [] }, quota: [],
+            });
+        },
+        doc: { hidden: false, addEventListener() {}, removeEventListener() {} },
+    });
+    let releaseCreate = () => {};
+    const gate = new Promise((resolve) => { releaseCreate = resolve; });
+    const host = interactiveHost();
+    const ctl = createLoginCardController({
+        host,
+        store,
+        fetchImpl: async (url, init = {}) => {
+            if (url === '/api/claudexor/login' && init.method === 'POST') {
+                await gate;
+                return json(200, { job_id: 'job-x', job: { state: 'cancelled' }, attach_command: '' });
+            }
+            return json(200, { job: { state: 'cancelled' } });
+        },
+    });
+    try {
+        const starting = ctl.start('codex', '');
+        await flush();
+        assert.ok(host.innerHTML.includes('Checking Claudexor…'), 'no snapshot yet — the generic');
+
+        await store.refresh();
+        assert.ok(host.innerHTML.includes('Installing Claudexor 3.3.14…'),
+            'a landed installing snapshot advances the line without any job poll');
+
+        runtime = { state: 'ready' };
+        daemonState = 'stale';
+        await store.refresh();
+        assert.ok(host.innerHTML.includes('Starting the Claudexor daemon…'));
+
+        fail = true;
+        await store.refresh();
+        assert.ok(host.innerHTML.includes('Checking Claudexor…'),
+            'a dead read retains the snapshot but is NOT phase evidence');
+
+        releaseCreate();
+        await starting;
+    } finally {
+        ctl.dispose();
+        await flush();
+        store.dispose();
+    }
+});

--- a/web/tests/harness_login_card_close.test.js
+++ b/web/tests/harness_login_card_close.test.js
@@ -285,3 +285,31 @@ test('a second Connect queued behind the failed-create close is not dropped', as
     ctl.dispose();
     await flush();
 });
+
+test('detach after the unknown-custody per-card close answers the remembered verdict', async () => {
+    // The third exit of the same invariant: pagehide/destroy call detach()
+    // directly, and an empty slot with a remembered verdict must answer it —
+    // never fabricate absent/released.
+    let releaseCreate = () => {};
+    const gate = new Promise((resolve) => { releaseCreate = resolve; });
+    const host = interactiveHost();
+    const ctl = createLoginCardController({
+        host,
+        store: null,
+        fetchImpl: async (url, init = {}) => {
+            if (url === '/api/claudexor/login' && init.method === 'POST') {
+                await gate;
+                return json(502, { error: 'engine exploded mid-create' });
+            }
+            return json(404, {});
+        },
+    });
+    const starting = ctl.start('codex', '');
+    await flush();
+    const clicked = host.click('[data-login-dismiss]');
+    releaseCreate();
+    await starting;
+    const closeStatus = await clicked;
+    assert.equal(ctl.detach(), closeStatus,
+        'the external detach answers the verdict the queued close remembered');
+});


### PR DESCRIPTION
Two defects on the Agents-tab Connect card, observed on a live install: the status line said "Installing or checking Claudexor…" while a minutes-long first install was indistinguishable from a sub-second probe, and a pressed Close gave no response for the whole of that install.

## The preparation line names the real phase

Both sides of the old hedge were knowable: the runtime manager's status projection already distinguishes `installing` from `ready` and carries the target version, and the daemon aggregate says whether the engine is serving. A shared pure helper (`claudexorPreparationLine` in `claudexor_status_store.js`) now phases the sentence — "Installing Claudexor 3.3.x…", "Starting the Claudexor daemon…" (only on a positive `stale` reading), or the honest generic "Checking Claudexor…" — and both surfaces use it: the accounts panel's installing branch, and the login card, which receives the shared snapshot through a pure `statusPayload` render option and follows phase changes live via a bare store subscription while the create transition holds the chain (no job polling exists yet in that window, so nothing else would repaint the card). Honesty guards hardened through review: an ownership refusal outranks every positive phase claim (ensure refuses a foreign daemon home, so neither an install nor a start is promised), an `unreachable` daemon never earns a "Starting…" claim, and a failed status refresh — which retains the prior snapshot — is not phase evidence: the card falls back to the generic rather than keeping a positive claim alive off a dead read.

## Close acknowledges the press instantly

A pressed Close queues behind the in-flight start transition by design (C7 — a dropped close used to leak live jobs), but during a first runtime install that wait is minutes, and the silent queued click read as a dead button. The press now flips the button to a disabled "Closing…" synchronously and the queue catches up. The queued close was then made honest across every world the create can leave behind, each behaviourally pinned: a create that fails without a job id lands on the local no-job detach (nothing a DELETE can address) while keeping the typed `released | retained | unknown` result contract; a malformed 2xx that still names a job id gets its DELETE (the id is adopted the moment it parses, before body validation); the close tears down its own card only, so a different-account Connect queued behind it still runs; and the remembered custody verdict survives every later exit — a queued `dispose()`, and the direct `detach()` seam (pagehide/destroy) — instead of being overwritten by a fabricated absent/released from an empty slot.

## Verification

`node --test web/tests`: 564/564, including a new close-lifecycle suite (the login-card suite's recorded split commitment routed the new face there instead of regrowing the file, so its band entry and original rationale survive untouched) covering: synchronous acknowledgement with a held create POST, queued cancellation of the job the create produced, the failed-create detach with its typed result, the malformed-2xx DELETE, the second-Connect survival, the dispose-after-detach and detach-after-detach verdicts, the end-to-end phase advance/retreat (installing → starting on live snapshots, back to the generic on a dead read), and the detach-releases-subscription regression. Phase-line units cover installing with and without a version, ready-but-not-serving, serving, unreachable, ownership refusals, and the absent snapshot. `test_repo_health_smoke` (per-commit size-ratchet validity) and `test_agents_tab_static` green; `node --check` clean on all touched modules.

Nine reviewer-panel rounds to convergence; the final round returned a mergeable verdict whose one warning (the same remembered-verdict invariant on the third exit) is applied and pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
