### PR TITLE
Fix OpenRouter application attribution

### DIFF
--- a/devtools/benchmarks/cybergym/cybergym_lifecycle.py
+++ b/devtools/benchmarks/cybergym/cybergym_lifecycle.py
@@ -59,6 +59,7 @@ from devtools.benchmarks.cybergym.cybergym_wire import (
     _unwrap_http_json,
     _unwrap_http_payload,
 )
+from ouroboros.openrouter_attribution import OPENROUTER_APP_HEADERS
 from devtools.benchmarks.cybergym.cybergym_docker import (
     _EXPECTED_MODEL,
     _GATEWAY_TASK_ID,
@@ -442,7 +443,8 @@ class _LifecycleMixin:
         }
         response = self.config.http_runner(
             "POST", self.config.provider_url, body=body,
-            headers={"Authorization": f"Bearer {key}"}, timeout=60,
+            headers={"Authorization": f"Bearer {key}", **OPENROUTER_APP_HEADERS},
+            timeout=60,
         )
         response = _unwrap_http_json(response, operation="provider probe")
         observed = str(response.get("model") or "").strip()

--- a/devtools/benchmarks/gaia/audit_leakage.py
+++ b/devtools/benchmarks/gaia/audit_leakage.py
@@ -51,7 +51,6 @@ if str(pathlib.Path(__file__).resolve().parents[3]) not in sys.path:
 
 # SSOT for leak-target hosts/URL/query patterns (shared with tests). See
 # leak_targets.py for the pattern-design constraints.
-from devtools.benchmarks.gaia.leak_targets import LEAK_QUERY_RE, LEAK_URL_RE  # noqa: E402
 # The solvers' SSOT prompt instructions are stripped from full-text traces before
 # scanning, so an echoed prompt cannot self-trip LEAK_QUERY_RE (the anti-leak text
 # names the answer-source concept; the format text contains "final answer").
@@ -60,6 +59,8 @@ from devtools.benchmarks.gaia.inspect_solver import (  # noqa: E402
     GAIA_EPISTEMIC_INSTRUCTION,
     GAIA_FORMAT_INSTRUCTION,
 )
+from devtools.benchmarks.gaia.leak_targets import LEAK_QUERY_RE, LEAK_URL_RE  # noqa: E402
+from ouroboros.openrouter_attribution import OPENROUTER_APP_HEADERS  # noqa: E402
 
 # Web-ish Ouroboros tools whose args/results can carry URLs or retrieved text.
 # Every network-capable tool that stays ENABLED in the bench profiles must be
@@ -342,8 +343,15 @@ def _judge(sample_id: str, gold: str, acts: list, model: str, api_key: str) -> d
     )
     body = json.dumps({"model": model, "messages": [{"role": "user", "content": prompt}],
                        "max_tokens": 200, "temperature": 0}).encode()
-    req = urllib.request.Request("https://openrouter.ai/api/v1/chat/completions", data=body,
-                                 headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"})
+    req = urllib.request.Request(
+        "https://openrouter.ai/api/v1/chat/completions",
+        data=body,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            **OPENROUTER_APP_HEADERS,
+        },
+    )
     try:
         with urllib.request.urlopen(req, timeout=90) as r:
             txt = json.load(r)["choices"][0]["message"]["content"]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2629,6 +2629,12 @@ never classified as a mask; `prepare_settings_for_persist()` applies the same
 top-level repair at the common writer boundary. Password, token, and MCP masks
 remain context-specific rather than sharing a suffix heuristic.
 
+`ouroboros/openrouter_attribution.py` is the application-identity SSOT for every
+first-party paid OpenRouter request, including runtime, review probes, and benchmark
+diagnostics. Its canonical public URL is the primary OpenRouter application id and
+`X-OpenRouter-Title` supplies the display name. A fork or another product must use
+its own URL rather than sharing this identity and competing to rename one app record.
+
 ### LLM output token budgets
 
 Ouroboros uses provider-specific names for the same output-token budget:

