### PR TITLE
Draft: delegated runtime integrity handoff

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1249,10 +1249,16 @@ artifact has been read in full.
 
 **Project registration is a required step, not an optimization.** The first
 `delegate_start` against an unregistered root is answered with HTTP 404
-`project_not_registered`, so the nanny registers the root first. Claudexor has had
-`RunScope.ephemeral` — a one-shot root that never enters the durable registry — since
-3.3.0, but Ouroboros does not yet use it, so a registration WE created is retired when
-the run settles; a pre-existing registration is left alone.
+`project_not_registered`. On an engine satisfying
+`CLAUDEXOR_DELEGATED_WORKSPACE_ROOT_MIN_VERSION`, the nanny therefore registers the
+stable target root first: a mutating delegated run keeps that target in `scope.root`
+and puts its private execution snapshot in `execution.workspaceRoot`; the registration
+remains available for later attempts and is not retired as per-run cleanup. The pinned
+3.8.0 engine and older engines retain the legacy one-root shape, where the private
+snapshot itself is `scope.root` and the registration is retired with the run. Claudexor
+has had `RunScope.ephemeral` — a one-shot root that never enters the durable registry —
+since 3.3.0, but Ouroboros does not use it. Historical one-root custody rows retain
+their old retirement behavior.
 
 **Daemon lifecycle is owned, explicit, and lazy.** Reading status, booting the app,
 and `delegate_wait`/`delegate_cancel` never install or spawn anything. Connect,
@@ -1553,8 +1559,12 @@ veto the workspace-patch capture applies, DECIDED BEFORE ANYTHING IS HASHED (a
 blanket `git add -A` would write a blob for every untracked file, `.env` included,
 into the object database the execution worktree shares) — into a synthetic baseline
 commit pinned by a `refs/ouroboros/delegated/` ref, checks out a detached worktree of it under the
