### PR TITLE
Supervisor & process-custody reliability: monotonic watchdog, /proc-first boot-qualified process identity, cheap same-session reap

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -329,6 +329,26 @@ server.py (Starlette+uvicorn) ← HTTP + WebSocket on configurable host:port (de
       the reaper (server startup + 10-min supervisor tick) kills entries whose
       generation/task owner is gone, matching by STRICT fingerprint only —
       never by command-line class, so dev and packaged instances can coexist.
+      On Linux `start_time` is read from `/proc` and boot-qualified
+      (`"<ticks>.<boot8>"`, since boot-relative ticks recur across reboots and a
+      bare tick plus a recycled pid is a real collision). The mint order is
+      boot-qualified first; then, when the boot id is unreadable, the `ps`
+      wall-clock token, which cannot collide across boots; and only once `ps` has
+      ALSO failed, `"<ticks>."` as a disclosed last resort (two of THOSE from
+      different boots do string-match, which is why they are last, not first). A
+      post-change token is therefore never string-equal to a pre-change bare
+      tick: it is boot-qualified, a `ps` string, or separator-carrying. The
+      minted form changes if the boot id starts or stops being readable
+      mid-generation, so a row recorded across that transition mismatches its own
+      live process — safe, since a mismatch prunes and never kills. The match
+      accepts both Linux representations for pre-existing rows — current first,
+      and the pre-upgrade `ps -o lstart=` spelling (or its rare bare-tick
+      fallback) only once that mismatched; the `ps` spelling is re-derived only
+      when the current token is `/proc`-minted (elsewhere it would be the same
+      bytes again), while a bare-tick row resolves against `/proc` directly in
+      every mint order, so no legacy row shape is orphaned on a `/proc` host.
+      An upgrade therefore orphans no ledger row and the reaper's hot path never
+      pays for a second subprocess.
       Genuine `daemon` entries are kept; skill companions (daemon scope,
       `purpose companion:<skill>:<name>`) are the exception (v6.36.2) — reaped on
       owner-uninstall or a foreign generation, **log-only by default**

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -349,6 +349,12 @@ server.py (Starlette+uvicorn) ← HTTP + WebSocket on configurable host:port (de
       every mint order, so no legacy row shape is orphaned on a `/proc` host.
       An upgrade therefore orphans no ledger row and the reaper's hot path never
       pays for a second subprocess.
+      Current-generation session processes take a cheap liveness check instead
+      (the cheap path only ever keeps: an alive-but-recycled same-session pid is
+      retained one generation and pruned by the next generation's full
+      fingerprint check, never killed); full fingerprints remain for
+      stale/foreign records, and a DEAD pid still falls through to the
+      service-group evidence rather than being pruned on the spot.
       Genuine `daemon` entries are kept; skill companions (daemon scope,
       `purpose companion:<skill>:<name>`) are the exception (v6.36.2) — reaped on
       owner-uninstall or a foreign generation, **log-only by default**

--- a/ouroboros/platform_layer.py
+++ b/ouroboros/platform_layer.py
@@ -41,9 +41,8 @@ def executable_name_candidates(name: str) -> List[str]:
 def local_zoneinfo():
     """Best-effort DST-aware local timezone.
 
-    ``astimezone().tzinfo`` is a *fixed* offset that drifts across DST; resolve the IANA
-    zone (``TZ`` or ``/etc/localtime``), falling back to the fixed offset.
-    """
+    ``astimezone().tzinfo`` is a *fixed* offset that drifts across DST; resolve the IANA zone (``TZ`` or
+    ``/etc/localtime``), falling back to the fixed offset."""
     import datetime
     from zoneinfo import ZoneInfo
 
@@ -136,12 +135,11 @@ def bootstrap_process_path() -> list[str]:
 
 
 def scrub_repo_from_pythonpath(env: dict[str, str], repo_dir: "str | pathlib.Path | None") -> dict[str, str]:
-    """Return a copy of *env* with any ``PYTHONPATH`` entry resolving to the Ouroboros
-    system repo dir removed.
+    """Return a copy of *env* with any ``PYTHONPATH`` entry resolving to the Ouroboros system repo dir removed.
 
-    An EXTERNAL-workspace command inherits the worker's ``PYTHONPATH`` repo entry, which
-    makes the target's ``import web``/``server``/``ouroboros`` resolve to OUROBOROS's modules.
-    Dropping ONLY the repo entry isolates the target; no-op without one."""
+    An EXTERNAL-workspace command inherits the worker's ``PYTHONPATH`` repo entry, which makes the target's
+    ``import web``/``server``/``ouroboros`` resolve to OUROBOROS's modules. Dropping ONLY the repo entry isolates
+    the target; no-op without one."""
     out = dict(env)
     raw = out.get("PYTHONPATH", "")
     if not raw or not repo_dir:
@@ -440,9 +438,8 @@ def pid_is_alive(pid: int) -> bool:
 def pid_provably_gone(pid: int) -> bool:
     """True only when the OS positively answers that ``pid`` does not exist.
 
-    Stricter than ``not pid_is_alive``: the POSIX branch there folds EVERY
-    OSError into 'dead', but EPERM means the process EXISTS and merely refuses
-    our signal — a caller deciding whether a killed process is really gone
+    Stricter than ``not pid_is_alive``: the POSIX branch there folds EVERY OSError into 'dead', but EPERM means
+    the process EXISTS and merely refuses our signal — a caller deciding whether a killed process is really gone
     must treat that (and anything else undeterminable) as still present."""
     if pid <= 0:
         return True
@@ -553,12 +550,10 @@ def _win32_unlock(fd: int) -> None:
 def kill_process_tree(proc: subprocess.Popen) -> None:
     """Force-kill a subprocess and its entire process tree.
 
-    On POSIX the immediate process group is SIGKILLed first, then descendants that
-    escaped into their own session/group are swept by PID — without that sweep a
-    cancelled child which spawned grandchildren in new groups leaks orphans.
-    Descendants are collected BEFORE the kill: once the parent dies its children are
-    reparented and the ppid links disappear.
-    """
+    On POSIX the immediate process group is SIGKILLed first, then descendants that escaped into their own
+    session/group are swept by PID — without that sweep a cancelled child which spawned grandchildren in new
+    groups leaks orphans. Descendants are collected BEFORE the kill: once the parent dies its children are
+    reparented and the ppid links disappear."""
     pid = proc.pid
     if IS_WINDOWS:
         try:
@@ -655,21 +650,44 @@ def current_process_group_id() -> int:
         return 0
 
 
+_BOOT_ID = ""  # first 8 hex of the /proc boot id; empty until a successful read, then latched
+
+
 def process_start_time(pid: int) -> str:
     """Best-effort stable start-time token for (pid, start_time) fingerprints.
 
-    A bare pid is not an identity — the kernel reuses it. ``(pid, start_time)`` is, which is what
-    lets a caller refuse to signal a pid it merely used to own. POSIX uses ``ps -o lstart=``,
-    falling back to the same /proc field the containment scan dates candidates by, so the
-    fingerprint stays real on an image with no usable ``ps``. Windows returns "" (callers degrade
-    to pid liveness), as does a pid that is already gone."""
-    if pid <= 0:
+    A bare pid is not an identity (kernels reuse pids) and boot-relative ticks RECUR across reboots, so a bare
+    tick + a recycled pid + the same command line is a real collision; refusing that kill is the job. Linux mints
+    IN THIS ORDER: ``"<ticks>.<boot8>"`` when the boot id is readable (no subprocess); else the ``ps`` wall-clock
+    token, which cannot collide across boots; and only once ``ps`` has ALSO failed, ``"<ticks>."`` as a disclosed
+    last resort — two of THOSE from different boots do string-match, hence last, not first. No ``/proc``: legacy
+    throughout; Windows and a dead pid return "". A post-change token is never string-equal to a bare pre-change
+    tick: it is boot-qualified, a ``ps`` string, or separator-carrying. Disclosed: the FORM changes if the boot id
+    starts or stops being readable mid-generation, so a row recorded across it mismatches its own live process —
+    safe: it prunes, never kills, and the cheap reap path skips live rows."""
+    global _BOOT_ID
+    if pid <= 0 or os.name == "nt":
         return ""
-    if os.name == "nt":
+    if not (ticks := _proc_start_ticks(pid)):
+        return process_start_time_legacy(pid)  # no /proc here (macOS, BSD): ps is the only source
+    if not _BOOT_ID:  # a failed read is transient: retry next call, never downgrade the generation
+        try:
+            _BOOT_ID = pathlib.Path("/proc/sys/kernel/random/boot_id").read_text().strip().replace("-", "")[:8]
+        except (OSError, ValueError):  # matches _proc_start_ticks; an escapee would abort a custody sweep
+            pass
+    if _BOOT_ID:
+        return f"{ticks}.{_BOOT_ID}"
+    # legacy degrades to str(ticks) when ps ALSO failed; only then is the separator form the best we have.
+    return legacy if (legacy := process_start_time_legacy(pid)) and legacy != str(ticks) else f"{ticks}."
+
+
+def process_start_time_legacy(pid: int) -> str:
+    """The historical ``ps -o lstart=`` token (bare ``/proc`` ticks when ``ps`` fails); the compatibility half of the
+    dual-format fingerprint match, consulted only after a boot-qualified current token failed to match."""
+    if pid <= 0 or os.name == "nt":
         return ""
     try:
-        out = subprocess.run(["ps", "-o", "lstart=", "-p", str(pid)],
-                             capture_output=True, text=True, timeout=5)
+        out = subprocess.run(["ps", "-o", "lstart=", "-p", str(pid)], capture_output=True, text=True, timeout=5)
         text = (out.stdout or "").strip()
         if out.returncode == 0 and text:
             return text
@@ -722,10 +740,9 @@ def force_kill_pid(pid: int) -> None:
 def kill_pid_tree(pid: int, exclude_pids: "set[int] | None" = None) -> None:
     """Force-kill a PID tree recursively.
 
-    ``exclude_pids`` are spared along with their own descendants, keeping
-    ``service_teardown=keep`` services reachable for a verifier when a worker is
-    force-killed; spared children reparent to init and fall to the custody reaper.
-    """
+    ``exclude_pids`` are spared along with their own descendants, keeping ``service_teardown=keep`` services
+    reachable for a verifier when a worker is force-killed; spared children reparent to init and fall to the
+    custody reaper."""
     exclude = {int(p) for p in (exclude_pids or set())}
     if IS_WINDOWS:
         # exclude_pids is a POSIX-only nicety: descendant enumeration relies on
@@ -889,24 +906,19 @@ def interpreter_is_embedded(interpreter: str) -> bool:
 def pip_install_target_args(interpreter: str) -> List[str]:
     """Extra pip flags so an install never writes INSIDE the packaged bundle.
 
-    The embedded interpreter lives in the signed bundle, so its own
-    ``site-packages`` is the wrong install target: writing there breaks the code
-    signature and fails outright on a read-only install. ``--user`` redirects to
-    the user site under ``PYTHONUSERBASE`` (set by
-    ``launcher_bootstrap.embedded_python_env`` for every process that runs the
-    embedded interpreter). A non-embedded interpreter — a dev venv, a system
-    python — gets NO flag: ``--user`` is refused inside a virtualenv, so a blanket
-    flag would trade one broken install for another.
-    """
+    The embedded interpreter lives in the signed bundle, so its own ``site-packages`` is the wrong install target:
+    writing there breaks the code signature and fails outright on a read-only install. ``--user`` redirects to the
+    user site under ``PYTHONUSERBASE`` (set by ``launcher_bootstrap.embedded_python_env`` for every process that
+    runs the embedded interpreter). A non-embedded interpreter — a dev venv, a system python — gets NO flag:
+    ``--user`` is refused inside a virtualenv, so a blanket flag would trade one broken install for another."""
     return ["--user"] if interpreter_is_embedded(interpreter) else []
 
 
 def project_venv_python(project_root: pathlib.Path) -> str:
     """Return the executable for a valid project ``.venv`` on this platform.
 
-    Keep the lexical venv path (rather than resolving its symlink) so Python
-    discovers the adjacent ``pyvenv.cfg`` and activates the environment.
-    """
+    Keep the lexical venv path (rather than resolving its symlink) so Python discovers the adjacent ``pyvenv.cfg``
+    and activates the environment."""
     env_root = pathlib.Path(project_root) / ".venv"
     if not (env_root / "pyvenv.cfg").is_file():
         return ""
@@ -980,13 +992,10 @@ BUNDLE_DIR_ENV = "OUROBOROS_BUNDLE_DIR"
 def bundled_resource_ancestor_bases(executable: "str | pathlib.Path | None" = None) -> List[pathlib.Path]:
     """Bundle roots recoverable from an embedded interpreter path.
 
-    Managed updates replace the server checkout but not the frozen launcher.
-    Launchers predating ``OUROBOROS_BUNDLE_DIR`` still start the updated server
-    with ``.../Resources/python-standalone/...`` (macOS) or
-    ``.../_internal/python-standalone/...`` (portable builds).  The interpreter
-    path therefore remains a durable, cross-platform pointer to the old app's
-    resource root.
-    """
+    Managed updates replace the server checkout but not the frozen launcher. Launchers predating
+    ``OUROBOROS_BUNDLE_DIR`` still start the updated server with ``.../Resources/python-standalone/...`` (macOS)
+    or ``.../_internal/python-standalone/...`` (portable builds). The interpreter path therefore remains a
+    durable, cross-platform pointer to the old app's resource root."""
     try:
         start = pathlib.Path(executable or sys.executable).resolve()
     except (OSError, ValueError):
@@ -1009,17 +1018,13 @@ def bundled_resource_ancestor_bases(executable: "str | pathlib.Path | None" = No
 def bundled_resource_bases() -> List[pathlib.Path]:
     """Roots to search for a resource shipped INSIDE the packaged bundle.
 
-    SSOT for every bundled-payload lookup, because the process that consumes a
-    bundled payload is usually NOT the frozen launcher. In a packaged install the
-    launcher runs the server/CLI as a SEPARATE child of the embedded interpreter,
-    out of the launcher-managed repo under the data dir: that child has no
-    ``sys._MEIPASS`` and its ``__file__`` parent is the managed repo, so both
-    historical bases miss and every bundled payload silently reads as absent.
-    The launcher therefore hands the bundle root down by value in
-    ``OUROBOROS_BUNDLE_DIR`` and it is searched FIRST. The other two bases stay
-    for the frozen process itself and for the dev/source layout (payloads sit at
-    the repo root, two levels up from this module).
-    """
+    SSOT for every bundled-payload lookup, because the process that consumes a bundled payload is usually NOT the
+    frozen launcher. In a packaged install the launcher runs the server/CLI as a SEPARATE child of the embedded
+    interpreter, out of the launcher-managed repo under the data dir: that child has no ``sys._MEIPASS`` and its
+    ``__file__`` parent is the managed repo, so both historical bases miss and every bundled payload silently
+    reads as absent. The launcher therefore hands the bundle root down by value in ``OUROBOROS_BUNDLE_DIR`` and it
+    is searched FIRST. The other two bases stay for the frozen process itself and for the dev/source layout
+    (payloads sit at the repo root, two levels up from this module)."""
     bases: List[pathlib.Path] = []
     env_base = str(os.environ.get(BUNDLE_DIR_ENV) or "").strip()
     if env_base:
@@ -1058,11 +1063,9 @@ def _resolve_bundled_payload(candidates_for: Callable[[pathlib.Path], List[pathl
 def resolve_bundled_node() -> Optional[str]:
     """Return the path to the bundled, signed Node.js runtime if present.
 
-    The packaged app ships an official notarized node under ``node-standalone``
-    (re-signed under the hardened runtime by the build's signing pass). Prefer it
-    over a PATH (e.g. Homebrew) node, which macOS code-signing enforcement can
-    SIGKILL when launched from the packaged process tree.
-    """
+    The packaged app ships an official notarized node under ``node-standalone`` (re-signed under the hardened
+    runtime by the build's signing pass). Prefer it over a PATH (e.g. Homebrew) node, which macOS code-signing
+    enforcement can SIGKILL when launched from the packaged process tree."""
     return _resolve_bundled_payload(embedded_node_candidates)
 
 
@@ -1280,11 +1283,9 @@ def subprocess_new_group_kwargs() -> dict:
 
 
 def install_shutdown_signal_handlers(handler) -> None:
-    """Register ``handler`` for the signals that ask a console process to shut
-    down: SIGINT everywhere, SIGTERM on POSIX. The platform-specific signal
-    surface lives HERE, never in callers (checklist 15). The handler must only
-    set a flag/event — real teardown belongs on the caller's main thread, not
-    inside a signal frame."""
+    """Register ``handler`` for the signals that ask a console process to shut down: SIGINT everywhere, SIGTERM on
+    POSIX. The platform-specific signal surface lives HERE, never in callers (checklist 15). The handler must only
+    set a flag/event — real teardown belongs on the caller's main thread, not inside a signal frame."""
     signal.signal(signal.SIGINT, handler)
     if not IS_WINDOWS:
         signal.signal(signal.SIGTERM, handler)

--- a/ouroboros/process_custody.py
+++ b/ouroboros/process_custody.py
@@ -34,13 +34,15 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 from ouroboros.platform_layer import (
-    kill_process_tree,
+    _proc_start_ticks,
     kill_process_group_id,
+    kill_process_tree,
     pid_is_alive,
     process_command,
     process_group_id,
     process_group_is_alive,
     process_start_time,
+    process_start_time_legacy,
     subprocess_new_group_kwargs,
 )
 from ouroboros.utils import append_jsonl, utc_now_iso
@@ -182,12 +184,47 @@ def spawn_supervised(
     return proc
 
 
+def _legacy_start_matches(pid: int, recorded: str, current: str) -> bool:
+    """Accept a start-time token written BEFORE /proc-first, so the upgrade orphans no ledger row.
+
+    ``process_start_time`` now returns a boot-qualified ``"<ticks>.<boot8>"``. A row written
+    before that change carries the ``ps -o lstart=`` spelling instead, or — on the rare path
+    where ``ps`` itself failed — a BARE boot-relative tick count. Both are accepted, and only
+    here: this runs solely AFTER the current token already failed to match, so the extra ``ps``
+    stays off the reaper's hot path and a genuinely different process still fails every form.
+    A bare-tick row resolves against /proc directly even when the current primary token is the
+    ``ps`` spelling (boot id unreadable), so no legacy row shape is orphaned on a /proc host.
+
+    BOUNDED EXPOSURE, stated rather than hidden: the bare-tick form carries no boot id, so such a
+    row can still collide across a reboot exactly as it always could (same ticks, recycled pid,
+    same command line). No post-change token is written in that form — a /proc mint is
+    boot-qualified, a ``ps`` string, or separator-carrying — so the PRE-CHANGE window closes as the
+    ledger turns over. What does NOT close by turnover is the separator form itself, minted only
+    when the boot id AND ``ps`` both fail: two of those from different boots string-match on the
+    equality check above, before this helper is ever consulted. That is why the separator form is
+    the last resort rather than the boot-id-less default.
+    """
+    ticks, sep, _ = current.partition(".")
+    if not (sep and ticks.isdigit()):
+        # The current token IS the legacy ``ps`` form (no /proc, or the boot id was
+        # unreadable so ``ps`` won the mint order). Re-running ``ps`` would return the
+        # byte-identical value that already failed to match — but a recorded BARE-TICK
+        # row is still resolvable against /proc directly (0 on hosts without /proc,
+        # which never equals a digit row), at zero subprocess cost.
+        return recorded.isdigit() and recorded == str(_proc_start_ticks(pid))
+    if recorded.isdigit() and recorded == ticks:
+        return True  # pre-change bare-tick fallback row; the tick half of today's token
+    return bool(recorded) and process_start_time_legacy(pid) == recorded
+
+
 def _fingerprint_matches(entry: Dict[str, Any]) -> bool:
     """STRICT identity: the live process must still BE the recorded one.
 
     pid alive + same start_time (when we have one) + same command hash (when
     we have one). A recycled pid fails this and is left alone. We never match
-    by command-line class.
+    by command-line class. The start-time comparison is DUAL-FORMAT on Linux:
+    the cheap current representation first, and the pre-upgrade spelling only
+    once that mismatched (see ``_legacy_start_matches``).
     """
     pid = int(entry.get("pid") or 0)
     if pid <= 0 or not pid_is_alive(pid):
@@ -196,7 +233,9 @@ def _fingerprint_matches(entry: Dict[str, Any]) -> bool:
     recorded_start = str(fp.get("start_time") or "")
     if recorded_start:
         live_start = process_start_time(pid)
-        if live_start and live_start != recorded_start:
+        if live_start and live_start != recorded_start and not _legacy_start_matches(
+            pid, recorded_start, live_start
+        ):
             return False
     recorded_cmd = str(fp.get("cmd_sha256") or "")
     if recorded_cmd:

--- a/ouroboros/process_custody.py
+++ b/ouroboros/process_custody.py
@@ -516,6 +516,31 @@ def reap_orphaned_processes(
         pid = int(entry.get("pid") or 0)
         scope = str(entry.get("scope") or "task")
         same_session = str(entry.get("session_id") or "") == _SESSION_ID
+        # CHEAP PATH for the current generation's own session processes. The branch
+        # further down keeps every same-session session entry regardless of what the
+        # fingerprint said (``task_owner_gone`` is task-scope-only), so for a LIVE pid
+        # the cheap path only ever KEEPS: an alive-but-RECYCLED same-session pid is
+        # retained one generation (foreign next generation -> full fingerprint ->
+        # prune), never killed. The skipped fingerprint only cost a `ps` per row on
+        # every 600s tick and startup sweep. This is the hot majority of the ledger:
+        # worker-pool members, the SyncManager, the claudexor daemon, the local-model
+        # server and keep-services are all scope="session".
+        #
+        # A DEAD pid deliberately FALLS THROUGH instead of pruning here: a session
+        # service whose leader died while its process group is still alive is preserved
+        # today by ``_service_group_survives_leader``, and a prune-on-dead shortcut would
+        # throw that evidence away. Companions are excluded so the daemon-scope companion
+        # rules below stay the only authority on them even for a malformed session-scope
+        # row. This path only ever KEEPS — it can never authorize a kill.
+        if (
+            scope == "session"
+            and same_session
+            and pid > 0
+            and not str(entry.get("purpose") or "").startswith("companion:")
+            and pid_is_alive(pid)
+        ):
+            survivors.append(entry)
+            continue
         leader_matches = _fingerprint_matches(entry)
         group_survives = _service_group_survives_leader(entry)
         if not leader_matches and not group_survives:

--- a/server.py
+++ b/server.py
@@ -988,7 +988,16 @@ def _start_supervisor_liveness_watchdog(liveness: list, stop_event=None) -> None
         wedged_task = None
         while not _restart_requested.is_set() and not (stop_event is not None and stop_event.is_set()):
             time.sleep(interval)
-            now = time.time()
+            # TWO clocks, deliberately: each half must read the SAME clock its own
+            # stamps were taken on. The liveness tick is monotonic (it measures an
+            # elapsed gap, and a wall-clock jump — NTP step, DST/timezone change,
+            # manual set, VM resume — must neither fabricate a stall nor mask one),
+            # while the chat-turn wedge compares against ``agent._last_activity_ts``,
+            # a WALL stamp (agent.py). Feeding a monotonic ``now`` into that half
+            # would make ``now - turn_ts`` hugely negative and silently disable wedge
+            # detection forever. Do not collapse these back into one variable.
+            now = time.monotonic()
+            now_wall = time.time()
             # (1) Supervisor loop stall — new-message intake starvation.
             if _supervisor_loop_stalled(liveness[0], now, deadline):
                 if not loop_alerted:
@@ -1028,9 +1037,9 @@ def _start_supervisor_liveness_watchdog(liveness: list, stop_event=None) -> None
                 busy, turn_task, turn_ts = chat_turn_liveness()
             except Exception:
                 busy, turn_task, turn_ts = (False, None, None)
-            if _chat_turn_wedged(busy, turn_ts, now, deadline):
+            if _chat_turn_wedged(busy, turn_ts, now_wall, deadline):
                 if wedged_task != turn_task:  # alert once per wedged turn
-                    _alert_chat_turn_wedge(turn_task, now - (turn_ts or now))
+                    _alert_chat_turn_wedge(turn_task, now_wall - (turn_ts or now_wall))
                     wedged_task = turn_task
             elif not busy:
                 wedged_task = None
@@ -2183,13 +2192,15 @@ def _run_supervisor(settings: dict) -> None:
     _last_review_job_reconcile = [time.time()]
     # WS3: a dedicated watchdog thread (outside this loop, so it fires even if the
     # loop stalls) surfaces a wedge as an observable signal + owner alert instead
-    # of silent hours; the loop publishes a liveness tick each iteration.
-    _loop_liveness = [time.time()]
+    # of silent hours; the loop publishes a liveness tick each iteration. The tick
+    # is MONOTONIC: it is only ever read as an elapsed gap, so a wall-clock jump
+    # must not turn a healthy loop into a phantom stall (nor hide a real one).
+    _loop_liveness = [time.monotonic()]
     _watchdog_stop = threading.Event()  # per-generation: stops the watchdog when THIS loop exits
     _start_supervisor_liveness_watchdog(_loop_liveness, _watchdog_stop)
     while not _restart_requested.is_set():
         try:
-            _loop_liveness[0] = time.time()
+            _loop_liveness[0] = time.monotonic()
             rotate_chat_log_if_needed(DATA_DIR)
             # progress.jsonl rotates on the same supervisor tick (v6.90.x P2); its
             # readers (history backfill, SSE replay, api_logs_tail, TB ATIF) are

--- a/tests/test_process_custody.py
+++ b/tests/test_process_custody.py
@@ -782,3 +782,63 @@ def test_start_time_match_matrix(tmp_path, monkeypatch, live, recorded, expected
         assert process_custody._fingerprint_matches(entry) is expected, why
     finally:
         proc.kill(); proc.wait(timeout=5)
+
+
+# --- OB-07: cheap liveness for the current generation's own session rows ---
+
+
+@_POSIX_ONLY
+@pytest.mark.parametrize("purpose", ["live-session-service", "service:web", "workspace_service:api"])
+def test_reaper_skips_the_fingerprint_for_live_same_session_rows(tmp_path, monkeypatch, purpose):
+    """A live same-session session row is kept either way, so the `ps` is pure cost.
+
+    The counter is the assertion: worker-pool members, the SyncManager, the claudexor
+    daemon, the local-model server and keep-services are ALL scope="session", so this is
+    the hot majority of the ledger on every 600s tick and startup sweep.
+    """
+    calls = []
+    real = process_custody._fingerprint_matches
+    monkeypatch.setattr(
+        process_custody, "_fingerprint_matches",
+        lambda entry: (calls.append(entry.get("pid")), real(entry))[1],
+    )
+    proc = _sleeper(tmp_path, purpose, "session")
+    try:
+        reaped = reap_orphaned_processes(tmp_path)
+        assert proc.pid not in reaped
+        assert proc.poll() is None, "a live same-session service must be kept"
+        assert calls == [], f"no fingerprint should be computed for a live session row; got {calls}"
+        # and the row is still in the ledger for the next generation to judge
+        kept = [json.loads(line) for line in ledger_path(tmp_path).read_text().splitlines() if line.strip()]
+        assert [e["pid"] for e in kept] == [proc.pid]
+    finally:
+        proc.kill(); proc.wait(timeout=5)
+
+
+def test_reaper_keeps_dead_leader_session_service_with_a_live_group(tmp_path, monkeypatch):
+    """A DEAD pid must fall through to the group evidence, never take a prune shortcut.
+
+    A session service whose leader died while its process group is still alive is
+    preserved by ``_service_group_survives_leader``; pruning on a dead pid inside the
+    cheap path would have silently dropped that row and orphaned the group.
+    """
+    entry = {
+        "pid": 123,
+        "pgid": 456,
+        "purpose": "service:background-child",
+        "scope": "session",
+        "session_id": process_custody._SESSION_ID,  # CURRENT generation
+        "fingerprint": {"start_time": "gone", "cmd_sha256": "gone"},
+    }
+    rewritten = []
+    monkeypatch.setattr(process_custody, "_read_ledger", lambda _root: [entry])
+    monkeypatch.setattr(process_custody, "pid_is_alive", lambda _pid: False)  # leader is dead
+    monkeypatch.setattr(process_custody, "process_group_is_alive", lambda pgid: pgid == 456)
+    monkeypatch.setattr(
+        process_custody, "kill_process_group_id",
+        lambda pgid: pytest.fail(f"a surviving service group must not be killed (pgid={pgid})"),
+    )
+    monkeypatch.setattr(process_custody, "_rewrite_ledger", lambda _root, entries: rewritten.extend(entries))
+
+    assert reap_orphaned_processes(tmp_path) == []
+    assert rewritten == [entry], "the dead-leader row must survive on its group evidence"

--- a/tests/test_process_custody.py
+++ b/tests/test_process_custody.py
@@ -563,3 +563,222 @@ def test_installed_skill_names_is_disk_derived_and_none_on_failure(monkeypatch):
     monkeypatch.setattr(skl, "discover_skills",
                         lambda *a, **k: [SimpleNamespace(name="alpha"), SimpleNamespace(name="beta")])
     assert server._installed_skill_names() == {"alpha", "beta"}
+
+
+# --- OB-06: /proc-first start times, matched dual-format for pre-upgrade rows ---
+#
+# These call ``_fingerprint_matches`` DIRECTLY on purpose. The reaper's cheap
+# same-session liveness path would answer for a live session row before the
+# fingerprint is ever computed, so a reaper-level assertion would pass without
+# proving anything about the matcher.
+
+
+def _fingerprint_entry(tmp_path, *, start_time=None):
+    """A ledger entry for a real live process, with its start-time token overridden.
+
+    ``start_time=None`` records the host's own legacy (``ps``) token, which is exactly
+    what a pre-upgrade row on a Linux box would carry.
+    """
+    proc = _sleeper(tmp_path, "ob06-fingerprint", "task")
+    record = record_process(
+        tmp_path, pid=proc.pid, cmd=["sleep", "60"], purpose="ob06", scope="task",
+    )
+    if start_time is None:
+        start_time = process_custody.process_start_time_legacy(proc.pid)
+    return proc, dict(record, fingerprint=dict(record["fingerprint"], start_time=start_time))
+
+
+@_POSIX_ONLY
+def test_fingerprint_accepts_a_pre_upgrade_ps_start_time(tmp_path, monkeypatch):
+    """A row written before /proc-first carries the ``ps -o lstart=`` spelling.
+
+    After the upgrade the current token is boot-qualified, so recorded != current for
+    every pre-existing row. Without the dual-format match the whole existing ledger
+    would read as fingerprint-mismatched and be pruned on the next sweep.
+    """
+    if not process_custody.process_start_time_legacy(os.getpid()):
+        pytest.skip("no usable ps/lstart start-time token on this host")
+    proc, entry = _fingerprint_entry(tmp_path)
+    try:
+        assert entry["fingerprint"]["start_time"], "ps must answer for a live pid"
+        # Simulate the post-upgrade Linux world regardless of the host we run on.
+        monkeypatch.setattr(process_custody, "process_start_time", lambda pid: "4242.deadbeef")
+        assert process_custody._fingerprint_matches(entry) is True
+    finally:
+        proc.kill(); proc.wait(timeout=5)
+
+
+@_POSIX_ONLY
+def test_fingerprint_accepts_a_pre_upgrade_bare_tick_row(tmp_path, monkeypatch):
+    """The rare pre-change row where ``ps`` failed carries a BARE boot-relative tick.
+
+    It is accepted against the tick half of today's token — the bounded compatibility
+    the matcher documents. Nothing new is ever written in this form.
+    """
+    proc, entry = _fingerprint_entry(tmp_path, start_time="4242")
+    try:
+        monkeypatch.setattr(process_custody, "process_start_time", lambda pid: "4242.deadbeef")
+        assert process_custody._fingerprint_matches(entry) is True
+    finally:
+        proc.kill(); proc.wait(timeout=5)
+
+
+@_POSIX_ONLY
+def test_fingerprint_rejects_identical_ticks_from_another_boot(tmp_path, monkeypatch):
+    """Boot-relative ticks RECUR across reboots — the boot id is what makes them an identity.
+
+    Same tick count, different boot: a bare-tick token would have matched and authorized a
+    kill of an unrelated process that merely inherited the pid. The qualified token must not.
+    """
+    proc, entry = _fingerprint_entry(tmp_path, start_time="4242.aaaaaaaa")
+    try:
+        monkeypatch.setattr(process_custody, "process_start_time", lambda pid: "4242.bbbbbbbb")
+        assert process_custody._fingerprint_matches(entry) is False
+    finally:
+        proc.kill(); proc.wait(timeout=5)
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="/proc start times are Linux-only")
+def test_process_start_time_is_boot_qualified_on_linux():
+    """On Linux the token comes from /proc and carries the boot id, without spawning ``ps``."""
+    token = process_custody.process_start_time(os.getpid())
+    assert re.fullmatch(r"\d+\.[0-9a-f]{1,8}", token), token
+    assert token != process_custody.process_start_time_legacy(os.getpid())
+
+
+@_POSIX_ONLY
+def test_foreign_row_mismatch_costs_no_second_ps_without_proc(tmp_path, monkeypatch):
+    """On a host with no /proc the current token already IS the ``ps`` spelling.
+
+    Re-running ``ps`` there would return the byte-identical value that just failed to
+    match, so the mismatch path must refuse before paying for a second subprocess.
+    """
+    calls = []
+    real_legacy = process_custody.process_start_time_legacy
+    monkeypatch.setattr(
+        process_custody, "process_start_time_legacy",
+        lambda pid: (calls.append(pid), real_legacy(pid))[1],
+    )
+    monkeypatch.setattr(process_custody, "process_start_time", lambda pid: "Mon Aug 25 12:00:00 2026")
+    proc, entry = _fingerprint_entry(tmp_path, start_time="FOREIGN")
+    try:
+        assert process_custody._fingerprint_matches(entry) is False
+        assert calls == [], f"a legacy-form current token must not trigger a second ps; got {calls}"
+    finally:
+        proc.kill(); proc.wait(timeout=5)
+
+
+@_POSIX_ONLY
+def test_unreadable_boot_id_prefers_the_collision_free_ps_token(monkeypatch):
+    """With ticks but no boot id, ``ps`` wins — ``"<ticks>."`` is the LAST resort.
+
+    Two ``"<ticks>."`` tokens from different boots string-MATCH, which is the exact
+    cross-boot false positive this fix exists to prevent, and it sits on the kill path.
+    The ``ps`` wall-clock token cannot collide across boots, so it is preferred; the
+    separator form is reached only when ``ps`` has also failed.
+    """
+    from ouroboros import platform_layer
+
+    monkeypatch.setattr(platform_layer, "_BOOT_ID", "")
+    monkeypatch.setattr(platform_layer, "_proc_start_ticks", lambda pid: 4242)
+    monkeypatch.setattr(
+        pathlib.Path, "read_text",
+        lambda self, *a, **k: (_ for _ in ()).throw(OSError("no boot id here")),
+    )
+    monkeypatch.setattr(platform_layer, "process_start_time_legacy", lambda pid: "Mon Aug 25 12:00:00 2026")
+    assert platform_layer.process_start_time(os.getpid()) == "Mon Aug 25 12:00:00 2026"
+
+
+@_POSIX_ONLY
+def test_separator_form_is_the_last_resort_when_ps_also_fails(monkeypatch):
+    """Only once ``ps`` has ALSO failed does the token degrade to ``"<ticks>."``.
+
+    It still carries the separator so it can never be string-equal to a genuine
+    pre-change bare-tick row — the ambiguity the separator removes.
+    """
+    from ouroboros import platform_layer
+
+    monkeypatch.setattr(platform_layer, "_BOOT_ID", "")
+    monkeypatch.setattr(platform_layer, "_proc_start_ticks", lambda pid: 4242)
+    monkeypatch.setattr(
+        pathlib.Path, "read_text",
+        lambda self, *a, **k: (_ for _ in ()).throw(OSError("no boot id here")),
+    )
+    # ps failed, so the legacy helper degrades to its own bare-tick fallback.
+    monkeypatch.setattr(platform_layer, "process_start_time_legacy", lambda pid: "4242")
+    token = platform_layer.process_start_time(os.getpid())
+    assert token == "4242.", token
+    assert token != "4242", "a /proc token must never be confusable with a pre-change bare tick"
+
+
+@_POSIX_ONLY
+@pytest.mark.parametrize("boom", [
+    OSError("transient"),
+    UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte"),  # a ValueError: the fix-4 arm
+])
+def test_boot_id_read_failure_retries_then_latches(monkeypatch, boom):
+    """One transient boot-id read failure must not downgrade the whole server generation.
+
+    Both arms of the guard are covered: an OSError and a UnicodeDecodeError (a ValueError,
+    which an unguarded caller would let escape and abort a whole custody sweep).
+    """
+    from ouroboros import platform_layer
+
+    attempts = []
+
+    def _read(self, *a, **k):
+        attempts.append(str(self))
+        if len(attempts) == 1:
+            raise boom
+        return "aabbccdd-0000-0000-0000-000000000000\n"
+
+    monkeypatch.setattr(platform_layer, "_BOOT_ID", "")
+    monkeypatch.setattr(platform_layer, "_proc_start_ticks", lambda pid: 7)
+    monkeypatch.setattr(platform_layer, "process_start_time_legacy", lambda pid: "Mon Aug 25 12:00:00 2026")
+    monkeypatch.setattr(pathlib.Path, "read_text", _read)
+
+    # The failed read falls to the collision-free ps token, NOT to "7." (see the priority order).
+    assert platform_layer.process_start_time(os.getpid()) == "Mon Aug 25 12:00:00 2026"
+    assert platform_layer.process_start_time(os.getpid()) == "7.aabbccdd"   # retried, boot id now readable
+    assert len(attempts) == 2
+    assert platform_layer.process_start_time(os.getpid()) == "7.aabbccdd"   # latched
+    assert len(attempts) == 2, "a successful read must latch and stop re-reading"
+
+
+# The token forms a ledger row (or a live process) can carry, after the priority reorder:
+#   Q  boot-qualified "<ticks>.<boot8>"      — post-change, boot id readable
+#   Q2 same ticks, DIFFERENT boot            — the cross-boot impostor
+#   P  ps wall-clock string                  — pre-change, or post-change without a boot id
+#   S  "<ticks>."                            — post-change last resort (no boot id AND no ps)
+#   B  bare "<ticks>"                        — pre-change ps-failed fallback only
+_Q, _Q2, _P, _S, _B = "4242.aabbccdd", "4242.bbbbbbbb", "Mon Aug 25 12:00:00 2026", "4242.", "4242"
+
+
+@_POSIX_ONLY
+@pytest.mark.parametrize(("live", "recorded", "expected", "why"), [
+    (_Q, _Q, True, "same boot, same ticks"),
+    (_Q, _Q2, False, "SAME ticks from another boot must never match"),
+    (_Q, _P, True, "pre-change ps row still matches after the upgrade"),
+    (_Q, _B, True, "pre-change bare-tick fallback row still matches"),
+    (_Q, _S, False, "a row from a boot-id outage window mismatches after recovery (prunes, never kills)"),
+    (_P, _P, True, "no boot id on either side: the ps token is the identity"),
+    (_P, _Q, False, "a boot-qualified row mismatches once the boot id stops being readable"),
+    (_P, _B, True, "a bare-tick row resolves against /proc directly even when the primary token is ps"),
+    (_S, _S, True, "the disclosed last-resort collision: both sides degraded identically"),
+    (_S, _B, True, "pre-change bare tick still matches the tick half of the last-resort form"),
+    (_S, _P, False, "ps is broken here, so a ps-format row cannot be re-derived"),
+])
+def test_start_time_match_matrix(tmp_path, monkeypatch, live, recorded, expected, why):
+    """Every (live form x recorded form) pair the priority reorder can produce."""
+    # ``ps`` answers only while the live token is not itself a ps string; when the live token
+    # IS ps-shaped, re-running ps returns that same value (which is what fix 1 short-circuits).
+    monkeypatch.setattr(process_custody, "process_start_time_legacy",
+                        lambda pid: _P if live in (_Q, _P) else _B)
+    monkeypatch.setattr(process_custody, "process_start_time", lambda pid: live)
+    # simulated readable /proc: the direct bare-tick comparator sees today's tick count
+    monkeypatch.setattr(process_custody, "_proc_start_ticks", lambda pid: 4242)
+    proc, entry = _fingerprint_entry(tmp_path, start_time=recorded)
+    try:
+        assert process_custody._fingerprint_matches(entry) is expected, why
+    finally:
+        proc.kill(); proc.wait(timeout=5)

--- a/tests/test_ws3_wedge_resilience.py
+++ b/tests/test_ws3_wedge_resilience.py
@@ -44,7 +44,7 @@ def test_watchdog_noop_when_disabled(monkeypatch):
 
     monkeypatch.setenv("OUROBOROS_SUPERVISOR_LIVENESS_DEADLINE_SEC", "0")
     before = threading.active_count()
-    server._start_supervisor_liveness_watchdog([time.time()])
+    server._start_supervisor_liveness_watchdog([time.monotonic()])
     assert threading.active_count() == before  # no watchdog thread spawned
 
 
@@ -64,12 +64,13 @@ def test_watchdog_alerts_owner_once_on_stall(monkeypatch):
     monkeypatch.setattr("supervisor.state.append_jsonl", lambda *a, **k: None)
     stop = threading.Event()  # local per-test token; do NOT touch the global restart flag
     try:
-        server._start_supervisor_liveness_watchdog([time.time() - 100], stop)  # already stale
+        # The liveness tick is a MONOTONIC stamp (OB-03) — seed it on the same clock.
+        server._start_supervisor_liveness_watchdog([time.monotonic() - 100], stop)  # already stale
         end = time.time() + 6
         while not alerts and time.time() < end:
             time.sleep(0.1)
     finally:
-        stop.set()  # stop THIS watchdog thread (no cross-test leakage)
+        _stop_watchdog(stop)  # join it too: a leaked in-flight iteration outlives the monkeypatch
     assert len(alerts) == 1
     assert alerts[0][0] == 5 and "stalled" in alerts[0][1]
     assert alerts[0][2]["is_progress"] is True
@@ -128,12 +129,12 @@ def test_watchdog_alerts_on_chat_turn_wedge(monkeypatch):
         _busy=True, _current_task_id="wedged1", _last_activity_ts=time.time() - 100))
     stop = threading.Event()  # local per-test token
     try:
-        server._start_supervisor_liveness_watchdog([time.time()], stop)
+        server._start_supervisor_liveness_watchdog([time.monotonic()], stop)
         end = time.time() + 6
         while not any("wedged" in a[1] for a in alerts) and time.time() < end:
             time.sleep(0.1)
     finally:
-        stop.set()
+        _stop_watchdog(stop)  # join it too: a leaked in-flight iteration outlives the monkeypatch
     assert any("wedged" in a[1] for a in alerts)  # the chat-turn wedge was surfaced
     assert any(a[0] == 7 for a in alerts)
     wedge = next(a for a in alerts if "wedged" in a[1])
@@ -143,3 +144,145 @@ def test_watchdog_alerts_on_chat_turn_wedge(monkeypatch):
         "task_incident": "chat_turn_wedge",
         "toast_once": "wedged1:chat_turn_wedge",
     }
+
+
+# --- OB-03: the watchdog's two halves run on two different clocks ------------
+
+
+class _FakeServerClock:
+    """A controllable stand-in for the ``time`` module ``server`` reads.
+
+    Only the three calls the watchdog makes are driven (``sleep``/``time``/
+    ``monotonic``); everything else falls through to the real module. The TEST
+    HARNESS keeps the real clock — this module's own ``time`` is never patched —
+    so a simulated wall-clock jump cannot make the harness's own timeouts lie.
+    """
+
+    def __init__(self, *, wall: float, mono: float) -> None:
+        self.wall = wall
+        self.mono = mono
+        self.ticks = 0
+
+    def __getattr__(self, name):  # anything the watchdog does not drive stays real
+        return getattr(time, name)
+
+    def time(self) -> float:
+        return self.wall
+
+    def monotonic(self) -> float:
+        return self.mono
+
+    def sleep(self, _seconds: float) -> None:
+        self.ticks += 1
+        time.sleep(0.01)  # a REAL yield; the fake clock advances only when a test says so
+
+
+def _wait_until(predicate, budget: float = 6.0) -> None:
+    end = time.time() + budget  # real clock: the harness never rides the fake one
+    while not predicate() and time.time() < end:
+        time.sleep(0.01)
+
+
+def _stop_watchdog(stop: threading.Event) -> None:
+    """Set the token AND wait for the thread to leave the loop.
+
+    The watchdog re-reads the token only at the TOP of the loop, so an iteration
+    already in flight still completes its clock reads and checks. Returning before
+    that finishes would let it run against a torn-down monkeypatch — reading the
+    real ``time`` module against a fake liveness stamp — and emit a phantom alert
+    into whatever the next test has patched.
+    """
+    stop.set()
+    for thread in threading.enumerate():
+        if thread.name == "supervisor-liveness-watchdog":
+            thread.join(timeout=5)
+
+
+def _collect_alerts(monkeypatch, chat_id: int) -> list:
+    alerts: list = []
+
+    class _Bridge:
+        def send_message(self, cid, text, *a, **k):
+            alerts.append((cid, text, k))
+            return (True, "")
+
+    monkeypatch.setattr("supervisor.message_bus.get_bridge", lambda: _Bridge())
+    monkeypatch.setattr("supervisor.state.load_state", lambda: {"owner_chat_id": chat_id})
+    monkeypatch.setattr("supervisor.state.append_jsonl", lambda *a, **k: None)
+    return alerts
+
+
+def test_wall_clock_jump_neither_fabricates_nor_masks_a_supervisor_stall(monkeypatch):
+    """OB-03: the stall half is measured on ``time.monotonic()``.
+
+    The liveness tick and its comparison used to both be ``time.time()``, so an
+    ordinary wall-clock step — NTP correction, DST/timezone change, manual set, a
+    resumed VM — was indistinguishable from an unresponsive supervisor loop. Both
+    directions are pinned: a forward jump must not INVENT a stall, and a backward
+    jump must not MASK a real one.
+    """
+    import server
+    import supervisor.workers as w
+
+    monkeypatch.setenv("OUROBOROS_SUPERVISOR_LIVENESS_DEADLINE_SEC", "1")
+    monkeypatch.setattr(w, "_chat_agent", None)  # isolate the stall half
+    alerts = _collect_alerts(monkeypatch, 11)
+
+    boot_mono = 500.0
+    wall = 1_700_000_000.0
+    clock = _FakeServerClock(wall=wall, mono=boot_mono)
+    monkeypatch.setattr(server, "time", clock)
+    stop = threading.Event()  # local per-test token
+    try:
+        # The loop ticked "just now" on the monotonic clock — it is healthy.
+        server._start_supervisor_liveness_watchdog([boot_mono], stop)
+        # Now the wall clock steps an hour forward while the loop keeps ticking.
+        clock.wall = wall + 3600.0
+        _wait_until(lambda: clock.ticks >= 3)
+        assert alerts == [], "a wall-clock jump must not fabricate a supervisor stall"
+
+        # A genuine stall (100s of MONOTONIC silence) is still caught, and a
+        # backward wall step cannot hide it.
+        clock.wall = wall - 86_400.0
+        clock.mono = boot_mono + 100.0
+        _wait_until(lambda: alerts)
+    finally:
+        _stop_watchdog(stop)
+    assert len(alerts) == 1
+    assert alerts[0][0] == 11 and "stalled" in alerts[0][1]
+    assert alerts[0][2]["progress_meta"]["task_incident"] == "supervisor_loop_stall"
+
+
+def test_wedge_half_stays_on_the_wall_clock_under_a_monotonic_tick(monkeypatch):
+    """OB-03 regression: the wedge half must keep comparing WALL stamps.
+
+    ``agent._last_activity_ts`` is a ``time.time()`` stamp. Swapping the whole
+    watchdog to one monotonic ``now`` makes ``now - turn_ts`` a large NEGATIVE
+    number on any host whose uptime is shorter than the Unix epoch — i.e. every
+    host — so ``_chat_turn_wedged`` would answer False forever and this alert
+    would silently never fire again. That is the split this test defends.
+    """
+    import types
+
+    import server
+    import supervisor.workers as w
+
+    monkeypatch.setenv("OUROBOROS_SUPERVISOR_LIVENESS_DEADLINE_SEC", "1")
+    alerts = _collect_alerts(monkeypatch, 13)
+
+    wall = 1_700_000_000.0
+    clock = _FakeServerClock(wall=wall, mono=42.0)  # a freshly booted host
+    monkeypatch.setattr(server, "time", clock)
+    monkeypatch.setattr(w, "_chat_agent", types.SimpleNamespace(
+        _busy=True, _current_task_id="wedged-split", _last_activity_ts=wall - 100.0))
+    stop = threading.Event()  # local per-test token
+    try:
+        # Liveness tick == the current monotonic reading: the loop is HEALTHY.
+        server._start_supervisor_liveness_watchdog([clock.mono], stop)
+        _wait_until(lambda: alerts)
+    finally:
+        _stop_watchdog(stop)
+    assert alerts, "a wall-stale chat turn must still be detected under a monotonic tick"
+    assert "wedged" in alerts[0][1]
+    assert alerts[0][2]["task_id"] == "wedged-split"
+    assert not any("stalled" in a[1] for a in alerts)  # the healthy tick raised nothing


### PR DESCRIPTION
## Summary

Three fixes with one purpose: **the supervisor must neither stall on its own custody sweeps nor misreport stalls.** The reaper's per-row `ps` storms are the very stalls the wall-clock watchdog then phantom-reports; the three commits remove the cost, harden process identity across upgrades and reboots, and make the stall detector immune to clock jumps.

1. **Measure supervisor liveness on the monotonic clock** — the watchdog's stall half
   compared a wall-clock tick against a deadline, so an NTP step or laptop wake produced
   phantom stall alerts (or masked a real one). The tick and stall comparison move to
   `time.monotonic()`; the chat-turn wedge half keeps a wall `now_wall` because it
   compares agent wall timestamps. Owner stall alert unchanged.
2. **Read process start times from /proc first and boot-qualify them** — on Linux every
   fingerprint spawned `ps` (5s timeout) although `/proc` answers without a fork. New
   Linux tokens are `"<ticks>.<boot_id8>"` (boot-qualified; cross-boot pid/tick reuse
   cannot false-match); with an unreadable boot id the collision-free `ps` wall-clock
   token is preferred, and the separator-carrying `"<ticks>."` form is the disclosed
   last resort. Pre-upgrade ledger rows keep matching via a legacy comparator consulted
   only on mismatch. `process_command` is deliberately unchanged (its output feeds two
   durable cmd-hash stores).
3. **Use a cheap liveness check for current-generation session custody rows** — the
   reaper ran two `ps` per ledger row for the live session's own worker pool on every
   sweep, synchronously on the supervisor path (stalling the loop is exactly what the
   watchdog above then reports). Same-session session-scope rows now take a
   `pid_is_alive` check; dead leaders fall through to the full path so service-group
   evidence still applies; task/daemon/companion scopes unchanged.

Root causes were identified from a downstream production deployment; every fix here is
re-implemented independently against the current tree from the root cause.

## Scope

In scope:

- `server.py` (watchdog clocks), `ouroboros/platform_layer.py` (/proc-first,
  boot-qualified start tokens, legacy helper), `ouroboros/process_custody.py`
  (dual-format fingerprint matching, cheap same-session path) + their tests
  (`tests/test_ws3_wedge_resilience.py`, `tests/test_process_custody.py`) and the
  matching `docs/ARCHITECTURE.md` content updates in the owning commits.

Non-goals:

- No version-carrier changes (VERSION, pyproject version, uv.lock root, web/package.json,
  GATEWAY_CONTRACT_VERSION, README badge/history/links, ARCHITECTURE version header, tags).
- No change to `process_command` (its output feeds two durable cmd-hash stores).
- No change to task/daemon/companion reap semantics or the owner stall alert.

Known remaining costs (disclosed, deliberately out of scope):

- `live_kept_service_pids` still fingerprints per session-service entry on the
  cancel/hard-timeout path.
- A pre-change bare-tick ledger row cannot be resolved against a `ps` wall-clock live
  token (both occur only in already-rare fallback states; mismatch direction is
  prune-not-kill).

## Verification

- [x] Focused tests for the changed behavior pass.
- [x] The default local test suite passes (CI-order two-pass split) on this branch head.
- [x] Lint/static checks relevant to this change pass.

Commands and results (per-branch transcript attached as per-branch-gauntlet.log):

```text
.venv/bin/python -m ruff check . --select F                       -> exit 0
pytest tests/ -m "not serial and not integration and not browser
  and not ui_browser and not ui_browser_docker and not portable_detail
  and not skill_smoke and not size_ratchet" -n auto --dist loadscope
  --max-worker-restart=0 --timeout=300 --timeout-method=thread    -> exit 0
pytest tests/ -m "serial and ..." (same exclusions)               -> exit 0
scripts/regenerate_size_ratchet.py --check                        -> exit 0
OURO_SIZE_RATCHET_BASE_REF=<base> pytest -m size_ratchet          -> exit 0
git status --short                                                -> empty
```

New/extended tests run combined: tests/test_ws3_wedge_resilience.py + tests/test_process_custody.py — green; 1 expected darwin skip (Linux-only /proc shape test).

## Visual evidence

- [x] Not applicable; this PR has no visible UI change.

## Governance and documentation

- [x] I read `CONTRIBUTING.md`; for a substantive change I also read `BIBLE.md`,
      `docs/ARCHITECTURE.md`, `docs/DEVELOPMENT.md`, and `docs/CHECKLISTS.md` in full.
- [x] I updated tests and documentation where behavior or architecture changed.
- [x] I did not include secrets, local settings, runtime state, logs, caches, or
      generated build/review artifacts in the commit.
- [x] I did **not** bump `VERSION` or release-only version carriers.

## Review evidence

- Review status: PASS (multi-stage) — contributor packet: INCOMPLETE_MAINTAINER_TRUSTED_BASE_RERUN_REQUIRED (typed, by design: the diff carries its mandated docs/ARCHITECTURE.md content edit, and that file is review-substrate — the lane deterministically defers triad+scope to a maintainer trusted-base rerun, $0 spent)
- Authoring agent/context: Claude Code (Opus 5 orchestrator + per-fix Opus 5
  implementation subagents), separate stream worktrees.
- Separate review agent/context: per-commit adversarial reviews in fresh agent contexts
  (two rounds), a synthesis interference review over the combined seven-fix range
  (verdict: PASS), a codex CLI final review (gpt-5.5, xhigh), and
  `scripts/run_external_review.py --contributor` for this branch: packet attached (review-evidence.json + full-output.txt + review-packet.zip); hermetic test preflight ran green inside the lane's isolated checkout before the typed assembly refusal
- Reviewer model and effort: Opus 5 (adversarial/synthesis); gpt-5.5 @ xhigh (codex);
  contributor packet slots per its evidence json.
- Reviewed base SHA: 36bdbeb2
- Reviewed head SHA: 00784ba6
- Findings and disposition: every finding across all rounds verified against the code and
  fixed or rejected with recorded reasons; final rounds clean for the commits in this PR.
- Checks performed and coverage limitations: full CI-order local gauntlet on this branch
  head (above); darwin host — Linux-only /proc shape test relies on CI ubuntu; new POSIX-only tests are explicitly marked for the Windows serial lane.
- Full review output or artifact link: review-packet.zip + full-output.txt attached.
- If not run, reason: the contributor packet ran; its typed INCOMPLETE reason above is the documented outcome for substrate-touching diffs — final triad+scope belong to the maintainer's trusted-base rerun.

## Final checklist

- [x] The PR base branch is `ouroboros`.
- [x] The branch is based on a current `ouroboros` revision.
- [x] The PR is one coherent change and is ready for maintainer integration.
- [x] The description explains any limitations, follow-up work, or compatibility impact.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