--- a/ouroboros/llm.py
+++ b/ouroboros/llm.py
@@ -14,7 +14,6 @@ import threading
 import time
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from ouroboros.provider_models import OPENROUTER_DEFAULTS, PROVIDER_PREFIXES, normalize_anthropic_model_id, normalize_model_identity, resolve_minimax_base_url
 from ouroboros.anthropic_native_custody import (
     anthropic_replay_scoped,
     custody_private_key,
@@ -24,6 +23,8 @@ from ouroboros.anthropic_native_custody import (
     retain_native_assistant_content,
     scrub_native_custody,
 )
+from ouroboros.openrouter_attribution import OPENROUTER_APP_HEADERS
+from ouroboros.provider_models import OPENROUTER_DEFAULTS, PROVIDER_PREFIXES, normalize_anthropic_model_id, normalize_model_identity, resolve_minimax_base_url
 from ouroboros.request_wire_recovery import (
     finalize_wire_response,
     note_provider_metadata_drop_fields,
@@ -1434,10 +1435,7 @@ class LLMClient:
             "usage_model": usage_model,
             "api_key": current_api_key,
             "base_url": "https://openrouter.ai/api/v1" if explicit_settings else self._base_url,
-            "default_headers": {
-                "HTTP-Referer": "https://ouroboros.local/",
-                "X-Title": "Ouroboros",
-            },
+            "default_headers": dict(OPENROUTER_APP_HEADERS),
             "supports_openrouter_extensions": True,
             "supports_generation_cost": True,
         }
@@ -4358,6 +4356,7 @@ def openrouter_web_search_server_tool(
     client_kwargs: Dict[str, Any] = dict(
         api_key=api_key,
         base_url="https://openrouter.ai/api/v1",
+        default_headers=dict(OPENROUTER_APP_HEADERS),
         max_retries=0,
     )
     if timeout is not None:

--- a/ouroboros/openrouter_attribution.py
+++ b/ouroboros/openrouter_attribution.py
@@ -1,0 +1,10 @@
+"""Canonical OpenRouter application attribution for Ouroboros traffic."""
+
+from __future__ import annotations
+
+OPENROUTER_APP_URL = "https://ouroboros-agent.ai/"
+OPENROUTER_APP_TITLE = "Ouroboros"
+OPENROUTER_APP_HEADERS = {
+    "HTTP-Referer": OPENROUTER_APP_URL,
+    "X-OpenRouter-Title": OPENROUTER_APP_TITLE,
+}

--- a/scripts/run_external_review.py
+++ b/scripts/run_external_review.py
@@ -53,6 +53,8 @@ DATA = pathlib.Path(
 if str(REPO) not in sys.path:
     sys.path.insert(0, str(REPO))
 
+from ouroboros.openrouter_attribution import OPENROUTER_APP_HEADERS  # noqa: E402
+
 # Release diffs touch protected core paths; only pro mode may stage them for
 # review. An explicit operator env value still wins.
 os.environ.setdefault("OUROBOROS_RUNTIME_MODE", "pro")
@@ -81,6 +83,7 @@ _REVIEW_SUBSTRATE_PATHS = frozenset({
     "ouroboros/context_budget.py",
     "ouroboros/deadline_utils.py",
     "ouroboros/llm.py",
+    "ouroboros/openrouter_attribution.py",
     "ouroboros/outcomes.py",
     "ouroboros/platform_layer.py",
     "ouroboros/pricing.py",
@@ -380,7 +383,7 @@ def _probe_model_for_key(token: str, model: str) -> tuple[bool, str]:
 
         response = httpx.post(
             "https://openrouter.ai/api/v1/chat/completions",
-            headers={"Authorization": f"Bearer {token}"},
+            headers={"Authorization": f"Bearer {token}", **OPENROUTER_APP_HEADERS},
             json={
                 "model": model,
                 "max_tokens": 1,

--- a/tests/test_cybergym_executor_wire.py
+++ b/tests/test_cybergym_executor_wire.py
@@ -51,6 +51,7 @@ def test_provider_probe_checks_exact_model_without_server_search(monkeypatch, tm
             return {"data": {"limit_remaining": 100}}
         assert method == "POST"
         captured["body"] = body
+        captured["headers"] = headers
         return {
             "id": "response-1",
             "model": "deepseek/deepseek-v4-flash-0731",
@@ -77,6 +78,11 @@ def test_provider_probe_checks_exact_model_without_server_search(monkeypatch, tm
 
     assert captured["body"]["messages"] == [{"role": "user", "content": "Reply with OK."}]
     assert "tools" not in captured["body"]
+    from ouroboros.openrouter_attribution import OPENROUTER_APP_HEADERS
+
+    assert {
+        key: captured["headers"][key] for key in OPENROUTER_APP_HEADERS
+    } == OPENROUTER_APP_HEADERS
     assert executor.provider_observation["observed_model"] == (
         "deepseek/deepseek-v4-flash-0731"
     )

--- a/tests/test_external_review_script.py
+++ b/tests/test_external_review_script.py
@@ -48,6 +48,7 @@ def test_contributor_trust_boundary_covers_functional_review_dependencies():
         "ouroboros/delegate_output.py",
         "ouroboros/gateways/claudexor.py",
         "ouroboros/outcomes.py",
+        "ouroboros/openrouter_attribution.py",
         "ouroboros/platform_layer.py",
         "ouroboros/pricing.py",
         # The v6.87.21 seam split moved route vocabulary, transport dispatch and

--- a/tests/test_llm_provider_routing.py
+++ b/tests/test_llm_provider_routing.py
@@ -1,5 +1,17 @@
 import pytest
+
 from ouroboros.llm import LLMClient
+from ouroboros.openrouter_attribution import OPENROUTER_APP_HEADERS
+
+
+def test_resolve_openrouter_target_uses_canonical_app_attribution():
+    target = LLMClient()._resolve_remote_target("openai/gpt-5.6-sol")
+
+    assert OPENROUTER_APP_HEADERS == {
+        "HTTP-Referer": "https://ouroboros-agent.ai/",
+        "X-OpenRouter-Title": "Ouroboros",
+    }
+    assert target["default_headers"] == OPENROUTER_APP_HEADERS
 
 
 def test_resolve_openai_target(monkeypatch):

--- a/tests/test_llm_supported_parameters.py
+++ b/tests/test_llm_supported_parameters.py
@@ -353,6 +353,9 @@ class TestSupportedParametersFilter:
             "type": "openrouter:web_search",
             "parameters": {"search_context_size": "medium", "max_total_results": 10},
         }]
+        from ouroboros.openrouter_attribution import OPENROUTER_APP_HEADERS
+
+        assert captured["client"]["default_headers"] == OPENROUTER_APP_HEADERS
 
     def test_parameter_rejection_learns_sampling_strip_without_version_gate(self, monkeypatch):
         from ouroboros.llm import LLMClient

--- a/tests/test_openrouter_attribution.py
+++ b/tests/test_openrouter_attribution.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import urllib.request
+
+from ouroboros.openrouter_attribution import OPENROUTER_APP_HEADERS
+from scripts.run_external_review import _probe_model_for_key
+
+
+def test_external_review_probe_uses_canonical_app_attribution(monkeypatch):
+    import httpx
+
+    captured = {}
+
+    class Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"choices": [{"message": {"content": "pong"}}]}
+
+    def post(_url, **kwargs):
+        captured.update(kwargs)
+        return Response()
+
+    monkeypatch.setattr(httpx, "post", post)
+
+    assert _probe_model_for_key("secret", "openai/gpt-5.6-sol")[0] is True
+    assert {
+        key: captured["headers"][key] for key in OPENROUTER_APP_HEADERS
+    } == OPENROUTER_APP_HEADERS
+
+
+def test_gaia_judge_uses_canonical_app_attribution(monkeypatch):
+    import devtools.benchmarks.gaia.audit_leakage as audit
+
+    captured = {}
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return b'{"choices":[{"message":{"content":"{\\"verdict\\":\\"clean\\",\\"rationale\\":\\"ok\\"}"}}]}'
+
+    def urlopen(req, timeout=0):
+        captured["headers"] = req.headers
+        return Response()
+
+    monkeypatch.setattr(urllib.request, "urlopen", urlopen)
+
+    result = audit._judge("sample", "answer", [], "openai/gpt-5.6-luna", "secret")
+    assert result["verdict"] == "clean"
+    actual_headers = {key.lower(): value for key, value in captured["headers"].items()}
+    assert all(
+        actual_headers.get(key.lower()) == value
+        for key, value in OPENROUTER_APP_HEADERS.items()
+    )


### PR DESCRIPTION
OpenRouter application attribution was shared with the Hope fork, so Hope traffic could relabel Ouroboros traffic in OpenRouter analytics even though the API keys were separate. This PR adds one Ouroboros-owned attribution source and routes the main LLM client, server-side web search, external-review probe, GAIA judge, and CyberGym probe through it.

The change is intentionally narrow. It does not change keys, account ownership, provider routing, model selection, prices, budgets, or Hope code. All release/version carriers remain byte-identical to the ouroboros base; maintainers can assign the landing version.

Verification on base a66405a023a9d488e1edf0f957543ec6f1145c9c and head 9a20df6a63f55fde177d3bd972016c17d9f13b47: the five focused pytest files passed with 120 tests and producer exit code 0 under an isolated data root. Ruff F checks, py_compile, regenerate_size_ratchet.py --check, git diff --check, the version-carrier comparison, and clean-worktree checks also passed with exit code 0. The default full suite was NOT_RUN because broad lifecycle tests can touch process-global runtime state in this shared live workspace; CI remains the full-matrix authority.

The frozen range was reviewed independently through Claudexor. Claude Code claude-opus-5, run run-3e3c8593a5ee on profile claude-default, returned {"findings":[]}. Cursor cursor-grok-4.6-high, observed as Cursor Grok 4.6 High in run run-ad764ece701f on profile koshakcot, returned {"findings":[]}. Antigravity gemini-3.7-flash-high, run run-96f108fdbbb2 on profile anton-razzhigaev, returned {"findings":[]}. All three successful runs were readonly, used the requested model/profile, had durable settlement, and reported no tool errors. Two earlier Antigravity attempts ended before producing a review, first because readonly denied a git command and then because its long-file pager requested an offset past EOF; the same model and profile then completed against a hash-bound chunked evidence pack containing the full governance docs, checklist, diff, touched files, and OpenRouter search report.

Coverage limitation: no live paid OpenRouter request was sent. Header propagation is verified with stubbed request/client boundaries. Opus also checked the current OpenRouter header name through web search; Cursor and Gemini reviewed repository evidence only.
