### PR TITLE
Show serving routes in model catalog labels

### DIFF
--- a/ouroboros/gateway/models.py
+++ b/ouroboros/gateway/models.py
@@ -60,14 +60,15 @@ def _build_model_catalog_entry(
 ) -> dict[str, str]:
     raw_id = str(model_id or "").strip()
     name = str(display_name or "").strip() or raw_id
+    source_label = source or provider_label
     return {
         "provider_id": provider_id,
         "provider": provider_label,
-        "source": source or provider_label,
+        "source": source_label,
         "id": raw_id,
         "name": name,
         "value": _tagged_model_value(provider_id, raw_id),
-        "label": f"{provider_label} · {name}",
+        "label": f"{source_label} · {name}",
     }
 
 
@@ -394,7 +395,7 @@ async def api_model_catalog(_request: Request) -> JSONResponse:
             seen_values.add(value)
             items.append(item)
 
-    items.sort(key=lambda item: (item.get("provider", "").lower(), item.get("label", "").lower()))
+    items.sort(key=lambda item: (item.get("provider", "").lower(), item.get("name", "").lower()))
     return JSONResponse({
         "items": items,
         "errors": errors,

--- a/tests/test_model_catalog_api.py
+++ b/tests/test_model_catalog_api.py
@@ -31,7 +31,8 @@ def test_model_catalog_tags_provider_values(monkeypatch):
 
     async def fake_openrouter(_client, _api_key):
         return [model_catalog_api._build_model_catalog_entry(
-            "openrouter", "Anthropic", "anthropic/claude-opus", "Claude Opus", source="OpenRouter"
+            "openrouter", "Anthropic", "anthropic/claude-sonnet-4-6", "Claude Sonnet 4.6",
+            source="OpenRouter",
         )]
 
     async def fake_anthropic(_client, _api_key):
@@ -58,9 +59,10 @@ def test_model_catalog_tags_provider_values(monkeypatch):
 
     response = asyncio.run(model_catalog_api.api_model_catalog(None))
     payload = json.loads(response.body.decode("utf-8"))
-    values = {item["value"] for item in payload["items"]}
+    items_by_value = {item["value"]: item for item in payload["items"]}
+    values = set(items_by_value)
 
-    assert "anthropic/claude-opus" in values
+    assert "anthropic/claude-sonnet-4-6" in values
     assert "openai::gpt-4.1" in values
     assert "anthropic::claude-sonnet-4-6" in values
     assert "openai-compatible::compatible-pro" in values
@@ -70,6 +72,19 @@ def test_model_catalog_tags_provider_values(monkeypatch):
     # the region host), so the fake returns exactly one model for it.
     assert "minimax::MiniMax-M3" in values
     assert payload["errors"] == []
+
+    openrouter_item = items_by_value["anthropic/claude-sonnet-4-6"]
+    direct_item = items_by_value["anthropic::claude-sonnet-4-6"]
+    assert openrouter_item["source"] == "OpenRouter"
+    assert openrouter_item["label"] == "OpenRouter · Claude Sonnet 4.6"
+    assert direct_item["source"] == "Anthropic"
+    assert direct_item["label"] == "Anthropic · Claude Sonnet 4.6"
+    assert openrouter_item["label"] != direct_item["label"]
+    assert all(item["label"] == f'{item["source"]} · {item["name"]}' for item in payload["items"])
+    assert [
+        item["value"] for item in payload["items"]
+        if item["provider"] == "Anthropic" and item["name"] == "Claude Sonnet 4.6"
+    ] == ["anthropic/claude-sonnet-4-6", "anthropic::claude-sonnet-4-6"]
 
 
 def test_model_catalog_returns_errors_nonfatally(monkeypatch):


### PR DESCRIPTION
Model suggestions now show their actual serving route using the catalog’s existing source field. OpenRouter models are labeled “OpenRouter · …”, while direct Anthropic models are labeled “Anthropic · …”; routed model values and slash/double-colon dispatch stay unchanged.

The shared catalog-entry builder applies this consistently to every current catalog provider and future producers using the same source field. Sorting remains publisher/name based, preserving the existing order and stable ties.

The endpoint regression covers the same Anthropic model through OpenRouter and direct Anthropic, exact labels, unchanged routed values, the shared source/name invariant, and stable ordering. Focused tests, the full isolated pytest lanes, repo-wide Ruff F, and a live Settings picker check pass.