-subagent-worktree root (`subagent_worktrees.provision_execution_snapshot`), and
-scopes the run there: `scope.root` IS the snapshot. The typed binding
+subagent-worktree root (`subagent_worktrees.provision_execution_snapshot`). On a
+future engine satisfying `CLAUDEXOR_DELEGATED_WORKSPACE_ROOT_MIN_VERSION`, it scopes
+the run with the stable target in `scope.root` plus the snapshot in
+`execution.workspaceRoot`; on the pinned/legacy engine it scopes the run at the
+snapshot in `scope.root` because the strict schema cannot accept the new field. The
+typed binding
 `{target_root, execution_root, baseline_sha, authority_source, snapshot_id}` is recorded durably on the
 custody request/start rows BEFORE the POST, the canonical request carries it, and an
 explicit retry reproduces it exactly (a GC-collected snapshot is a typed
@@ -1703,9 +1713,18 @@ above. Four things follow, and they are one mechanism, not four:
   exists. It is checked inside `subagents.route_health`, the ONE health reader, so the
   DISPATCHER refuses that engine before a token is spent and the nanny's own
   `delegate_start` gives the identical typed `engine_rejects_delegated_marker` blocker. It
-  has to be a version and not a capability probe: `RunExecution` is STRICT (an unknown key
+  has to be a version and not a capability probe for this historical marker: `RunExecution` is STRICT (an unknown key
   is a 400, not an ignored field) and the catalog's `runControlKeys` are TOP-LEVEL request
-  keys only, so a nested marker is undiscoverable. READ-ONLY delegation sends no marker
+  keys only, so a nested marker is undiscoverable. Fresh mutating delegation uses the
+  explicit release contract `CLAUDEXOR_DELEGATED_WORKSPACE_ROOT_MIN_VERSION` (3.8.1),
+  which is the next compatible semver release carrying PR216 after the pinned 3.8.0.
+  Engines below that contract retain the legacy snapshot-in-`scope.root` shape; engines
+  at or above it receive stable target `scope.root` plus `execution.workspaceRoot`.
+  Retries always replay the stored body byte-identically. An accepted idempotency key
+  may replay across the upgrade; an unknown legacy pending body that the future schema
+  rejects remains pending with a typed compatibility reason, and a future-shaped body
+  is held back from an old engine.
+  READ-ONLY delegation sends no marker
   and keeps the lower transport floor (`CLAUDEXOR_MIN_VERSION` = 3.2.0, the oldest engine
   that serves that lane and the one the operator actually runs). THE TWO FLOORS ARE
   DIFFERENT NUMBERS ON PURPOSE: an engine between them serves read-only and refuses

--- a/docs/DELEGATED_ADMISSION.md
+++ b/docs/DELEGATED_ADMISSION.md
@@ -1,6 +1,6 @@
 # Delegated-run admission — threat model
 
-Status: **schema floor enforced at admission; the boundary is read back per attempt and
+Status: **schema/capability floors enforced at admission; the OS containment boundary is read back per attempt and
 DISCLOSED, never required.** Owner: `ouroboros/config.py` (the two floors),
 `ouroboros/subagents.route_health` (the admission decision),
 `ouroboros/gateways/claudexor.attempt_containment` (the applied-fact reader) and
@@ -23,6 +23,26 @@ operator's own home, at an absolute path a scoped `HOME` does not redirect. Ouro
 daemon (D30) is the exception: it is spawned under `CLAUDEXOR_CONFIG_DIR`, and that override IS
 the complete relocatable root — its token lives under `data/claudexor/`, not in the operator's
 home. Either way the token is an absolute path the child does not have to guess.
+
+## 2a. Stable project identity and private execution workspace
+
+Fresh mutating delegated starts on an engine satisfying the workspace-root release
+contract register and retain the actual target project in `scope.root`. The host copies
+that target into a private snapshot and sends the snapshot as `execution.workspaceRoot`,
+so the engine's project identity and the child's writable filesystem are separate facts.
+The pinned 3.8.0 engine and older engines keep the legacy shape, with the private
+snapshot itself in `scope.root`; they do not receive the new field. A retry always
+replays its recorded request byte-for-byte. An already accepted idempotency key may
+therefore replay across an engine upgrade; an unknown legacy pending start that the
+future schema rejects remains pending with a typed compatibility reason, while a
+future-shaped pending body is held back from an old engine. Read-only starts keep the legacy
+`mode: ask` envelope and send no `execution.workspaceRoot`.
+
+This shape depends on a Claudexor schema that accepts `workspaceRoot`. Ouroboros uses the
+explicit release contract `CLAUDEXOR_DELEGATED_WORKSPACE_ROOT_MIN_VERSION = 3.8.1`, the
+next compatible semver release carrying Claudexor PR216 after the currently pinned 3.8.0.
+Older engines keep the legacy snapshot-in-`scope.root` shape and retire their one-shot
+registration; a future engine at or above the contract gets the stable-target shape.
 
 ## 2. The actor
 

--- a/ouroboros/agent.py
+++ b/ouroboros/agent.py
@@ -973,6 +973,7 @@ class OuroborosAgent:
         if _exec_note:
             messages.append({"role": "user", "content": _exec_note})
         subagent_bootstrap.append_startup_receipt(ctx, messages, startup_wake)
+        startup_refusal = subagent_bootstrap.startup_refusal_outcome(startup_wake)
         # The nanny postcondition's input fact for the loop's finalization seam:
         # THIS task was dispatched onto the delegated substrate. ALL economics
         # marks reset together per dispatch (F4) — defensive, since the
@@ -1000,6 +1001,13 @@ class OuroborosAgent:
 
         cap_info["budget_remaining"] = budget_remaining
         cap_info["budget_accounting_status"] = budget_accounting_status
+        if startup_refusal is not None:
+            # A definite configured-session refusal is terminal before the loop
+            # gets a chance to spend a native/API round.  Keep ambiguous startup
+            # receipts (pending, uncustodied, recovery) on the normal wake rail.
+            subagent_bootstrap.apply_startup_refusal_projection(
+                task, cap_info, startup_refusal,
+            )
         # An explicit executor pin that no route can honor ends the task UNRUN: the
         # caller reads this instead of the loop (D28 — the pin exists to keep the work
         # off metered API tokens, so re-routing it to paid native execution spends the
@@ -1111,14 +1119,14 @@ class OuroborosAgent:
             task_type_str = str(task.get("type") or "").lower()
             initial_effort = _initial_effort_for(task, task_type_str)
 
-            # The owner's first phase-6 UI directive: the LEDE must show that THIS
-            # bubble / subagent runs on codex (a chip, not a badge). The fact is
-            # recorded onto the live task metadata that `_subagent_progress_meta`
-            # already projects — read from the ONE record the dispatch resolution
-            # stamped onto the task, never re-derived per surface.
             self._record_executor_facts(task)
 
-            if str(cap_info.get("executor_blocked_reason") or ""):
+            startup_refusal = cap_info.get("configured_startup_refusal")
+            if isinstance(startup_refusal, dict):
+                text = str(startup_refusal.get("text") or "")
+                usage = dict(startup_refusal.get("usage") or {})
+                llm_trace = dict(startup_refusal.get("llm_trace") or {})
+            elif str(cap_info.get("executor_blocked_reason") or ""):
                 text, usage, llm_trace = _blocked_executor_terminal(cap_info, task)
             elif task_type_str == "deep_self_review":
                 # Deep self-review bypasses the tool loop.

--- a/ouroboros/claudexor_daemon.py
+++ b/ouroboros/claudexor_daemon.py
@@ -459,14 +459,17 @@ class OwnedClaudexorDaemon:
             _write_ownership_marker()
             deadline = time.monotonic() + _SPAWN_WAIT_SEC
             while time.monotonic() < deadline:
-                if self._proc.poll() is not None:
-                    break
                 # RECONCILE: fresh discovery + AUTHENTICATED handshake against
                 # the descriptor the new daemon just wrote — the same identity
                 # proof attach uses, so a restart never claims a port it does
-                # not hold.
+                # not hold.  A spawned loser may exit before the winner has
+                # published its descriptor; keep polling through the existing
+                # deadline instead of treating that observation as proof that
+                # no authenticated winner can still appear.
                 endpoint = self._alive_endpoint()
                 if endpoint is not None:
+                    if self._proc.poll() is not None:
+                        self._proc = None
                     self._last_error = ""
                     return endpoint
                 time.sleep(_SPAWN_POLL_SEC)

--- a/ouroboros/config.py
+++ b/ouroboros/config.py
@@ -355,10 +355,9 @@ CLAUDEXOR_MIN_VERSION: str = "3.2.0"
 # declares the same number on a host where it applies nothing — and a version describes a
 # BUILD, never what THIS attempt did. That question goes to the attempt record
 # (`gateways.claudexor.attempt_containment`), and a run reporting no mechanism is DISCLOSED,
-# not refused: the child already holds a shell here, so the step to "shell plus token" does
-# not buy a lane-wide refusal (AGENTS.md "Disclose instead of forbid"). Two gates, two
-# questions, no overlap; bands: docs/DELEGATED_ADMISSION.md.
+# Not refused: "shell plus token" buys no lane-wide refusal; see docs/DELEGATED_ADMISSION.md.
 CLAUDEXOR_DELEGATED_MARKER_MIN_VERSION: str = "3.3.0"
+CLAUDEXOR_DELEGATED_WORKSPACE_ROOT_MIN_VERSION: str = "3.8.1"  # PR216 field; next patch after pinned 3.8.0.
 
 
 def _main_model() -> str:

--- a/ouroboros/delegate_custody.py
+++ b/ouroboros/delegate_custody.py
@@ -115,6 +115,8 @@ class RunCustody:
     profile_id: str = ""
     project_id: str = ""
     project_owned: bool = False
+    # Stable target registration persists; absent on legacy one-shot rows.
+    project_persistent: bool = False
     root_task_id: str = ""
     parent_task_id: str = ""
     ledger_root: str = ""
@@ -324,6 +326,7 @@ def _merge_started_into(entry: RunCustody, previous: RunCustody) -> None:
     for attr in _STARTED_PROGRESS_FLAGS:
         setattr(entry, attr, getattr(previous, attr))
     entry.project_owned = previous.project_owned and entry.project_owned
+    entry.project_persistent = previous.project_persistent or entry.project_persistent
     for attr in _STARTED_FIRST_WINS_FACTS:
         prior = getattr(previous, attr)
         if prior:
@@ -344,6 +347,7 @@ def _apply(state: Dict[str, RunCustody], row: Dict[str, Any]) -> None:
         entry = RunCustody(
             run_id=run_id,
             project_owned=bool(row.get("project_owned")),
+            project_persistent=bool(row.get("project_persistent")),
             delegated=row.get("delegated") is True,
             resource_ref=dict(ref) if isinstance(ref, dict) else {},
             **{attr: str(row.get(key) or "") for attr, key in _STARTED_STR_FIELDS},
@@ -628,6 +632,7 @@ def invocation_record(drive_root: Any, invocation_id: str) -> Optional[Dict[str,
                 "route": str(row.get("route") or ""),
                 "project_id": str(row.get("project_id") or ""),
                 "project_owned": bool(row.get("project_owned")),
+                "project_persistent": bool(row.get("project_persistent")),
                 "idempotency_key": str(row.get("idempotency_key") or ""),
                 # The C1 isolation binding: a retry reproduces EXACTLY these — the
                 # snapshot, the execution root, the baseline and the authority
@@ -673,8 +678,6 @@ def record_started(drive_root: Any, custody: RunCustody,
     The memo update goes through the SAME first-wins merge the replay uses (gate
     fix 8): a duplicate start must not diverge the in-process view from replay.
     """
-    # Fold the row-only shape onto the object first (the row spreads it last),
-    # so the memo and a replay of this same row start from identical facts.
     for attr in ("access", "mode", "isolation"):
         if shape and attr in shape:
             setattr(custody, attr, str(shape.get(attr) or ""))
@@ -684,11 +687,9 @@ def record_started(drive_root: Any, custody: RunCustody,
     if previous is not None and previous is not custody:
         _merge_started_into(custody, previous)
     _CUSTODY[custody.run_id] = custody
-    # The C1 binding and the resource reference ride the SAME row (a binding
-    # recorded separately can lose half of itself to a crash); shape spreads LAST.
     return emit(drive_root, STARTED, {
         "run_id": custody.run_id,
-        "project_owned": custody.project_owned,
+        "project_owned": custody.project_owned, "project_persistent": custody.project_persistent,
         "resource_ref": custody.resource_ref or {},
         **{key: getattr(custody, attr) for attr, key in _STARTED_STR_FIELDS},
         **(shape or {}),
@@ -810,6 +811,10 @@ def retire_project(drive_root: Any, gateway: Any, custody: RunCustody) -> None:
     attempts, so mutual deferral cannot deadlock, and once the canonical sharer
     removes the project the others discharge on the daemon's 404.
     """
+    if custody.project_persistent:
+        # Stable target identity outlives an individual run.
+        custody.project_owned = False
+        return
     if not (custody.project_owned and custody.project_id):
         return
     try:
@@ -886,7 +891,9 @@ def settle_run(drive_root: Any, gateway: Any, custody: RunCustody, detail: Dict[
     call returned.
     """
     if custody.settled:
-        return {"settled": True, "ledger_recorded": True, "project_retired": True, "retried": False}
+        return {"settled": True, "ledger_recorded": True,
+                "project_retired": not custody.project_persistent, "project_persistent": custody.project_persistent,
+                "retried": False}
     summary = summary_of(detail)
     # Claudexor reports CASH in `spendUsd` and its EXACTNESS in `spendEstimated`. A
     # delegated run is only free when the amount is really zero AND really settled: an
@@ -973,7 +980,8 @@ def settle_run(drive_root: Any, gateway: Any, custody: RunCustody, detail: Dict[
     return {
         "settled": custody.settled,
         "ledger_recorded": custody.ledger_recorded,
-        "project_retired": not custody.project_owned,
+        "project_retired": not custody.project_owned and not custody.project_persistent,
+        "project_persistent": custody.project_persistent,
         "retried": True,
     }
 
@@ -1352,19 +1360,31 @@ def _recover_pending_invocation(drive_root: Any, gateway: Any,
                                 record: Dict[str, Any]) -> Dict[str, Any]:
     """Recover the run (if any) behind an orphaned pending invocation, idempotently.
 
-    The stored canonical body is re-POSTed under the invocation's own wire key:
-    the engine returns the ORIGINAL handle when the first POST was accepted, and
-    starts fresh only when the daemon truly never saw it. A definite 4xx retires
-    the invocation and its registration; an unknown outcome stays pending.
+    Re-POST the stored body under its own key. Accepted keys replay; unknown
+    outcomes stay pending, while definite 4xx responses retire the invocation.
     """
+    from ouroboros.delegate_shared import (
+        is_legacy_workspace_root_request, workspace_root_recovery_block,
+    )
     from ouroboros.gateways.claudexor import ClaudexorUnavailable
 
     invocation_id = str(record["invocation_id"])
     task_id = str(record["task_id"])
+    if blocked := workspace_root_recovery_block(gateway, record):
+        emit(drive_root, RECONCILED, blocked)
+        return blocked
     try:
         handle = gateway.start_run(dict(record["request"]), idempotency_key=invocation_id)
     except ClaudexorUnavailable as exc:
         status = int(getattr(exc, "status_code", 0) or 0)
+        if (is_legacy_workspace_root_request(record.get("request"))
+                and exc.code == "execution_workspace_required"):
+            result = {"invocation_id": invocation_id, "task_id": task_id,
+                      "action": "recovery_blocked",
+                      "reason": "legacy_workspace_root_requires_compatible_retry",
+                      "engine_version": str(getattr(gateway, "engine_version", "") or "")}
+            emit(drive_root, RECONCILED, result)
+            return result
         if 400 <= status < 500:
             retired = _retire_recovered_registration(gateway, record)
             emit(drive_root, START_FAILED, {
@@ -1381,8 +1401,7 @@ def _recover_pending_invocation(drive_root: Any, gateway: Any,
         return result
     run_id = str(handle.get("runId") or handle.get("jobId") or "")
     if not run_id:
-        # Queued without an id: durably enqueued, still unnameable. Leave the
-        # invocation pending; the next sweep replays the same key and tries again.
+        # Leave a queued-without-id invocation pending for the next sweep.
         result = {"invocation_id": invocation_id, "task_id": task_id,
                   "action": "recovery_pending"}
         emit(drive_root, RECONCILED, result)
@@ -1396,6 +1415,7 @@ def _recover_pending_invocation(drive_root: Any, gateway: Any,
         model=str(body.get("model") or ""),
         profile_id=str(body.get("credentialProfileId") or ""),
         project_id=record["project_id"], project_owned=bool(record["project_owned"]),
+        project_persistent=bool(record.get("project_persistent")),
         root_task_id=str(record.get("root_task_id") or ""),
         parent_task_id=str(record.get("parent_task_id") or ""),
         # The sweep runs against the canonical root; a recovered run's ledger row
@@ -1406,11 +1426,7 @@ def _recover_pending_invocation(drive_root: Any, gateway: Any,
         config_fingerprint=str(record.get("config_fingerprint") or ""),
         work_order_fingerprint=str(record.get("work_order_fingerprint") or ""),
         authority_fingerprint=str(record.get("authority_fingerprint") or ""),
-        # The C1 isolation binding survives recovery VERBATIM: the recovered run
-        # executes in the snapshot the original attempt provisioned (the replayed
-        # body's scope.root), so its STARTED row must name that binding or the
-        # snapshot — and the child's work in it — becomes GC food the moment the
-        # invocation stops being pending.
+        # Recovery preserves the original snapshot/workspace binding verbatim.
         snapshot_id=str(record.get("snapshot_id") or ""),
         execution_root=str(record.get("execution_root") or ""),
         baseline_sha=str(record.get("baseline_sha") or ""),
@@ -1418,15 +1434,12 @@ def _recover_pending_invocation(drive_root: Any, gateway: Any,
         authority_source=str(record.get("authority_source") or ""),
         # Carried opaquely VERBATIM — recovery never re-authorizes a target (R1-2).
         resource_ref=record.get("resource_ref") if isinstance(record.get("resource_ref"), dict) else {},
-        # The GRANTED shape on the recovered OBJECT too, not only the row (gate
-        # fix 8c): the memo must answer the same lookups the replay does.
+        # Keep the granted shape on the recovered object as well as the row.
         access=str(body.get("access") or ""),
         mode=str(body.get("mode") or ""),
         isolation=str(execution.get("isolation") or ""),
         delegated=bool(execution.get("delegated")))
     record_started(drive_root, custody, shape={
-        # The stored invocation is the single source of a replay's facts — the same
-        # doctrine the explicit retry path follows.
         "effort": str(body.get("effort") or ""), "access": str(body.get("access") or ""),
         "mode": str(body.get("mode") or ""), "isolation": str(execution.get("isolation") or ""),
         "delegated": bool(execution.get("delegated")), "root": str(scope.get("root") or ""),
@@ -1437,7 +1450,7 @@ def _recover_pending_invocation(drive_root: Any, gateway: Any,
 
 def _retire_recovered_registration(gateway: Any, record: Dict[str, Any]) -> bool:
     """Discharge the registration an ORIGINAL attempt owned, when its invocation dies."""
-    if not (record.get("project_owned") and record.get("project_id")):
+    if record.get("project_persistent") or not (record.get("project_owned") and record.get("project_id")):
         return False
     try:
         gateway.remove_project(record["project_id"])

--- a/ouroboros/delegate_pending.py
+++ b/ouroboros/delegate_pending.py
@@ -28,6 +28,7 @@ def pending_invocations(
                 "route": str(row.get("route") or ""),
                 "project_id": str(row.get("project_id") or ""),
                 "project_owned": bool(row.get("project_owned")),
+                "project_persistent": bool(row.get("project_persistent")),
                 "idempotency_key": str(row.get("idempotency_key") or ""),
                 "root_task_id": str(row.get("root_task_id") or ""),
                 "parent_task_id": str(row.get("parent_task_id") or ""),

--- a/ouroboros/delegate_shared.py
+++ b/ouroboros/delegate_shared.py
@@ -27,6 +27,44 @@ def _fail(tool: str, code: str, detail: str, **extra: Any) -> str:
     return json.dumps(payload, ensure_ascii=False, indent=2)
 
 
+def engine_supports_workspace_root(gateway: Any) -> bool:
+    from ouroboros.config import CLAUDEXOR_DELEGATED_WORKSPACE_ROOT_MIN_VERSION
+    from ouroboros.gateways.claudexor import engine_at_least
+
+    return engine_at_least(
+        str(getattr(gateway, "engine_version", "") or ""),
+        CLAUDEXOR_DELEGATED_WORKSPACE_ROOT_MIN_VERSION,
+    )
+
+
+def is_legacy_workspace_root_request(request: Any) -> bool:
+    execution = request.get("execution") if isinstance(request, dict) else None
+    return bool(
+        isinstance(execution, dict)
+        and request.get("mode", "agent") == "agent"
+        and request.get("access") != "readonly"
+        and execution.get("delegated") is True
+        and execution.get("isolation") == "live"
+        and "workspaceRoot" not in execution
+    )
+
+
+def workspace_root_recovery_block(gateway: Any, record: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    request = record.get("request") if isinstance(record, dict) else None
+    execution = request.get("execution") if isinstance(request, dict) else None
+    if not isinstance(execution, dict) or "workspaceRoot" not in execution:
+        return None
+    if engine_supports_workspace_root(gateway):
+        return None
+    return {
+        "invocation_id": str(record.get("invocation_id") or ""),
+        "task_id": str(record.get("task_id") or ""),
+        "action": "recovery_blocked",
+        "reason": "engine_rejects_delegated_workspace_root",
+        "engine_version": str(getattr(gateway, "engine_version", "") or ""),
+    }
+
+
 def _emit(ctx: ToolContext, kind: str, payload: Dict[str, Any]) -> None:
     custody.emit(custody.custody_root(ctx), kind, {
         "task_id": str(getattr(ctx, "task_id", "") or ""), **payload,
@@ -57,4 +95,7 @@ def _owned_run(ctx: ToolContext, tool: str, run_id: str) -> Tuple[Optional[str],
     return None, entry
 
 
-__all__ = ["_emit", "_fail", "_owned_run"]
+__all__ = [
+    "_emit", "_fail", "_owned_run", "engine_supports_workspace_root",
+    "is_legacy_workspace_root_request", "workspace_root_recovery_block",
+]

--- a/ouroboros/delegate_start_binding.py
+++ b/ouroboros/delegate_start_binding.py
@@ -1,0 +1,133 @@
+"""Fresh delegated-start binding and wire construction.
+
+The facade keeps the nanny verbs small; this seam owns the one-time operation that
+turns a host authority target into a snapshot, project registration, idempotency key,
+and canonical run-start body. Retries never call it: they replay their stored body.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, NamedTuple, Optional
+
+from ouroboros import delegate_custody as custody
+
+
+class FreshStartBinding(NamedTuple):
+    request_body: Dict[str, Any]
+    root: str
+    execution_root: str
+    invocation_id: str
+    key: str
+    project_id: str
+    owned_project_id: str
+    project_persistent: bool
+    seconds: int
+    snapshot_id: str
+    target_root: str
+    baseline_sha: str
+    authority_source: str
+    resource_ref: Dict[str, Any]
+
+
+def start_request(ctx: Any, route: Any, authority: Any, root: str, text: str,
+                  seconds: int, instructions: str, *, execution_root: str = "") -> Dict[str, Any]:
+    """Build one canonical POST body from the already-derived run shape."""
+    request: Dict[str, Any] = {
+        "prompt": text,
+        "instructions": instructions,
+        "authPreference": "subscription",
+        "mode": authority.mode,
+        "scope": {"kind": "project", "root": root},
+        "harnesses": [route.route_id],
+        "primaryHarness": route.route_id,
+        "access": authority.access,
+    }
+    if authority.isolation:
+        request["execution"] = {
+            "isolation": authority.isolation,
+            "delegated": authority.delegated,
+        }
+        if execution_root:
+            request["execution"]["workspaceRoot"] = execution_root
+    if route.model:
+        request["model"] = route.model
+    if route.effort:
+        request["effort"] = route.effort
+    if route.profile_id:
+        request["credentialProfileId"] = route.profile_id
+    if seconds:
+        request["maxSeconds"] = seconds
+    return request
+
+
+def prepare_fresh_start(
+    ctx: Any, drive: Any, gateway: Any, route: Any, authority: Any, actor: Dict[str, Any],
+    text: str, max_seconds: Optional[int], payload_auth: Optional[Dict[str, Any]],
+    workspace_root_supported: bool, *,
+    host_instructions: Callable[..., str], assignment_instructions: Callable[..., str],
+    bounded_max_seconds: Callable[..., int],
+) -> tuple[Optional[FreshStartBinding], str]:
+    """Provision and describe a fresh mutating or read-only start."""
+    from ouroboros.tools import delegate_integration as integration
+
+    if payload_auth is not None:
+        record_auth = payload_auth
+    else:
+        record_auth, root_error = integration._mutation_authority(ctx, authority)
+        if root_error:
+            return None, root_error
+    invocation_id = custody.new_invocation_id()
+    root = str(record_auth["target_root"])
+    target_root = ""
+    authority_source = ""
+    snapshot_id = ""
+    execution_root = ""
+    baseline_sha = ""
+    resource_ref: Dict[str, Any] = {}
+    if authority.access == "workspace_write":
+        target_root = str(record_auth["target_root"])
+        authority_source = str(record_auth["source"])
+        if authority_source == "skill_payload":
+            snapshot, snap_error = integration._provision_payload_snapshot(
+                ctx, drive, record_auth, invocation_id)
+        else:
+            snapshot, snap_error = integration._provision_snapshot(
+                ctx, drive, target_root, invocation_id)
+        if snap_error:
+            return None, snap_error
+        snapshot_id, baseline_sha, execution_root = (
+            snapshot.snapshot_id, snapshot.baseline_sha, snapshot.path)
+        if not workspace_root_supported:
+            root = execution_root
+        resource_ref = dict(record_auth.get("resource_ref") or {})
+    existing_project = gateway.find_project_id(root)
+    project_id = existing_project or gateway.register_project(root)
+    owned_project_id = "" if existing_project else project_id
+    project_persistent = bool(workspace_root_supported and authority.access == "workspace_write")
+    assignment = ("" if bool(actor.get("compiled_work_order"))
+                  else assignment_instructions(ctx))
+    # The caller supplies the ordinary assignment builder to keep this seam independent
+    # of the facade's prompt constants; payload runs still receive their resource name.
+    instructions = host_instructions(
+        authority, assignment,
+        payload_skill=(str((record_auth.get("resource_ref") or {}).get("skill_name") or "")
+                       if payload_auth is not None else ""),
+    )
+    seconds = bounded_max_seconds(ctx, max_seconds)
+    key = custody.idempotency_key(
+        getattr(ctx, "task_id", ""), route.route_id, authority.access,
+        authority.mode, authority.isolation, root,
+        execution_root if workspace_root_supported else "", text, instructions,
+    )
+    request_body = start_request(
+        ctx, route, authority, root, text, seconds, instructions,
+        execution_root=(execution_root if workspace_root_supported else ""),
+    )
+    return FreshStartBinding(
+        request_body, root, execution_root, invocation_id, key, project_id,
+        owned_project_id, project_persistent, seconds, snapshot_id, target_root,
+        baseline_sha, authority_source, resource_ref,
+    ), ""
+
+
+__all__ = ["FreshStartBinding", "prepare_fresh_start", "start_request"]

--- a/ouroboros/subagent_bootstrap.py
+++ b/ouroboros/subagent_bootstrap.py
@@ -8,6 +8,92 @@ from typing import Any, Mapping
 from ouroboros.subagent_work_order import WorkOrderBudgetExceeded, compile_external_work_order
 
 
+def startup_refusal_outcome(startup_wake: str) -> dict[str, Any] | None:
+    """Return a terminal outcome for a definite configured-session no-start.
+
+    A configured session is an exact user choice.  A typed refusal from the
+    route preflight or the exact start request therefore cannot fall through to
+    a native/API model round.  Other startup receipts remain deliberately
+    ambiguous: an unparseable response, an uncustodied start, or a recovery
+    wake may still describe a run that needs custody recovery.
+    """
+    if not startup_wake:
+        return None
+    try:
+        receipt = json.loads(startup_wake)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(receipt, dict):
+        return None
+    if str(receipt.get("status") or "") != "configured_session_start_wake":
+        return None
+    startup = receipt.get("startup")
+    if not isinstance(startup, dict):
+        return None
+    startup_status = str(startup.get("status") or "").strip().lower()
+    if startup_status not in {"temporarily_unavailable", "refused"}:
+        return None
+    # A refusal carrying any daemon/custody handle is not a definite no-start:
+    # the POST may have queued or bound a run while returning a typed negative
+    # envelope. Preserve that wake for recovery rather than terminalizing over
+    # an invocation the host may still need to wait/cancel.
+    custody_keys = (
+        "pending_invocation_id", "pending_invocation_ids", "invocation_id",
+        "run_id", "job_id", "queued_handle", "handle", "run_dir",
+    )
+    if any(startup.get(key) for key in custody_keys):
+        return None
+    reason = str(startup.get("reason") or "configured_session_start_refused").strip()
+    selected = str(startup.get("selected_subagent_id") or "").strip()
+    reset_at = str(startup.get("reset_at") or "").strip()
+    alternatives = startup.get("alternatives") if isinstance(startup.get("alternatives"), list) else []
+    if startup_status == "temporarily_unavailable":
+        reason_code = "subagent_executor_unavailable"
+        headline = "SUBAGENT_UNAVAILABLE"
+    else:
+        reason_code = "configured_subagent_start_refused"
+        headline = "SUBAGENT_START_REFUSED"
+    text = (
+        f"⚠️ {headline}: the selected configured session"
+        + (f" ({selected})" if selected else "")
+        + f" could not start ({reason}). The task was NOT run: no LLM, tool, "
+        "or native/API fallback was executed."
+        + (f" Route reset: {reset_at}." if reset_at else "")
+        + (f" Explicit alternatives: {json.dumps(alternatives, ensure_ascii=False, sort_keys=True)}."
+           if alternatives else "")
+    )
+    usage = {
+        "execution_status": "infra_failed",
+        "reason_code": reason_code,
+        "unavailable_reason": reason,
+        "reset_at": reset_at,
+        "alternatives": alternatives,
+        "startup_status": startup_status,
+        "host_fallback": False,
+    }
+    return {
+        "text": text,
+        "usage": usage,
+        "llm_trace": {"reasoning_notes": ["configured_session_start_refused"], "tool_calls": []},
+    }
+
+
+def apply_startup_refusal_projection(
+    task: dict[str, Any], cap_info: dict[str, Any], refusal: dict[str, Any],
+) -> None:
+    cap_info["configured_startup_refusal"] = refusal
+    usage = dict(refusal.get("usage") or {})
+    availability = dict(task.get("subagent_availability") or {})
+    availability.update({
+        "status": usage.get("startup_status", "refused"),
+        "reason": usage.get("unavailable_reason", ""),
+        "reset_at": usage.get("reset_at", ""),
+        "alternatives": usage.get("alternatives", []),
+        "host_fallback": False,
+    })
+    task["subagent_availability"] = availability
+
+
 def bootstrap_before_context(ctx: Any, task: Mapping[str, Any], dispatch: Any) -> str:
     """Mark exact routing and atomically bootstrap before context/model work."""
 
@@ -166,4 +252,7 @@ def bootstrap_session_leaf(ctx: Any, task: Mapping[str, Any], dispatch: Any) -> 
     }, ensure_ascii=False, indent=2)
 
 
-__all__ = ["append_startup_receipt", "bootstrap_before_context", "bootstrap_session_leaf"]
+__all__ = [
+    "append_startup_receipt", "apply_startup_refusal_projection",
+    "bootstrap_before_context", "bootstrap_session_leaf", "startup_refusal_outcome",
+]

--- a/ouroboros/subagent_work_order.py
+++ b/ouroboros/subagent_work_order.py
@@ -28,6 +28,15 @@ def _text(value: Any) -> str:
     return str(value or "").strip()
 
 
+def _delegation_budget_text(value: Any) -> str:
+    """Render the normalized delegation authority without losing its intent note."""
+    if not isinstance(value, Mapping):
+        return ""
+    # Keep this a complete structured block: the child must receive the same
+    # typed authority that schedule_subagent persisted, not a lossy paraphrase.
+    return json.dumps(dict(value), ensure_ascii=False, sort_keys=True)
+
+
 def assignment_instructions(ctx: Any) -> str:
     """Host-authored immutable objective/output block for every delegate start."""
 
@@ -57,6 +66,7 @@ def _render_external_work_order(task: Mapping[str, Any]) -> str:
         ("EXPECTED OUTPUT", task.get("expected_output") or contract.get("expected_output")),
         ("CONSTRAINTS / NON-GOALS", task.get("constraints") or contract.get("constraints")),
         ("ACCEPTANCE CLAIMS", contract.get("acceptance_claims")),
+        ("DELEGATION BUDGET / INTENT", _delegation_budget_text(contract.get("delegation_budget"))),
     ]
     authority = {
         "task_id": str(task.get("id") or ""),

--- a/ouroboros/subagents.py
+++ b/ouroboros/subagents.py
@@ -128,12 +128,14 @@ class DelegatedRunShape:
 def delegated_run_shape(acting: bool) -> DelegatedRunShape:
     """The run shape for an acting (mutating) child, or for a read-only one.
 
-    A MUTATING child runs ``live``: Claudexor edits the nanny's OWN worktree in place,
-    so the nanny's existing workspace-patch capture sees the harness's edits with no
-    new plumbing, and the same capture invalidates itself if the harness dared to
-    commit. In place is also the ONE shape where Claudexor would otherwise hand the
-    harness the operator's real ``$HOME`` — which holds the daemon control token — so
-    ``delegated`` travels with it, inseparably, in the same record.
+    A MUTATING child asks for ``live``: on the future workspace-root contract Claudexor
+    edits the private execution snapshot while the stable target remains the project
+    identity; the pinned legacy engine receives that snapshot as ``scope.root``. The
+    nanny's existing workspace-patch capture still sees the snapshot's edits, and the
+    same capture invalidates itself if the harness dared to commit. In place is also the
+    ONE shape where Claudexor would otherwise hand the harness the operator's real
+    ``$HOME`` — which holds the daemon control token — so ``delegated`` travels with it,
+    inseparably, in the same record.
 
     A READ-ONLY child has nothing to write back, so it runs in Claudexor's default
     envelope, which is scoped already and needs no marker: that is one transport with
@@ -387,7 +389,7 @@ def resolve_subagent_executor(
 
 def route_health(
     gateway: Any, route_id: str, shape: DelegatedRunShape, *, route_model: str = "",
-    pinned_profile: str = "",
+    pinned_profile: str = "", workspace_root_required: bool = False,
 ) -> tuple[str, str]:
     """Return ``(unavailable_reason, reset_at)`` for a route about to run ``shape``.
 
@@ -416,7 +418,10 @@ def route_health(
     refuse. Empty (automatic rotation) keeps the harness-wide judgement: WHICH
     profile an unpinned run lands on stays Claudexor's business.
     """
-    from ouroboros.config import CLAUDEXOR_DELEGATED_MARKER_MIN_VERSION
+    from ouroboros.config import (
+        CLAUDEXOR_DELEGATED_MARKER_MIN_VERSION,
+        CLAUDEXOR_DELEGATED_WORKSPACE_ROOT_MIN_VERSION,
+    )
     from ouroboros.gateways.claudexor import engine_at_least
 
     catalog = gateway.agent_capabilities()
@@ -464,6 +469,16 @@ def route_health(
         CLAUDEXOR_DELEGATED_MARKER_MIN_VERSION,
     ):
         return "engine_rejects_delegated_marker", ""
+    # A future Claudexor release accepts the private execution snapshot in the
+    # nested ``workspaceRoot`` field. A retry tells us explicitly whether its
+    # frozen body has that field; historical one-root bodies remain replayable
+    # byte-for-byte. This is a release contract for PR216, not a catalog probe.
+    requires_workspace = bool(workspace_root_required)
+    if requires_workspace:
+        if not engine_at_least(
+                str(getattr(gateway, "engine_version", "") or ""),
+                CLAUDEXOR_DELEGATED_WORKSPACE_ROOT_MIN_VERSION):
+            return "engine_rejects_delegated_workspace_root", ""
     exhausted, reset_at = _exhausted_window(gateway, route_id, route_model, pinned_profile)
     if exhausted and not reset_at:
         # Spent with no named healing instant: still spent. The old shape carried

--- a/ouroboros/tools/delegate.py
+++ b/ouroboros/tools/delegate.py
@@ -90,7 +90,14 @@ from ouroboros.delegate_interactions import (  # noqa: F401
 from ouroboros.delegate_shared import (  # noqa: F401
     _emit,
     _fail,
+    engine_supports_workspace_root,
+    is_legacy_workspace_root_request,
     _owned_run,
+)
+from ouroboros.delegate_start_binding import (  # noqa: F401
+    FreshStartBinding,
+    prepare_fresh_start,
+    start_request as _start_request,
 )
 # The C1 integration seam (mutation authority, execution snapshots, retry binding,
 # terminal patch capture) lives in its own module (size gate); re-exported here
@@ -586,73 +593,6 @@ def _delivered_terminal_payload(ctx: ToolContext, run_id: str, detail: Dict[str,
                             full_ok=full_ok, full_note=full_note)
 
 
-# -- tools --------------------------------------------------------------------
-
-
-def _start_request(ctx: ToolContext, route: Any, authority: "DelegatedRunShape",
-                   root: str, text: str, seconds: int, instructions: str) -> Dict[str, Any]:
-    """The POST body for one delegated run, built from the derived SHAPE.
-
-    Extracted so the caller stays inside the method-size gate, and so the body has ONE
-    author: the shape decides the mode and whether the delegated marker rides along,
-    and nothing here re-derives either.
-
-    ``seconds`` and ``instructions`` arrive PRE-BUILT rather than being derived here:
-    a transport retry of a pending invocation must present a byte-identical body for
-    the engine's replay match, and both the deadline-derived bound and the
-    contract-derived instructions can change between calls, so the caller decides
-    whether to recompute them or replay the recorded ones (the retry path never calls
-    this function at all — it replays the stored canonical body verbatim).
-    """
-    request: Dict[str, Any] = {
-        "prompt": text,
-        # Built from the SHAPE plus the task contract, so a mutating delegated
-        # child is told that its boundary is a request and not a fact — the same
-        # disclosure the durable record and the parent's result carry, in the one
-        # place the child can read — and the nanny's own objective rides along
-        # structurally (`_assignment_instructions`).
-        "instructions": instructions,
-        # The engine's default authPreference is `auto` = subscription-first WITH
-        # policy fallback to a paid API key. That fallback is invisible to us and
-        # would be settled at a confident $0.00 — the one shape the ledger must
-        # never produce. Ask for the substrate we are actually claiming.
-        "authPreference": "subscription",
-        # The run SHAPE comes from the derived authority, not from re-deriving it
-        # here: one predicate decides what this child may do, and the mode follows it.
-        "mode": authority.mode,
-        "scope": {"kind": "project", "root": root},
-        # PIN, not preference: `primaryHarness` only fronts the engine's
-        # auto-pool, which still holds every other doctor-OK harness — the run
-        # could fail over onto a route the owner never configured. The
-        # explicit one-element `harnesses` pool is the engine's pinning
-        # contract (its own MCP surface spells a forced route exactly this
-        # way): the child rides THIS route or the start refuses typed.
-        "harnesses": [route.route_id],
-        "primaryHarness": route.route_id,
-        "access": authority.access,
-    }
-    if authority.isolation:
-        # `delegated` rides WITH the isolation, from the same record, because they
-        # are the same decision: `live` is in-place, and in place is exactly where
-        # Claudexor would otherwise hand the harness the operator's real `$HOME`
-        # — daemon control token included. Sending one without the other is the
-        # containment hole, so neither is assembled separately.
-        request["execution"] = {
-            "isolation": authority.isolation,
-            "delegated": authority.delegated,
-        }
-    if route.model:
-        request["model"] = route.model
-    if route.effort:
-        request["effort"] = route.effort
-    if route.profile_id:
-        # Account pin (D-U5), reviewer-slot wire contract; strict (D-U6). In the stored canonical body, so a retry_of replay stays byte-identical, pin included.
-        request["credentialProfileId"] = route.profile_id
-    if seconds:
-        request["maxSeconds"] = seconds
-    return request
-
-
 def _delegate_start(ctx: ToolContext, prompt: str, max_seconds: Optional[int] = None,
                     retry_of: Optional[str] = None, root: Optional[str] = None,
                     bucket: Optional[str] = None, skill_name: Optional[str] = None, _resolved_binding: Any = None) -> str:
@@ -679,8 +619,10 @@ def _delegate_start(ctx: ToolContext, prompt: str, max_seconds: Optional[int] = 
 
     drive = custody.custody_root(ctx)
     owned_project_id = ""
+    project_persistent = False
     invocation_id = ""
     snapshot_id = ""
+    execution_root = ""
     baseline_sha = ""
     target_root = ""
     authority_source = ""
@@ -704,8 +646,9 @@ def _delegate_start(ctx: ToolContext, prompt: str, max_seconds: Optional[int] = 
         binding, refusal = _resolve_retry_invocation(ctx, drive, retry_token, text)
         if refusal:
             return refusal
-        (request_body, route, authority, root, key, project_id, owned_project_id,
-         seconds, snapshot_id, target_root, baseline_sha, authority_source,
+        (request_body, route, authority, root, execution_root, key, project_id,
+         owned_project_id, project_persistent, seconds, snapshot_id, target_root,
+         baseline_sha, authority_source,
          resource_ref) = binding
         invocation_id = retry_token
         payload_auth = None
@@ -730,10 +673,18 @@ def _delegate_start(ctx: ToolContext, prompt: str, max_seconds: Optional[int] = 
         return _fail("delegate_start", exc.code, str(exc), executor=resolution.executor)
 
     try:
+        workspace_root_supported = engine_supports_workspace_root(gateway)
         # Health checks the stored route/confinement shape on retries, never current
         # environment defaults; blockers stay typed instead of falling through to API spend.
+        retry_execution = (request_body.get("execution") if recovering
+                           and isinstance(request_body.get("execution"), dict) else {})
         unavailable, reset_at = route_health(
-            gateway, route.route_id, authority, route_model=route.model, pinned_profile=route.profile_id)
+            gateway, route.route_id, authority, route_model=route.model,
+            pinned_profile=route.profile_id,
+            workspace_root_required=(
+                ("workspaceRoot" in retry_execution)
+                if recovering else
+                (workspace_root_supported and authority.access == "workspace_write")))
         resolution = resolve_subagent_executor(
             "harness", route=route, unavailable_reason=unavailable, reset_at=reset_at,
         )
@@ -748,52 +699,19 @@ def _delegate_start(ctx: ToolContext, prompt: str, max_seconds: Optional[int] = 
             )
 
         if not recovering:
-            if payload_auth is not None:
-                record_auth = payload_auth
-            else:
-                record_auth, root_error = _mutation_authority(ctx, authority)
-                if root_error:
-                    return root_error
-            invocation_id = custody.new_invocation_id()
-            root = record_auth["target_root"]
-            if authority.access == "workspace_write":
-                # C1: the run executes in a PRIVATE snapshot of the authority target,
-                # never in the shared tree. Provisioned (and durably registered)
-                # BEFORE the start intent below; scope.root becomes the snapshot.
-                # A payload target gets the STANDALONE snapshot (the live payload
-                # is never initialized as Git); a Git target keeps the worktree
-                # snapshot byte-identically.
-                target_root = record_auth["target_root"]
-                authority_source = record_auth["source"]
-                if authority_source == "skill_payload":
-                    snapshot, snap_error = _provision_payload_snapshot(
-                        ctx, drive, record_auth, invocation_id)
-                else:
-                    snapshot, snap_error = _provision_snapshot(ctx, drive, target_root, invocation_id)
-                if snap_error:
-                    return snap_error
-                snapshot_id = snapshot.snapshot_id
-                baseline_sha = snapshot.baseline_sha
-                root = snapshot.path
-                resource_ref = dict(record_auth.get("resource_ref") or {})
-            existing_project = gateway.find_project_id(root)
-            project_id = existing_project or gateway.register_project(root)
-            owned_project_id = "" if existing_project else project_id
-            # The canonical ASSIGNMENT — prompt plus host-authored instructions —
-            # is digested together: two starts whose prompts agree but whose
-            # contract blocks differ are two different logical starts. The digest
-            # is the LOOKUP identity only; the wire key stays the invocation id,
-            # and a retry replays the STORED body byte-identically regardless.
-            instructions = _host_instructions(
-                authority, "" if bool(actor.get("compiled_work_order")) else _assignment_instructions(ctx),
-                payload_skill=(str((record_auth.get("resource_ref") or {})
-                                   .get("skill_name") or "")
-                               if payload_auth is not None else ""))
-            key = custody.idempotency_key(getattr(ctx, "task_id", ""), route.route_id, access,
-                                          authority.mode, authority.isolation, root, text,
-                                          instructions)
-            seconds = _bounded_max_seconds(ctx, max_seconds)
-            request_body = _start_request(ctx, route, authority, root, text, seconds, instructions)
+            binding, refusal = prepare_fresh_start(
+                ctx, drive, gateway, route, authority, actor, text, max_seconds,
+                payload_auth, workspace_root_supported,
+                host_instructions=_host_instructions,
+                assignment_instructions=_assignment_instructions,
+                bounded_max_seconds=_bounded_max_seconds,
+            )
+            if refusal:
+                return refusal
+            assert binding is not None
+            (request_body, root, execution_root, invocation_id, key, project_id,
+             owned_project_id, project_persistent, seconds, snapshot_id, target_root,
+             baseline_sha, authority_source, resource_ref) = binding
         lineage = getattr(ctx, "task_metadata", {}) or {}
         lineage = lineage if isinstance(lineage, dict) else {}
         # Fresh payload run: busy check + durable write = ONE atomic claim (fix 5).
@@ -803,7 +721,8 @@ def _delegate_start(ctx: ToolContext, prompt: str, max_seconds: Optional[int] = 
             run_id="", task_id=str(getattr(ctx, "task_id", "") or ""),
             idempotency_key=key, invocation_id=invocation_id,
             max_seconds=seconds, request=request_body, project_id=project_id,
-            project_owned=bool(owned_project_id), route=route.route_id,
+            project_owned=bool(owned_project_id), project_persistent=project_persistent,
+            route=route.route_id,
             # Lineage rides the request row so a run RECOVERED from a pending
             # invocation (P34R.2) can still attribute its ledger row to the tree.
             root_task_id=str(lineage.get("root_task_id") or ""),
@@ -811,7 +730,7 @@ def _delegate_start(ctx: ToolContext, prompt: str, max_seconds: Optional[int] = 
             # The C1 isolation binding, durable BEFORE the POST: these name the
             # snapshot, baseline and authority target so a retry reproduces the
             # exact binding and the startup GC can see the pending snapshot.
-            snapshot_id=snapshot_id, execution_root=(root if snapshot_id else ""),
+            snapshot_id=snapshot_id, execution_root=execution_root,
             baseline_sha=baseline_sha, target_root=target_root,
             authority_source=authority_source, resource_ref=resource_ref,
             # Same pre-POST row as the request: crash recovery can prove the
@@ -827,11 +746,13 @@ def _delegate_start(ctx: ToolContext, prompt: str, max_seconds: Optional[int] = 
                 "check and the start-request write are one atomic claim). Finish "
                 "that run before starting another delegation against the same "
                 "skill.", holder=claim_holder,
-                **_retire_orphaned_registration(ctx, gateway, owned_project_id,
-                                                definite_refusal=True,
-                                                reason="payload_delegation_busy",
-                                                invocation_id=invocation_id,
-                                                snapshot_id=snapshot_id))
+                **_retire_orphaned_registration(
+                    ctx, gateway, owned_project_id,
+                    project_persistent=project_persistent,
+                    definite_refusal=True,
+                    reason="payload_delegation_busy",
+                    invocation_id=invocation_id,
+                    snapshot_id=snapshot_id))
         if not requested:
             # The POST is CONDITIONAL on the durable request row: a run started
             # without it is live and unfindable if this worker dies. A fresh
@@ -843,15 +764,15 @@ def _delegate_start(ctx: ToolContext, prompt: str, max_seconds: Optional[int] = 
                 "The durable start-request row could not be written, so the run was "
                 "NOT started: a run launched without its custody trail would be "
                 "unfindable if this worker died. Fix the drive/event log and retry.",
-                **_retire_orphaned_registration(ctx, gateway, owned_project_id,
-                                                definite_refusal=not recovering,
-                                                reason="start_request_row_unwritable",
-                                                invocation_id=invocation_id,
-                                                snapshot_id=("" if recovering else snapshot_id)))
+                **_retire_orphaned_registration(
+                    ctx, gateway, owned_project_id,
+                    project_persistent=project_persistent,
+                    definite_refusal=not recovering,
+                    reason="start_request_row_unwritable",
+                    invocation_id=invocation_id,
+                    snapshot_id=("" if recovering else snapshot_id)))
         handle = gateway.start_run(request_body, idempotency_key=invocation_id)
-        # A 202 answers with `jobId` and no `runId` when the run has not bound a run
-        # dir inside the daemon's start timeout; `jobId` is a usable GET/control
-        # handle — discarding it left a live run nobody could wait on or cancel.
+        # A queued `jobId` is a usable GET/control handle.
         run_id = str(handle.get("runId") or handle.get("jobId") or "")
         if not run_id:
             # The POST SUCCEEDED, so a run is more likely live here than on the
@@ -863,6 +784,7 @@ def _delegate_start(ctx: ToolContext, prompt: str, max_seconds: Optional[int] = 
                                     "delegate_start(prompt=..., "
                                     "retry_of=pending_invocation_id); a plain call starts a NEW run",
                          **_retire_orphaned_registration(ctx, gateway, owned_project_id,
+                                                         project_persistent=project_persistent,
                                                          definite_refusal=False,
                                                          reason="queued_without_run_id",
                                                          invocation_id=invocation_id))
@@ -871,6 +793,19 @@ def _delegate_start(ctx: ToolContext, prompt: str, max_seconds: Optional[int] = 
         # It used to be left behind with nothing anywhere naming its id.
         status = int(getattr(exc, "status_code", 0) or 0)
         definite = 400 <= status < 500
+        if recovering and is_legacy_workspace_root_request(request_body) \
+                and exc.code == "execution_workspace_required":
+            return _fail(
+                "delegate_start", "legacy_workspace_root_requires_compatible_retry",
+                "This legacy mutating invocation was not accepted before the engine "
+                "started requiring execution.workspaceRoot. Its exact retry token is "
+                "preserved; drain it on the legacy engine or use the engine's "
+                "server-owned Exact Retry path before upgrading.",
+                pending_invocation_id=invocation_id,
+                retry_hint="retry this same invocation after the compatible engine is available",
+                engine_version=str(getattr(gateway, "engine_version", "") or ""),
+                project_id=project_id,
+            )
         # An UNKNOWN outcome hands back the retry token: only the caller can say
         # whether the next call is a retry of this intention or a new intention, and
         # without the token every next call is a new one. A definite refusal retires
@@ -883,6 +818,7 @@ def _delegate_start(ctx: ToolContext, prompt: str, max_seconds: Optional[int] = 
         return _fail("delegate_start", exc.code, str(exc), executor="blocked",
                      reset_at=getattr(exc, "reset_at", ""), **pending,
                      **_retire_orphaned_registration(ctx, gateway, owned_project_id,
+                                                     project_persistent=project_persistent,
                                                      definite_refusal=definite,
                                                      reason=str(getattr(exc, "code", "")),
                                                      invocation_id=invocation_id,
@@ -894,6 +830,7 @@ def _delegate_start(ctx: ToolContext, prompt: str, max_seconds: Optional[int] = 
         # may be live against it. Named with a typed reason so the sweep's
         # pending-invocation recovery finds it, then re-raised — disclosure, not a swallow.
         _retire_orphaned_registration(ctx, gateway, owned_project_id,
+                                      project_persistent=project_persistent,
                                       definite_refusal=False,
                                       reason=f"pre_custody_exit_{type(exc).__name__}",
                                       invocation_id=invocation_id)
@@ -913,6 +850,7 @@ def _delegate_start(ctx: ToolContext, prompt: str, max_seconds: Optional[int] = 
         profile_id=route.profile_id,  # requested account pin, beside the requested model it mirrors
         project_id=project_id,
         project_owned=bool(owned_project_id),
+        project_persistent=project_persistent,
         root_task_id=str(metadata.get("root_task_id") or ""),
         parent_task_id=str(metadata.get("parent_task_id") or ""),
         # The CANONICAL (budget) root, the same one the custody rows themselves live
@@ -927,7 +865,7 @@ def _delegate_start(ctx: ToolContext, prompt: str, max_seconds: Optional[int] = 
         work_order_fingerprint=work_order_fingerprint,
         authority_fingerprint=authority_fingerprint,
         snapshot_id=snapshot_id,
-        execution_root=(root if snapshot_id else ""),
+        execution_root=execution_root,
         baseline_sha=baseline_sha,
         target_root=target_root,
         authority_source=authority_source,
@@ -944,20 +882,22 @@ def _delegate_start(ctx: ToolContext, prompt: str, max_seconds: Optional[int] = 
         # `max_seconds` rides too: delegate_wait reports elapsed-vs-cap from this row.
         "effort": route.effort, "access": access, "mode": authority.mode,
         "isolation": authority.isolation, "delegated": authority.delegated, "root": root,
+        "execution_root": execution_root,
         "max_seconds": seconds,
         "capture_mode": (_CAPTURE_DELEGATED_SNAPSHOT if snapshot_id else ""),
     })
     return _started_payload(handle, run_id, route, access, authority, root,
                             durable=durable, recovering=recovering,
                             invocation_id=invocation_id,
-                            snapshot_id=snapshot_id, target_root=target_root,
+                            snapshot_id=snapshot_id, execution_root=execution_root,
+                            target_root=target_root,
                             baseline_sha=baseline_sha)
 
 
 def _started_payload(handle: Dict[str, Any], run_id: str, route: Any, access: str,
                      authority: "DelegatedRunShape", root: str, *, durable: bool,
-                     recovering: bool, invocation_id: str, snapshot_id: str, target_root: str,
-                     baseline_sha: str) -> str:
+                     recovering: bool, invocation_id: str, snapshot_id: str,
+                     execution_root: str, target_root: str, baseline_sha: str) -> str:
     """The one author of delegate_start's started result (note + payload).
 
     The AUTHORITY guidance and the CUSTODY warning are independent facts about the same
@@ -1009,10 +949,9 @@ def _started_payload(handle: Dict[str, Any], run_id: str, route: Any, access: st
     if not durable:
         payload["pending_invocation_id"] = str(invocation_id or "")
     if snapshot_id:
-        # The C1 binding, stated where the nanny can read it: the run's scope.root is
-        # the EXECUTION snapshot; the authority target receives nothing until the
-        # explicit apply.
-        payload["execution_root"] = root
+        # Stable project identity remains the public root; the private execution
+        # workspace is disclosed separately and receives no automatic apply.
+        payload["execution_root"] = execution_root
         payload["authority_target_root"] = target_root
         payload["baseline_id"] = baseline_sha
     return json.dumps(payload, ensure_ascii=False, indent=2)
@@ -1021,7 +960,8 @@ def _started_payload(handle: Dict[str, Any], run_id: str, route: Any, access: st
 def _retire_orphaned_registration(ctx: ToolContext, gateway: Any, project_id: str, *,
                                   definite_refusal: bool, reason: str,
                                   invocation_id: str = "",
-                                  snapshot_id: str = "") -> Dict[str, Any]:
+                                  snapshot_id: str = "",
+                                  project_persistent: bool = False) -> Dict[str, Any]:
     """Retire a registration this start created but never bound to a run.
 
     Only when the daemon gave a DEFINITE negative answer (a 4xx refusal): a transport
@@ -1050,7 +990,12 @@ def _retire_orphaned_registration(ctx: ToolContext, gateway: Any, project_id: st
             log.warning("Failed to retire delegated execution snapshot %s", snapshot_id,
                         exc_info=True)
     retired = False
-    if project_id and definite_refusal:
+    if project_persistent:
+        # Stable project registrations intentionally outlive this invocation,
+        # including a definite start refusal. The next attempt reuses the same
+        # scope.root registration and trust/history identity.
+        retired = False
+    elif project_id and definite_refusal:
         try:
             gateway.remove_project(project_id)
             retired = True

--- a/ouroboros/tools/delegate_integration.py
+++ b/ouroboros/tools/delegate_integration.py
@@ -221,9 +221,11 @@ class _RetryBinding(NamedTuple):
     route: Any          # DelegationRoute
     authority: Any      # DelegatedRunShape
     root: str
+    execution_root: str
     key: str
     project_id: str
     owned_project_id: str
+    project_persistent: bool
     seconds: int
     snapshot_id: str
     target_root: str
@@ -264,7 +266,14 @@ def _resolve_retry_invocation(ctx: ToolContext, drive: pathlib.Path, retry_token
                                   mode=str(request_body.get("mode") or ""),
                                   isolation=str(execution.get("isolation") or ""),
                                   delegated=bool(execution.get("delegated")))
+    # New-shape requests keep the stable project in scope.root and put the
+    # disposable snapshot in execution.workspaceRoot. Historical requests may
+    # have scoped the engine directly at the private snapshot; preserve those
+    # bytes on explicit retry rather than rewriting their body.
     root = str(scope.get("root") or "")
+    execution_root = str(execution.get("workspaceRoot") or "")
+    if not execution_root:
+        execution_root = str(record.get("execution_root") or "")
     project_id = str(record.get("project_id") or "")
     # The C1 isolation binding recorded at the original attempt. Pre-C1 rows
     # carry none; their scope.root IS the authority target (in-place regime).
@@ -321,9 +330,11 @@ def _resolve_retry_invocation(ctx: ToolContext, drive: pathlib.Path, retry_token
         route=route,
         authority=authority,
         root=root,
+        execution_root=execution_root,
         key=str(record.get("idempotency_key") or ""),
         project_id=project_id,
         owned_project_id=(project_id if record.get("project_owned") else ""),
+        project_persistent=bool(record.get("project_persistent")),
         seconds=int(request_body.get("maxSeconds") or 0),
         snapshot_id=snapshot_id,
         target_root=target_root,

--- a/tests/test_available_subagents_core_followup.py
+++ b/tests/test_available_subagents_core_followup.py
@@ -169,6 +169,97 @@ def test_uncredentialed_api_actor_stops_before_the_llm_loop(monkeypatch, tmp_pat
     assert any(event.get("type") == "task_done" for event in events)
 
 
+@pytest.mark.parametrize(
+    ("startup_status", "reason"),
+    [("refused", "work_order_budget_exceeded"), ("temporarily_unavailable", "subscription_window_exhausted")],
+)
+def test_definite_configured_session_no_start_terminalizes_before_llm(
+    monkeypatch, tmp_path, startup_status, reason,
+):
+    """A selected session refusal is not permission to do the assignment natively."""
+    from ouroboros import agent as agent_module
+    import ouroboros.claudexor_daemon as daemon
+    import ouroboros.subagent_bootstrap as bootstrap
+    import ouroboros.subagents as subagents
+    from ouroboros.agent import Env, OuroborosAgent
+
+    repo, drive = tmp_path / "repo", tmp_path / "drive"
+    repo.mkdir()
+    drive.mkdir()
+    monkeypatch.setattr(daemon, "ensure_owned_gateway", lambda: SimpleNamespace(close=lambda: None))
+    monkeypatch.setattr(subagents, "route_health", lambda *_a, **_k: ("", ""))
+    monkeypatch.setattr(OuroborosAgent, "_log_worker_boot_once", lambda self: None)
+    monkeypatch.setattr(agent_module, "build_llm_messages", lambda **_kwargs: ([], {}))
+    monkeypatch.setattr(
+        bootstrap,
+        "bootstrap_session_leaf",
+        lambda *_a, **_k: json.dumps({
+            "status": "configured_session_start_wake",
+            "startup": {"status": startup_status, "reason": reason},
+        }),
+    )
+    calls = []
+    monkeypatch.setattr(
+        agent_module,
+        "run_llm_loop",
+        lambda **kwargs: calls.append(kwargs) or ("unexpected", {}, {}),
+    )
+
+    snapshot = _snapshot(_settings(_session_row()), "session-builder")
+    agent = OuroborosAgent(Env(repo_dir=repo, drive_root=drive))
+    agent.tools.available_tools = lambda: ["delegate_start", "delegate_wait", "delegate_cancel"]
+    events = agent._handle_task_scoped({
+        "id": "session-child",
+        "type": "task",
+        "chat_id": 1,
+        "text": "Use the exact session actor",
+        "delegation_role": "subagent",
+        "configured_subagent": snapshot,
+        "parent_cognitive_route": {
+            "model": "openai/parent", "effort": "high", "use_local_model": False,
+        },
+        "task_constraint": {},
+        "task_contract": {"objective": "Build", "expected_output": "Patch"},
+        "drive_root": str(drive),
+        "budget_drive_root": str(drive),
+    })
+
+    assert calls == []
+    result = json.loads(
+        (drive / "task_results" / "session-child.json").read_text(encoding="utf-8")
+    )
+    assert result["outcome_axes"]["execution"]["status"] == "infra_failed"
+    assert result["subagent_availability"]["host_fallback"] is False
+    assert reason in result["result"]
+    assert any(event.get("type") == "task_done" for event in events)
+
+
+def test_startup_refusal_classifier_preserves_ambiguous_wakes():
+    from ouroboros.subagent_bootstrap import startup_refusal_outcome
+
+    def receipt(status, *, outer="configured_session_start_wake"):
+        return json.dumps({"status": outer, "startup": {"status": status, "reason": "x"}})
+
+    assert startup_refusal_outcome(receipt("refused"))["usage"]["reason_code"] == "configured_subagent_start_refused"
+    assert startup_refusal_outcome(receipt("temporarily_unavailable"))["usage"]["reason_code"] == "subagent_executor_unavailable"
+    assert startup_refusal_outcome(receipt("started_uncustodied")) is None
+    assert startup_refusal_outcome(receipt("pending")) is None
+    assert startup_refusal_outcome(receipt("refused", outer="configured_session_recovery_wake")) is None
+    for key, value in (
+        ("pending_invocation_id", "inv-1"),
+        ("run_id", "run-1"),
+        ("queued_handle", {"jobId": "job-1"}),
+    ):
+        payload = json.loads(receipt("refused"))
+        payload["startup"][key] = value
+        assert startup_refusal_outcome(json.dumps(payload)) is None
+
+    # A malformed exact-start response is also ambiguous: the host cannot prove
+    # that the POST did not reach the daemon, so it must not synthesize a clean
+    # terminal no-start.
+    assert startup_refusal_outcome("not-json") is None
+
+
 def test_context_build_exception_propagates_after_exact_leaf_bootstrap(monkeypatch, tmp_path):
     from ouroboros import agent as agent_module
     import ouroboros.claudexor_daemon as daemon

--- a/tests/test_claudexor_owned_daemon.py
+++ b/tests/test_claudexor_owned_daemon.py
@@ -2570,6 +2570,57 @@ def test_first_spawn_loser_attaches_to_the_winners_endpoint(monkeypatch, tmp_pat
     assert manager.stop() is False
 
 
+def test_spawn_loser_keeps_polling_for_delayed_winner_after_child_exit(monkeypatch, tmp_path):
+    """An exited first-spawn loser must not end the winner's publication window."""
+    from ouroboros import claudexor_runtime as runtime
+    from ouroboros.gateways.claudexor import DaemonEndpoint
+
+    data_dir = tmp_path / "data"
+    config_dir = data_dir / "claudexor"
+    _point_owned_home(monkeypatch, config_dir, data_dir)
+    monkeypatch.setattr(owned, "verify_owned_home", lambda: "")
+    monkeypatch.setattr(owned, "_SPAWN_WAIT_SEC", 0.15)
+    monkeypatch.setattr(owned, "_SPAWN_POLL_SEC", 0.01)
+
+    class ReadyRuntime:
+        def ensure(self):
+            return ["/fixture/node", "/fixture/claudexord.bundle.cjs"]
+
+        def status(self, *args, **kwargs):
+            return {"source": "download"}
+
+    monkeypatch.setattr(runtime, "get_runtime_manager", lambda: ReadyRuntime())
+
+    class ExitedLoser:
+        pid = 424244
+
+        def poll(self):
+            return 1
+
+        def terminate(self):
+            raise AssertionError("an exited loser must not be terminated")
+
+    child = ExitedLoser()
+    import ouroboros.process_custody as custody_mod
+
+    monkeypatch.setattr(custody_mod, "spawn_supervised", lambda *_args, **_kwargs: child)
+    endpoint = DaemonEndpoint(host="127.0.0.1", port=45682, token="winner-token")
+    polls = iter([None, None, endpoint])
+    seen = []
+
+    def delayed_alive_endpoint():
+        seen.append(True)
+        return next(polls, endpoint)
+
+    manager = owned.OwnedClaudexorDaemon()
+    monkeypatch.setattr(manager, "_classify_liveness", lambda: (None, "not_provisioned", ""))
+    monkeypatch.setattr(manager, "_alive_endpoint", delayed_alive_endpoint)
+
+    assert manager.ensure_running() is endpoint
+    assert len(seen) >= 3
+    assert manager._proc is None
+
+
 def test_dead_owned_daemon_is_restarted_and_reconciled(monkeypatch, tmp_path):
     """The stale case end-to-end: descriptor exists, daemon dead, ownership
     marker OURS -> ensure_running restarts under the same supervision

--- a/tests/test_delegation_budget.py
+++ b/tests/test_delegation_budget.py
@@ -52,6 +52,30 @@ def test_compose_subagent_text_surfaces_budget():
     assert "[DELEGATION BUDGET]" not in txt2
 
 
+def test_external_work_order_surfaces_delegation_budget_and_intent_note():
+    from ouroboros.subagent_work_order import compile_external_work_order
+
+    work_order = compile_external_work_order({
+        "id": "child",
+        "task_contract": {
+            "objective": "Build the whole game",
+            "delegation_budget": {
+                "may_delegate": True,
+                "may_mutate": True,
+                "may_fan_out": True,
+                "depth_remaining": 2,
+                "max_children": 4,
+                "intent_note": "delegate per subsystem and synthesize the results",
+            },
+        },
+    })
+
+    assert "DELEGATION BUDGET / INTENT" in work_order
+    assert '"depth_remaining": 2' in work_order
+    assert '"max_children": 4' in work_order
+    assert "delegate per subsystem and synthesize the results" in work_order
+
+
 def test_absorption_full_then_whole_pointer_and_grandchild_rollup():
     from ouroboros.task_status import format_subagent_absorption_message
     children = [

--- a/tests/test_delegation_workspace_root.py
+++ b/tests/test_delegation_workspace_root.py
@@ -1,0 +1,331 @@
+"""Workspace-root compatibility and stable project identity for delegated starts."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from ouroboros.config import CLAUDEXOR_DELEGATED_WORKSPACE_ROOT_MIN_VERSION
+
+
+@pytest.fixture(autouse=True)
+def _transport_fixture(monkeypatch):
+    from ouroboros import claudexor_daemon, delegate_custody, subagent_runtime, subagents
+    from ouroboros.gateways import claudexor as gateway_module
+    from ouroboros.tools import delegate
+
+    monkeypatch.setattr(
+        claudexor_daemon, "ensure_owned_gateway",
+        lambda: gateway_module.ClaudexorGateway(),
+    )
+    original_actor = delegate.prepare_delegate_start_actor
+
+    def explicit_actor(ctx, drive_root, **kwargs):
+        if kwargs.get("recovering"):
+            return original_actor(ctx, drive_root, **kwargs)
+        route = subagents.get_subagent_harness()
+        if route is None:
+            return original_actor(ctx, drive_root, **kwargs)
+        token = subagent_runtime._EXACT_START_SELECTION.set({
+            "snapshot": {
+                "schema": 1, "selected_subagent_id": "workspace-root-fixture",
+                "config_fingerprint": "workspace-root-fixture-v1",
+                "route": {"kind": "agent_session", "target_id": route.route_id},
+                "effort": route.effort,
+            },
+        })
+        try:
+            return original_actor(ctx, drive_root, **kwargs)
+        finally:
+            subagent_runtime._EXACT_START_SELECTION.reset(token)
+
+    delegate_custody._CUSTODY.clear()
+    monkeypatch.setattr(delegate, "prepare_delegate_start_actor", explicit_actor)
+    yield
+    delegate_custody._CUSTODY.clear()
+
+
+def _ctx(tmp_path, *, task_id="t-workspace-root"):
+    from ouroboros.contracts.task_constraint import TaskConstraint
+    from ouroboros.tools.registry import ToolContext
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    worktree = tmp_path.parent / f"wt-{tmp_path.name}"
+    worktree.mkdir()
+    subprocess.run(["git", "init"], cwd=worktree, capture_output=True, check=True)
+    (worktree / "README.md").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=worktree, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "seed"],
+        cwd=worktree, capture_output=True, check=True,
+    )
+    ctx = ToolContext(
+        repo_dir=repo, drive_root=tmp_path,
+        task_constraint=TaskConstraint(
+            mode="acting_subagent", surface="self_worktree", write_root=str(worktree),
+        ),
+    )
+    ctx.workspace_root = str(worktree)
+    ctx.workspace_mode = "self_worktree"
+    ctx.task_id = task_id
+    ctx.task_metadata = {"root_task_id": "t-root", "parent_task_id": "t-root"}
+    return ctx
+
+
+def _started_request(tmp_path, monkeypatch, *, engine_version):
+    import ouroboros.tools.delegate as delegate
+    from ouroboros.gateways import claudexor as gateway
+
+    seen = {}
+
+    class Stub:
+        def handshake(self, **_kwargs):
+            return {}
+
+        def agent_capabilities(self):
+            return {"harnesses": [{
+                "id": "some-route", "enabled": True, "status": "ok",
+                "accessProfilesSupported": ["readonly", "workspace_write"],
+            }]}
+
+        def quota_snapshots(self):
+            return []
+
+        def find_project_id(self, _root):
+            return "prj-existing"
+
+        def register_project(self, _root):
+            raise AssertionError("the fixture registration should be reused")
+
+        def start_run(self, request, *, idempotency_key=""):
+            seen["request"] = request
+            return {"runId": "run-write", "runDir": "/tmp/run-write"}
+
+        def close(self):
+            pass
+
+    Stub.engine_version = engine_version
+    monkeypatch.setenv("OUROBOROS_SUBAGENT_HARNESS", "some-route=weak-model:low")
+    monkeypatch.setenv("OUROBOROS_SUBAGENT_WORKTREE_ROOT", str(tmp_path / "snap_root"))
+    monkeypatch.setattr(gateway, "ClaudexorGateway", lambda *a, **k: Stub())
+    delegate._CUSTODY.clear()
+    payload = json.loads(delegate._delegate_start(_ctx(tmp_path), "edit the README"))
+    delegate._CUSTODY.clear()
+    assert payload["status"] == "started", payload
+    return seen["request"], payload
+
+
+def test_pinned_old_engine_keeps_legacy_snapshot_scope_shape(tmp_path, monkeypatch):
+    request, payload = _started_request(tmp_path, monkeypatch, engine_version="3.8.0")
+    target = str(tmp_path.parent / f"wt-{tmp_path.name}")
+    assert request["scope"]["root"] != target
+    assert "workspaceRoot" not in request["execution"]
+    assert payload["execution_root"] == request["scope"]["root"]
+
+
+def test_future_engine_uses_stable_target_and_private_execution_root(tmp_path, monkeypatch):
+    import ouroboros.delegate_custody as custody
+
+    request, payload = _started_request(
+        tmp_path, monkeypatch, engine_version=CLAUDEXOR_DELEGATED_WORKSPACE_ROOT_MIN_VERSION,
+    )
+    target = str(tmp_path.parent / f"wt-{tmp_path.name}")
+    assert request["scope"]["root"] == target
+    assert request["execution"]["workspaceRoot"] != target
+    assert custody.replay(tmp_path)["run-write"].project_persistent is True
+    assert payload["authority_target_root"] == target
+
+
+def test_stable_project_registration_survives_settlement(tmp_path, monkeypatch):
+    import ouroboros.delegate_custody as custody
+    import ouroboros.tools.delegate as delegate
+    from ouroboros.gateways import claudexor as gateway
+
+    removed = []
+
+    class StableGateway:
+        engine_version = CLAUDEXOR_DELEGATED_WORKSPACE_ROOT_MIN_VERSION
+
+        def handshake(self, **_kwargs): return {}
+        def agent_capabilities(self):
+            return {"harnesses": [{"id": "some-route", "enabled": True,
+                                    "status": "ok",
+                                    "accessProfilesSupported": ["readonly", "workspace_write"]}]}
+        def quota_snapshots(self): return []
+        def find_project_id(self, _root): return ""
+        def register_project(self, _root): return "prj-stable"
+        def start_run(self, _request, *, idempotency_key=""): return {"runId": "run-stable"}
+        def remove_project(self, project_id): removed.append(project_id)
+        def close(self): pass
+
+    stub = StableGateway()
+    monkeypatch.setenv("OUROBOROS_SUBAGENT_HARNESS", "some-route=weak-model:low")
+    monkeypatch.setenv("OUROBOROS_SUBAGENT_WORKTREE_ROOT", str(tmp_path / "snap_root"))
+    monkeypatch.setattr(gateway, "ClaudexorGateway", lambda *a, **k: stub)
+    payload = json.loads(delegate._delegate_start(_ctx(tmp_path, task_id="t-stable"), "edit"))
+    assert payload["status"] == "started"
+    run = custody.replay(tmp_path)["run-stable"]
+    run.ledger_recorded = True
+    settled = custody.settle_run(tmp_path, stub, run,
+                                 {"summary": {"state": "succeeded", "spendUsd": 0.0}})
+    assert settled["project_retired"] is False
+    assert removed == []
+
+
+def test_retry_replays_stable_scope_and_workspace_root_verbatim(tmp_path, monkeypatch):
+    import ouroboros.tools.delegate as delegate
+    from ouroboros.gateways import claudexor as gateway
+
+    seen = []
+
+    class RetryGateway:
+        engine_version = CLAUDEXOR_DELEGATED_WORKSPACE_ROOT_MIN_VERSION
+
+        def handshake(self, **_kwargs): return {}
+        def agent_capabilities(self):
+            return {"harnesses": [{"id": "some-route", "enabled": True, "status": "ok",
+                                    "accessProfilesSupported": ["readonly", "workspace_write"]}]}
+        def quota_snapshots(self): return []
+        def find_project_id(self, _root): return "prj-existing"
+        def register_project(self, _root): raise AssertionError("stable registration is reused")
+        def start_run(self, request, *, idempotency_key=""):
+            seen.append(json.loads(json.dumps(request)))
+            if len(seen) == 1:
+                raise gateway.ClaudexorUnavailable("daemon_unreachable", "lost", status_code=0)
+            return {"runId": "run-retried"}
+        def close(self): pass
+
+    stub = RetryGateway()
+    monkeypatch.setenv("OUROBOROS_SUBAGENT_HARNESS", "some-route=weak-model:low")
+    monkeypatch.setenv("OUROBOROS_SUBAGENT_WORKTREE_ROOT", str(tmp_path / "snap_root"))
+    monkeypatch.setattr(gateway, "ClaudexorGateway", lambda *a, **k: stub)
+    ctx = _ctx(tmp_path, task_id="t-retry")
+    lost = json.loads(delegate._delegate_start(ctx, "edit"))
+    retried = json.loads(delegate._delegate_start(ctx, "edit", retry_of=lost["pending_invocation_id"]))
+    assert retried["status"] == "started"
+    assert seen[1] == seen[0]
+
+
+def test_new_shape_retry_refuses_old_engine_before_post(tmp_path, monkeypatch):
+    import ouroboros.tools.delegate as delegate
+    from ouroboros.gateways import claudexor as gateway
+
+    class StaleGateway:
+        engine_version = CLAUDEXOR_DELEGATED_WORKSPACE_ROOT_MIN_VERSION
+
+        def __init__(self): self.starts = 0
+        def handshake(self, **_kwargs): return {}
+        def agent_capabilities(self):
+            return {"harnesses": [{"id": "some-route", "enabled": True, "status": "ok",
+                                    "accessProfilesSupported": ["readonly", "workspace_write"]}]}
+        def quota_snapshots(self): return []
+        def find_project_id(self, _root): return "prj-existing"
+        def register_project(self, _root): raise AssertionError("registration is reused")
+        def start_run(self, *_args, **_kwargs):
+            self.starts += 1
+            raise gateway.ClaudexorUnavailable("daemon_unreachable", "lost", status_code=0)
+        def close(self): pass
+
+    stub = StaleGateway()
+    monkeypatch.setenv("OUROBOROS_SUBAGENT_HARNESS", "some-route=weak-model:low")
+    monkeypatch.setenv("OUROBOROS_SUBAGENT_WORKTREE_ROOT", str(tmp_path / "snap_root"))
+    monkeypatch.setattr(gateway, "ClaudexorGateway", lambda *a, **k: stub)
+    ctx = _ctx(tmp_path, task_id="t-stale")
+    lost = json.loads(delegate._delegate_start(ctx, "edit"))
+    stub.engine_version = "3.8.0"
+    stale = json.loads(delegate._delegate_start(ctx, "edit", retry_of=lost["pending_invocation_id"]))
+    assert stale["reason"] == "engine_rejects_delegated_workspace_root"
+    assert stub.starts == 1
+
+
+def _orphan(tmp_path, request, *, persistent=True):
+    import ouroboros.delegate_custody as custody
+
+    assert custody.record_start_requested(
+        tmp_path, invocation_id="inv-recovery", task_id="t-recovery", request=request,
+        route="some-route", project_id="prj-stable", project_owned=True,
+        project_persistent=persistent,
+    )
+    return custody.pending_invocations(tmp_path)[0]
+
+
+def test_recovery_blocks_future_shape_on_old_engine_without_post(tmp_path):
+    import ouroboros.delegate_custody as custody
+
+    record = _orphan(tmp_path, {
+        "mode": "agent", "access": "workspace_write",
+        "scope": {"kind": "project", "root": "/target"},
+        "execution": {"isolation": "live", "delegated": True,
+                       "workspaceRoot": "/snapshot"},
+    })
+
+    class OldGateway:
+        engine_version = "3.8.0"
+        def start_run(self, *_args, **_kwargs): raise AssertionError("must not POST")
+
+    result = custody._recover_pending_invocation(tmp_path, OldGateway(), record)
+    assert result["reason"] == "engine_rejects_delegated_workspace_root"
+    assert custody.pending_invocations(tmp_path)[0]["invocation_id"] == "inv-recovery"
+
+
+def test_recovery_keeps_legacy_pending_on_future_workspace_floor(tmp_path):
+    import ouroboros.delegate_custody as custody
+    from ouroboros.gateways import claudexor as gateway
+
+    record = _orphan(tmp_path, {
+        "mode": "agent", "access": "workspace_write",
+        "scope": {"kind": "project", "root": "/target"},
+        "execution": {"isolation": "live", "delegated": True},
+    })
+
+    class FutureGateway:
+        engine_version = CLAUDEXOR_DELEGATED_WORKSPACE_ROOT_MIN_VERSION
+        def __init__(self): self.calls = 0
+        def start_run(self, *_args, **_kwargs):
+            self.calls += 1
+            raise gateway.ClaudexorUnavailable(
+                "execution_workspace_required", "legacy body", status_code=400,
+            )
+        def remove_project(self, *_args, **_kwargs): raise AssertionError("persistent project")
+
+    stub = FutureGateway()
+    result = custody._recover_pending_invocation(tmp_path, stub, record)
+    assert stub.calls == 1
+    assert result["reason"] == "legacy_workspace_root_requires_compatible_retry"
+    assert custody.pending_invocations(tmp_path)[0]["invocation_id"] == "inv-recovery"
+    assert not any(row.get("type") == custody.START_FAILED
+                   for row in custody._iter_rows(custody.event_log_path(tmp_path)))
+
+
+def test_future_recovery_attempts_unknown_legacy_replay(tmp_path):
+    import ouroboros.delegate_custody as custody
+    from ouroboros.gateways import claudexor as gateway
+
+    record = _orphan(tmp_path, {
+        "mode": "agent", "access": "workspace_write",
+        "scope": {"kind": "project", "root": "/target"},
+        "execution": {"isolation": "live", "delegated": True},
+    })
+
+    class FutureGateway:
+        engine_version = CLAUDEXOR_DELEGATED_WORKSPACE_ROOT_MIN_VERSION
+        def start_run(self, *_args, **_kwargs):
+            raise gateway.ClaudexorUnavailable("daemon_unreachable", "lost", status_code=0)
+
+    result = custody._recover_pending_invocation(tmp_path, FutureGateway(), record)
+    assert result["action"] == "recovery_unreachable"
+    assert custody.pending_invocations(tmp_path)[0]["invocation_id"] == "inv-recovery"
+
+
+def test_pending_recovery_retains_persistent_project_marker(tmp_path):
+    import ouroboros.delegate_custody as custody
+
+    assert custody.record_start_requested(
+        tmp_path, invocation_id="inv-persistent", task_id="t-persistent",
+        request={"mode": "agent", "scope": {"root": "/target"}},
+        project_id="prj-stable", project_owned=True, project_persistent=True,
+    )
+    assert custody.pending_invocations(tmp_path)[0]["project_persistent"] is True


### PR DESCRIPTION
This is an intentionally unfinished handoff from the August 22 delegation investigation. It publishes the exact local WIP commit f9356572 so another agent can inspect and continue it from a stable remote ref.

The patch attempted four bounded repairs: definite configured-session no-start handling, complete delegation intent propagation, delayed daemon-winner reconciliation, and version-aware execution.workspaceRoot plus retry continuity.

Do not merge this as-is. Work stopped after Anton clarified that the preceding instruction meant continued research, not implementation. Focused checks passed (343 focused tests plus 237 additional tests, compileall, ruff F, diff check, and size ratchet), but the full pytest run stopped at a browser smoke failure. Final triad and scope review, live E2E, current-main integration, and the broader nested-agent design were not completed. The branch predates the later actor-first design and must be re-evaluated hunk by hunk rather than cherry-picked wholesale.

Original Codex task: 01a021cf-f729-7cc0-8af6-5d5310329168.