### PR TITLE
Supervisor process custody: boot-qualified fingerprints, downgrade-safe token pair, one monotonic clock

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -345,26 +345,36 @@ server.py (Starlette+uvicorn) ← HTTP + WebSocket on configurable host:port (de
       the reaper (server startup + 10-min supervisor tick) kills entries whose
       generation/task owner is gone, matching by STRICT fingerprint only —
       never by command-line class, so dev and packaged instances can coexist.
-      On Linux `start_time` is read from `/proc` and boot-qualified
-      (`"<ticks>.<boot8>"`, since boot-relative ticks recur across reboots and a
-      bare tick plus a recycled pid is a real collision). The mint order is
-      boot-qualified first; then, when the boot id is unreadable, the `ps`
-      wall-clock token, which cannot collide across boots; and only once `ps` has
-      ALSO failed, `"<ticks>."` as a disclosed last resort (two of THOSE from
-      different boots do string-match, which is why they are last, not first). A
-      post-change token is therefore never string-equal to a pre-change bare
-      tick: it is boot-qualified, a `ps` string, or separator-carrying. The
-      minted form changes if the boot id starts or stops being readable
-      mid-generation, so a row recorded across that transition mismatches its own
-      live process — safe, since a mismatch prunes and never kills. The match
-      accepts both Linux representations for pre-existing rows — current first,
-      and the pre-upgrade `ps -o lstart=` spelling (or its rare bare-tick
-      fallback) only once that mismatched; the `ps` spelling is re-derived only
-      when the current token is `/proc`-minted (elsewhere it would be the same
-      bytes again), while a bare-tick row resolves against `/proc` directly in
-      every mint order, so no legacy row shape is orphaned on a `/proc` host.
-      An upgrade therefore orphans no ledger row and the reaper's hot path never
-      pays for a second subprocess.
+      The fingerprint's start time is a DOWNGRADE-SAFE pair: the unversioned
+      `start_time` field keeps the legacy `ps -o lstart=` spelling an N−1
+      reader still compares correctly (a rollback that met an unknown token
+      here would mismatch every row and prune it WITHOUT a kill, orphaning the
+      process forever), while the versioned `start_time_boot` sibling — which
+      the current reader prefers — carries the Linux `/proc` boot-qualified
+      token `"<ticks>.<boot_hex>"` (boot-relative ticks recur across reboots,
+      and a bare tick plus a recycled pid is a real collision). The mint order
+      for the boot sibling is boot-qualified first; then, when the boot id is
+      unreadable, the `ps` wall-clock token (identical to the legacy field, so
+      the sibling is omitted); and only once `ps` has ALSO failed, `"<ticks>."`
+      as a disclosed last resort (two of THOSE from different boots do
+      string-match, which is why they are last, not first). One `ps` is paid
+      per SPAWN for the legacy field (a host without `/proc`, or with an
+      unreadable boot id, pays it twice — the preferred-token mint re-derives
+      the same spelling); the sweep's hot
+      path stays subprocess-free, and a SIBLING-FREE mismatched row falls back
+      to one `ps` comparison of the legacy spelling before pruning, so a
+      mid-generation boot-id readability change never prunes a live owned row.
+      A row that DOES carry a boot sibling is judged by boot evidence alone: a
+      mismatched sibling is positive proof of another boot and prunes without
+      consulting the legacy spelling (whose `ps`-less degradation to bare
+      ticks would otherwise re-qualify a cross-boot recycled pid). A recorded
+      BARE tick (the pre-change ps-failed fallback) never authorizes a kill
+      when any boot evidence contradicts it: on a `ps`-capable host it
+      compares against the `ps` spelling, fails, and is pruned — the safe
+      direction — while the one host class that ever mints bare ticks (no
+      usable `ps`) still resolves PRE-UPGRADE sibling-free rows through the
+      legacy helper's own tick fallback (the disclosed one-migration-window
+      residual on that class, alongside the `"<ticks>."` cross-boot twin).
       Current-generation session processes take a cheap liveness check instead
       (the cheap path only ever keeps: an alive-but-recycled same-session pid is
       retained one generation and pruned by the next generation's full

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -345,6 +345,26 @@ server.py (Starlette+uvicorn) ← HTTP + WebSocket on configurable host:port (de
       the reaper (server startup + 10-min supervisor tick) kills entries whose
       generation/task owner is gone, matching by STRICT fingerprint only —
       never by command-line class, so dev and packaged instances can coexist.
+      On Linux `start_time` is read from `/proc` and boot-qualified
+      (`"<ticks>.<boot8>"`, since boot-relative ticks recur across reboots and a
+      bare tick plus a recycled pid is a real collision). The mint order is
+      boot-qualified first; then, when the boot id is unreadable, the `ps`
+      wall-clock token, which cannot collide across boots; and only once `ps` has
+      ALSO failed, `"<ticks>."` as a disclosed last resort (two of THOSE from
+      different boots do string-match, which is why they are last, not first). A
+      post-change token is therefore never string-equal to a pre-change bare
+      tick: it is boot-qualified, a `ps` string, or separator-carrying. The
+      minted form changes if the boot id starts or stops being readable
+      mid-generation, so a row recorded across that transition mismatches its own
+      live process — safe, since a mismatch prunes and never kills. The match
+      accepts both Linux representations for pre-existing rows — current first,
+      and the pre-upgrade `ps -o lstart=` spelling (or its rare bare-tick
+      fallback) only once that mismatched; the `ps` spelling is re-derived only
+      when the current token is `/proc`-minted (elsewhere it would be the same
+      bytes again), while a bare-tick row resolves against `/proc` directly in
+      every mint order, so no legacy row shape is orphaned on a `/proc` host.
+      An upgrade therefore orphans no ledger row and the reaper's hot path never
+      pays for a second subprocess.
       Genuine `daemon` entries are kept; skill companions (daemon scope,
       `purpose companion:<skill>:<name>`) are the exception (v6.36.2) — reaped on
       owner-uninstall or a foreign generation, **log-only by default**

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -365,6 +365,12 @@ server.py (Starlette+uvicorn) ← HTTP + WebSocket on configurable host:port (de
       every mint order, so no legacy row shape is orphaned on a `/proc` host.
       An upgrade therefore orphans no ledger row and the reaper's hot path never
       pays for a second subprocess.
+      Current-generation session processes take a cheap liveness check instead
+      (the cheap path only ever keeps: an alive-but-recycled same-session pid is
+      retained one generation and pruned by the next generation's full
+      fingerprint check, never killed); full fingerprints remain for
+      stale/foreign records, and a DEAD pid still falls through to the
+      service-group evidence rather than being pruned on the spot.
       Genuine `daemon` entries are kept; skill companions (daemon scope,
       `purpose companion:<skill>:<name>`) are the exception (v6.36.2) — reaped on
       owner-uninstall or a foreign generation, **log-only by default**

--- a/ouroboros/agent.py
+++ b/ouroboros/agent.py
@@ -469,8 +469,9 @@ class OuroborosAgent:
 
         self._incoming_messages: queue.Queue = queue.Queue()
         self._busy = False
-        # WS3 (v6.34.0): wall-clock of the last liveness tick for the CURRENT turn
-        # (set at turn start, refreshed by the heartbeat loop, cleared when idle). The
+        # WS3 (v6.34.0): MONOTONIC stamp of the last liveness tick for the CURRENT turn
+        # (set at turn start, refreshed by the heartbeat loop, cleared when idle) — the
+        # watchdog compares it as an elapsed gap, so a wall-clock jump must not touch it. The
         # supervisor liveness watchdog reads it directly to spot a wedged chat turn —
         # the direct turn is in-process, not a worker RUNNING entry, so its heartbeat
         # is invisible to the worker queue.
@@ -1439,14 +1440,14 @@ class OuroborosAgent:
         # WS3: stamp liveness at turn start and on every tick, INDEPENDENT of the event
         # queue, so the watchdog can spot a wedged in-process chat turn even when this
         # agent has no event queue (the direct chat lane).
-        self._last_activity_ts = time.time()
+        self._last_activity_ts = time.monotonic()
         emit = self._event_queue is not None
         if emit:
             self._emit_task_heartbeat(task_id, "start")
 
         def _loop() -> None:
             while not stop.wait(interval):
-                self._last_activity_ts = time.time()
+                self._last_activity_ts = time.monotonic()
                 if emit:
                     self._emit_task_heartbeat(task_id, "running")
 

--- a/ouroboros/platform_layer.py
+++ b/ouroboros/platform_layer.py
@@ -41,9 +41,8 @@ def executable_name_candidates(name: str) -> List[str]:
 def local_zoneinfo():
     """Best-effort DST-aware local timezone.
 
-    ``astimezone().tzinfo`` is a *fixed* offset that drifts across DST; resolve the IANA
-    zone (``TZ`` or ``/etc/localtime``), falling back to the fixed offset.
-    """
+    ``astimezone().tzinfo`` is a *fixed* offset that drifts across DST; resolve the IANA zone (``TZ`` or
+    ``/etc/localtime``), falling back to the fixed offset."""
     import datetime
     from zoneinfo import ZoneInfo
 
@@ -136,12 +135,11 @@ def bootstrap_process_path() -> list[str]:
 
 
 def scrub_repo_from_pythonpath(env: dict[str, str], repo_dir: "str | pathlib.Path | None") -> dict[str, str]:
-    """Return a copy of *env* with any ``PYTHONPATH`` entry resolving to the Ouroboros
-    system repo dir removed.
+    """Return a copy of *env* with any ``PYTHONPATH`` entry resolving to the Ouroboros system repo dir removed.
 
-    An EXTERNAL-workspace command inherits the worker's ``PYTHONPATH`` repo entry, which
-    makes the target's ``import web``/``server``/``ouroboros`` resolve to OUROBOROS's modules.
-    Dropping ONLY the repo entry isolates the target; no-op without one."""
+    An EXTERNAL-workspace command inherits the worker's ``PYTHONPATH`` repo entry, which makes the target's
+    ``import web``/``server``/``ouroboros`` resolve to OUROBOROS's modules. Dropping ONLY the repo entry isolates
+    the target; no-op without one."""
     out = dict(env)
     raw = out.get("PYTHONPATH", "")
     if not raw or not repo_dir:
@@ -460,9 +458,8 @@ def pid_is_alive(pid: int) -> bool:
 def pid_provably_gone(pid: int) -> bool:
     """True only when the OS positively answers that ``pid`` does not exist.
 
-    Stricter than ``not pid_is_alive``: the POSIX branch there folds EVERY
-    OSError into 'dead', but EPERM means the process EXISTS and merely refuses
-    our signal — a caller deciding whether a killed process is really gone
+    Stricter than ``not pid_is_alive``: the POSIX branch there folds EVERY OSError into 'dead', but EPERM means
+    the process EXISTS and merely refuses our signal — a caller deciding whether a killed process is really gone
     must treat that (and anything else undeterminable) as still present."""
     if pid <= 0:
         return True
@@ -573,12 +570,10 @@ def _win32_unlock(fd: int) -> None:
 def kill_process_tree(proc: subprocess.Popen) -> None:
     """Force-kill a subprocess and its entire process tree.
 
-    On POSIX the immediate process group is SIGKILLed first, then descendants that
-    escaped into their own session/group are swept by PID — without that sweep a
-    cancelled child which spawned grandchildren in new groups leaks orphans.
-    Descendants are collected BEFORE the kill: once the parent dies its children are
-    reparented and the ppid links disappear.
-    """
+    On POSIX the immediate process group is SIGKILLed first, then descendants that escaped into their own
+    session/group are swept by PID — without that sweep a cancelled child which spawned grandchildren in new
+    groups leaks orphans. Descendants are collected BEFORE the kill: once the parent dies its children are
+    reparented and the ppid links disappear."""
     pid = proc.pid
     if IS_WINDOWS:
         try:
@@ -675,21 +670,44 @@ def current_process_group_id() -> int:
         return 0
 
 
+_BOOT_ID = ""  # first 8 hex of the /proc boot id; empty until a successful read, then latched
+
+
 def process_start_time(pid: int) -> str:
     """Best-effort stable start-time token for (pid, start_time) fingerprints.
 
-    A bare pid is not an identity — the kernel reuses it. ``(pid, start_time)`` is, which is what
-    lets a caller refuse to signal a pid it merely used to own. POSIX uses ``ps -o lstart=``,
-    falling back to the same /proc field the containment scan dates candidates by, so the
-    fingerprint stays real on an image with no usable ``ps``. Windows returns "" (callers degrade
-    to pid liveness), as does a pid that is already gone."""
-    if pid <= 0:
+    A bare pid is not an identity (kernels reuse pids) and boot-relative ticks RECUR across reboots, so a bare
+    tick + a recycled pid + the same command line is a real collision; refusing that kill is the job. Linux mints
+    IN THIS ORDER: ``"<ticks>.<boot8>"`` when the boot id is readable (no subprocess); else the ``ps`` wall-clock
+    token, which cannot collide across boots; and only once ``ps`` has ALSO failed, ``"<ticks>."`` as a disclosed
+    last resort — two of THOSE from different boots do string-match, hence last, not first. No ``/proc``: legacy
+    throughout; Windows and a dead pid return "". A post-change token is never string-equal to a bare pre-change
+    tick: it is boot-qualified, a ``ps`` string, or separator-carrying. Disclosed: the FORM changes if the boot id
+    starts or stops being readable mid-generation, so a row recorded across it mismatches its own live process —
+    safe: it prunes, never kills, and the cheap reap path skips live rows."""
+    global _BOOT_ID
+    if pid <= 0 or os.name == "nt":
         return ""
-    if os.name == "nt":
+    if not (ticks := _proc_start_ticks(pid)):
+        return process_start_time_legacy(pid)  # no /proc here (macOS, BSD): ps is the only source
+    if not _BOOT_ID:  # a failed read is transient: retry next call, never downgrade the generation
+        try:
+            _BOOT_ID = pathlib.Path("/proc/sys/kernel/random/boot_id").read_text().strip().replace("-", "")[:8]
+        except (OSError, ValueError):  # matches _proc_start_ticks; an escapee would abort a custody sweep
+            pass
+    if _BOOT_ID:
+        return f"{ticks}.{_BOOT_ID}"
+    # legacy degrades to str(ticks) when ps ALSO failed; only then is the separator form the best we have.
+    return legacy if (legacy := process_start_time_legacy(pid)) and legacy != str(ticks) else f"{ticks}."
+
+
+def process_start_time_legacy(pid: int) -> str:
+    """The historical ``ps -o lstart=`` token (bare ``/proc`` ticks when ``ps`` fails); the compatibility half of the
+    dual-format fingerprint match, consulted only after a boot-qualified current token failed to match."""
+    if pid <= 0 or os.name == "nt":
         return ""
     try:
-        out = subprocess.run(["ps", "-o", "lstart=", "-p", str(pid)],
-                             capture_output=True, text=True, timeout=5)
+        out = subprocess.run(["ps", "-o", "lstart=", "-p", str(pid)], capture_output=True, text=True, timeout=5)
         text = (out.stdout or "").strip()
         if out.returncode == 0 and text:
             return text
@@ -742,10 +760,9 @@ def force_kill_pid(pid: int) -> None:
 def kill_pid_tree(pid: int, exclude_pids: "set[int] | None" = None) -> None:
     """Force-kill a PID tree recursively.
 
-    ``exclude_pids`` are spared along with their own descendants, keeping
-    ``service_teardown=keep`` services reachable for a verifier when a worker is
-    force-killed; spared children reparent to init and fall to the custody reaper.
-    """
+    ``exclude_pids`` are spared along with their own descendants, keeping ``service_teardown=keep`` services
+    reachable for a verifier when a worker is force-killed; spared children reparent to init and fall to the
+    custody reaper."""
     exclude = {int(p) for p in (exclude_pids or set())}
     if IS_WINDOWS:
         # exclude_pids is a POSIX-only nicety: descendant enumeration relies on
@@ -952,24 +969,19 @@ def interpreter_is_embedded(interpreter: str) -> bool:
 def pip_install_target_args(interpreter: str) -> List[str]:
     """Extra pip flags so an install never writes INSIDE the packaged bundle.
 
-    The embedded interpreter lives in the signed bundle, so its own
-    ``site-packages`` is the wrong install target: writing there breaks the code
-    signature and fails outright on a read-only install. ``--user`` redirects to
-    the user site under ``PYTHONUSERBASE`` (set by
-    ``launcher_bootstrap.embedded_python_env`` for every process that runs the
-    embedded interpreter). A non-embedded interpreter — a dev venv, a system
-    python — gets NO flag: ``--user`` is refused inside a virtualenv, so a blanket
-    flag would trade one broken install for another.
-    """
+    The embedded interpreter lives in the signed bundle, so its own ``site-packages`` is the wrong install target:
+    writing there breaks the code signature and fails outright on a read-only install. ``--user`` redirects to the
+    user site under ``PYTHONUSERBASE`` (set by ``launcher_bootstrap.embedded_python_env`` for every process that
+    runs the embedded interpreter). A non-embedded interpreter — a dev venv, a system python — gets NO flag:
+    ``--user`` is refused inside a virtualenv, so a blanket flag would trade one broken install for another."""
     return ["--user"] if interpreter_is_embedded(interpreter) else []
 
 
 def project_venv_python(project_root: pathlib.Path) -> str:
     """Return the executable for a valid project ``.venv`` on this platform.
 
-    Keep the lexical venv path (rather than resolving its symlink) so Python
-    discovers the adjacent ``pyvenv.cfg`` and activates the environment.
-    """
+    Keep the lexical venv path (rather than resolving its symlink) so Python discovers the adjacent ``pyvenv.cfg``
+    and activates the environment."""
     env_root = pathlib.Path(project_root) / ".venv"
     if not (env_root / "pyvenv.cfg").is_file():
         return ""
@@ -1051,13 +1063,10 @@ BUNDLE_DIR_ENV = "OUROBOROS_BUNDLE_DIR"
 def bundled_resource_ancestor_bases(executable: "str | pathlib.Path | None" = None) -> List[pathlib.Path]:
     """Bundle roots recoverable from an embedded interpreter path.
 
-    Managed updates replace the server checkout but not the frozen launcher.
-    Launchers predating ``OUROBOROS_BUNDLE_DIR`` still start the updated server
-    with ``.../Resources/python-standalone/...`` (macOS) or
-    ``.../_internal/python-standalone/...`` (portable builds).  The interpreter
-    path therefore remains a durable, cross-platform pointer to the old app's
-    resource root.
-    """
+    Managed updates replace the server checkout but not the frozen launcher. Launchers predating
+    ``OUROBOROS_BUNDLE_DIR`` still start the updated server with ``.../Resources/python-standalone/...`` (macOS)
+    or ``.../_internal/python-standalone/...`` (portable builds). The interpreter path therefore remains a
+    durable, cross-platform pointer to the old app's resource root."""
     try:
         start = pathlib.Path(executable or sys.executable).resolve()
     except (OSError, ValueError):
@@ -1080,17 +1089,13 @@ def bundled_resource_ancestor_bases(executable: "str | pathlib.Path | None" = No
 def bundled_resource_bases() -> List[pathlib.Path]:
     """Roots to search for a resource shipped INSIDE the packaged bundle.
 
-    SSOT for every bundled-payload lookup, because the process that consumes a
-    bundled payload is usually NOT the frozen launcher. In a packaged install the
-    launcher runs the server/CLI as a SEPARATE child of the embedded interpreter,
-    out of the launcher-managed repo under the data dir: that child has no
-    ``sys._MEIPASS`` and its ``__file__`` parent is the managed repo, so both
-    historical bases miss and every bundled payload silently reads as absent.
-    The launcher therefore hands the bundle root down by value in
-    ``OUROBOROS_BUNDLE_DIR`` and it is searched FIRST. The other two bases stay
-    for the frozen process itself and for the dev/source layout (payloads sit at
-    the repo root, two levels up from this module).
-    """
+    SSOT for every bundled-payload lookup, because the process that consumes a bundled payload is usually NOT the
+    frozen launcher. In a packaged install the launcher runs the server/CLI as a SEPARATE child of the embedded
+    interpreter, out of the launcher-managed repo under the data dir: that child has no ``sys._MEIPASS`` and its
+    ``__file__`` parent is the managed repo, so both historical bases miss and every bundled payload silently
+    reads as absent. The launcher therefore hands the bundle root down by value in ``OUROBOROS_BUNDLE_DIR`` and it
+    is searched FIRST. The other two bases stay for the frozen process itself and for the dev/source layout
+    (payloads sit at the repo root, two levels up from this module)."""
     bases: List[pathlib.Path] = []
     env_base = str(os.environ.get(BUNDLE_DIR_ENV) or "").strip()
     if env_base:
@@ -1129,11 +1134,9 @@ def _resolve_bundled_payload(candidates_for: Callable[[pathlib.Path], List[pathl
 def resolve_bundled_node() -> Optional[str]:
     """Return the path to the bundled, signed Node.js runtime if present.
 
-    The packaged app ships an official notarized node under ``node-standalone``
-    (re-signed under the hardened runtime by the build's signing pass). Prefer it
-    over a PATH (e.g. Homebrew) node, which macOS code-signing enforcement can
-    SIGKILL when launched from the packaged process tree.
-    """
+    The packaged app ships an official notarized node under ``node-standalone`` (re-signed under the hardened
+    runtime by the build's signing pass). Prefer it over a PATH (e.g. Homebrew) node, which macOS code-signing
+    enforcement can SIGKILL when launched from the packaged process tree."""
     return _resolve_bundled_payload(embedded_node_candidates)
 
 
@@ -1351,11 +1354,9 @@ def subprocess_new_group_kwargs() -> dict:
 
 
 def install_shutdown_signal_handlers(handler) -> None:
-    """Register ``handler`` for the signals that ask a console process to shut
-    down: SIGINT everywhere, SIGTERM on POSIX. The platform-specific signal
-    surface lives HERE, never in callers (checklist 15). The handler must only
-    set a flag/event — real teardown belongs on the caller's main thread, not
-    inside a signal frame."""
+    """Register ``handler`` for the signals that ask a console process to shut down: SIGINT everywhere, SIGTERM on
+    POSIX. The platform-specific signal surface lives HERE, never in callers (checklist 15). The handler must only
+    set a flag/event — real teardown belongs on the caller's main thread, not inside a signal frame."""
     signal.signal(signal.SIGINT, handler)
     if not IS_WINDOWS:
         signal.signal(signal.SIGTERM, handler)

--- a/ouroboros/platform_layer.py
+++ b/ouroboros/platform_layer.py
@@ -41,8 +41,9 @@ def executable_name_candidates(name: str) -> List[str]:
 def local_zoneinfo():
     """Best-effort DST-aware local timezone.
 
-    ``astimezone().tzinfo`` is a *fixed* offset that drifts across DST; resolve the IANA zone (``TZ`` or
-    ``/etc/localtime``), falling back to the fixed offset."""
+    ``astimezone().tzinfo`` is a *fixed* offset that drifts across DST; resolve the IANA
+    zone (``TZ`` or ``/etc/localtime``), falling back to the fixed offset.
+    """
     import datetime
     from zoneinfo import ZoneInfo
 
@@ -135,11 +136,12 @@ def bootstrap_process_path() -> list[str]:
 
 
 def scrub_repo_from_pythonpath(env: dict[str, str], repo_dir: "str | pathlib.Path | None") -> dict[str, str]:
-    """Return a copy of *env* with any ``PYTHONPATH`` entry resolving to the Ouroboros system repo dir removed.
+    """Return a copy of *env* with any ``PYTHONPATH`` entry resolving to the Ouroboros
+    system repo dir removed.
 
-    An EXTERNAL-workspace command inherits the worker's ``PYTHONPATH`` repo entry, which makes the target's
-    ``import web``/``server``/``ouroboros`` resolve to OUROBOROS's modules. Dropping ONLY the repo entry isolates
-    the target; no-op without one."""
+    An EXTERNAL-workspace command inherits the worker's ``PYTHONPATH`` repo entry, which
+    makes the target's ``import web``/``server``/``ouroboros`` resolve to OUROBOROS's modules.
+    Dropping ONLY the repo entry isolates the target; no-op without one."""
     out = dict(env)
     raw = out.get("PYTHONPATH", "")
     if not raw or not repo_dir:
@@ -458,8 +460,9 @@ def pid_is_alive(pid: int) -> bool:
 def pid_provably_gone(pid: int) -> bool:
     """True only when the OS positively answers that ``pid`` does not exist.
 
-    Stricter than ``not pid_is_alive``: the POSIX branch there folds EVERY OSError into 'dead', but EPERM means
-    the process EXISTS and merely refuses our signal — a caller deciding whether a killed process is really gone
+    Stricter than ``not pid_is_alive``: the POSIX branch there folds EVERY
+    OSError into 'dead', but EPERM means the process EXISTS and merely refuses
+    our signal — a caller deciding whether a killed process is really gone
     must treat that (and anything else undeterminable) as still present."""
     if pid <= 0:
         return True
@@ -570,10 +573,12 @@ def _win32_unlock(fd: int) -> None:
 def kill_process_tree(proc: subprocess.Popen) -> None:
     """Force-kill a subprocess and its entire process tree.
 
-    On POSIX the immediate process group is SIGKILLed first, then descendants that escaped into their own
-    session/group are swept by PID — without that sweep a cancelled child which spawned grandchildren in new
-    groups leaks orphans. Descendants are collected BEFORE the kill: once the parent dies its children are
-    reparented and the ppid links disappear."""
+    On POSIX the immediate process group is SIGKILLed first, then descendants that
+    escaped into their own session/group are swept by PID — without that sweep a
+    cancelled child which spawned grandchildren in new groups leaks orphans.
+    Descendants are collected BEFORE the kill: once the parent dies its children are
+    reparented and the ppid links disappear.
+    """
     pid = proc.pid
     if IS_WINDOWS:
         try:
@@ -670,21 +675,22 @@ def current_process_group_id() -> int:
         return 0
 
 
-_BOOT_ID = ""  # first 8 hex of the /proc boot id; empty until a successful read, then latched
+_BOOT_ID = ""  # full hex of the /proc boot id; empty until a successful read, then latched
 
 
 def process_start_time(pid: int) -> str:
     """Best-effort stable start-time token for (pid, start_time) fingerprints.
 
-    A bare pid is not an identity (kernels reuse pids) and boot-relative ticks RECUR across reboots, so a bare
-    tick + a recycled pid + the same command line is a real collision; refusing that kill is the job. Linux mints
-    IN THIS ORDER: ``"<ticks>.<boot8>"`` when the boot id is readable (no subprocess); else the ``ps`` wall-clock
-    token, which cannot collide across boots; and only once ``ps`` has ALSO failed, ``"<ticks>."`` as a disclosed
-    last resort — two of THOSE from different boots do string-match, hence last, not first. No ``/proc``: legacy
-    throughout; Windows and a dead pid return "". A post-change token is never string-equal to a bare pre-change
-    tick: it is boot-qualified, a ``ps`` string, or separator-carrying. Disclosed: the FORM changes if the boot id
-    starts or stops being readable mid-generation, so a row recorded across it mismatches its own live process —
-    safe: it prunes, never kills, and the cheap reap path skips live rows."""
+    A bare pid is not an identity (kernels reuse pids) and boot-relative ticks RECUR across
+    reboots, so a bare tick + a recycled pid + the same command line is a real collision;
+    refusing that kill is the job. Linux mints IN THIS ORDER: ``"<ticks>.<boot_hex>"`` when the
+    boot id is readable (no subprocess); else the ``ps`` wall-clock token, which does not recur
+    across boots in practice; and only once ``ps`` has ALSO failed, ``"<ticks>."`` as a
+    disclosed last resort — two of THOSE from different boots do string-match, hence last, not
+    first. No ``/proc``: legacy throughout; Windows and a dead pid return "". Disclosed: the
+    FORM changes if the boot id starts or stops being readable mid-generation, so a row
+    recorded across it can mismatch its own live process — safe: it prunes, never kills, and
+    the cheap reap path skips live rows."""
     global _BOOT_ID
     if pid <= 0 or os.name == "nt":
         return ""
@@ -692,7 +698,7 @@ def process_start_time(pid: int) -> str:
         return process_start_time_legacy(pid)  # no /proc here (macOS, BSD): ps is the only source
     if not _BOOT_ID:  # a failed read is transient: retry next call, never downgrade the generation
         try:
-            _BOOT_ID = pathlib.Path("/proc/sys/kernel/random/boot_id").read_text().strip().replace("-", "")[:8]
+            _BOOT_ID = pathlib.Path("/proc/sys/kernel/random/boot_id").read_text().strip().replace("-", "")
         except (OSError, ValueError):  # matches _proc_start_ticks; an escapee would abort a custody sweep
             pass
     if _BOOT_ID:
@@ -702,12 +708,15 @@ def process_start_time(pid: int) -> str:
 
 
 def process_start_time_legacy(pid: int) -> str:
-    """The historical ``ps -o lstart=`` token (bare ``/proc`` ticks when ``ps`` fails); the compatibility half of the
-    dual-format fingerprint match, consulted only after a boot-qualified current token failed to match."""
+    """The historical ``ps -o lstart=`` token (bare ``/proc`` ticks when ``ps`` fails). Two jobs:
+    the DOWNGRADE-SAFE spelling the custody ledger keeps writing into ``fingerprint.start_time``
+    (an N−1 reader understands it), and the compatibility comparison a boot-qualified current
+    token falls back to (see ``process_custody._legacy_start_matches``)."""
     if pid <= 0 or os.name == "nt":
         return ""
     try:
-        out = subprocess.run(["ps", "-o", "lstart=", "-p", str(pid)], capture_output=True, text=True, timeout=5)
+        out = subprocess.run(["ps", "-o", "lstart=", "-p", str(pid)],
+                             capture_output=True, text=True, timeout=5)
         text = (out.stdout or "").strip()
         if out.returncode == 0 and text:
             return text
@@ -760,9 +769,10 @@ def force_kill_pid(pid: int) -> None:
 def kill_pid_tree(pid: int, exclude_pids: "set[int] | None" = None) -> None:
     """Force-kill a PID tree recursively.
 
-    ``exclude_pids`` are spared along with their own descendants, keeping ``service_teardown=keep`` services
-    reachable for a verifier when a worker is force-killed; spared children reparent to init and fall to the
-    custody reaper."""
+    ``exclude_pids`` are spared along with their own descendants, keeping
+    ``service_teardown=keep`` services reachable for a verifier when a worker is
+    force-killed; spared children reparent to init and fall to the custody reaper.
+    """
     exclude = {int(p) for p in (exclude_pids or set())}
     if IS_WINDOWS:
         # exclude_pids is a POSIX-only nicety: descendant enumeration relies on
@@ -969,19 +979,24 @@ def interpreter_is_embedded(interpreter: str) -> bool:
 def pip_install_target_args(interpreter: str) -> List[str]:
     """Extra pip flags so an install never writes INSIDE the packaged bundle.
 
-    The embedded interpreter lives in the signed bundle, so its own ``site-packages`` is the wrong install target:
-    writing there breaks the code signature and fails outright on a read-only install. ``--user`` redirects to the
-    user site under ``PYTHONUSERBASE`` (set by ``launcher_bootstrap.embedded_python_env`` for every process that
-    runs the embedded interpreter). A non-embedded interpreter — a dev venv, a system python — gets NO flag:
-    ``--user`` is refused inside a virtualenv, so a blanket flag would trade one broken install for another."""
+    The embedded interpreter lives in the signed bundle, so its own
+    ``site-packages`` is the wrong install target: writing there breaks the code
+    signature and fails outright on a read-only install. ``--user`` redirects to
+    the user site under ``PYTHONUSERBASE`` (set by
+    ``launcher_bootstrap.embedded_python_env`` for every process that runs the
+    embedded interpreter). A non-embedded interpreter — a dev venv, a system
+    python — gets NO flag: ``--user`` is refused inside a virtualenv, so a blanket
+    flag would trade one broken install for another.
+    """
     return ["--user"] if interpreter_is_embedded(interpreter) else []
 
 
 def project_venv_python(project_root: pathlib.Path) -> str:
     """Return the executable for a valid project ``.venv`` on this platform.
 
-    Keep the lexical venv path (rather than resolving its symlink) so Python discovers the adjacent ``pyvenv.cfg``
-    and activates the environment."""
+    Keep the lexical venv path (rather than resolving its symlink) so Python
+    discovers the adjacent ``pyvenv.cfg`` and activates the environment.
+    """
     env_root = pathlib.Path(project_root) / ".venv"
     if not (env_root / "pyvenv.cfg").is_file():
         return ""
@@ -1063,10 +1078,13 @@ BUNDLE_DIR_ENV = "OUROBOROS_BUNDLE_DIR"
 def bundled_resource_ancestor_bases(executable: "str | pathlib.Path | None" = None) -> List[pathlib.Path]:
     """Bundle roots recoverable from an embedded interpreter path.
 
-    Managed updates replace the server checkout but not the frozen launcher. Launchers predating
-    ``OUROBOROS_BUNDLE_DIR`` still start the updated server with ``.../Resources/python-standalone/...`` (macOS)
-    or ``.../_internal/python-standalone/...`` (portable builds). The interpreter path therefore remains a
-    durable, cross-platform pointer to the old app's resource root."""
+    Managed updates replace the server checkout but not the frozen launcher.
+    Launchers predating ``OUROBOROS_BUNDLE_DIR`` still start the updated server
+    with ``.../Resources/python-standalone/...`` (macOS) or
+    ``.../_internal/python-standalone/...`` (portable builds).  The interpreter
+    path therefore remains a durable, cross-platform pointer to the old app's
+    resource root.
+    """
     try:
         start = pathlib.Path(executable or sys.executable).resolve()
     except (OSError, ValueError):
@@ -1089,13 +1107,17 @@ def bundled_resource_ancestor_bases(executable: "str | pathlib.Path | None" = No
 def bundled_resource_bases() -> List[pathlib.Path]:
     """Roots to search for a resource shipped INSIDE the packaged bundle.
 
-    SSOT for every bundled-payload lookup, because the process that consumes a bundled payload is usually NOT the
-    frozen launcher. In a packaged install the launcher runs the server/CLI as a SEPARATE child of the embedded
-    interpreter, out of the launcher-managed repo under the data dir: that child has no ``sys._MEIPASS`` and its
-    ``__file__`` parent is the managed repo, so both historical bases miss and every bundled payload silently
-    reads as absent. The launcher therefore hands the bundle root down by value in ``OUROBOROS_BUNDLE_DIR`` and it
-    is searched FIRST. The other two bases stay for the frozen process itself and for the dev/source layout
-    (payloads sit at the repo root, two levels up from this module)."""
+    SSOT for every bundled-payload lookup, because the process that consumes a
+    bundled payload is usually NOT the frozen launcher. In a packaged install the
+    launcher runs the server/CLI as a SEPARATE child of the embedded interpreter,
+    out of the launcher-managed repo under the data dir: that child has no
+    ``sys._MEIPASS`` and its ``__file__`` parent is the managed repo, so both
+    historical bases miss and every bundled payload silently reads as absent.
+    The launcher therefore hands the bundle root down by value in
+    ``OUROBOROS_BUNDLE_DIR`` and it is searched FIRST. The other two bases stay
+    for the frozen process itself and for the dev/source layout (payloads sit at
+    the repo root, two levels up from this module).
+    """
     bases: List[pathlib.Path] = []
     env_base = str(os.environ.get(BUNDLE_DIR_ENV) or "").strip()
     if env_base:
@@ -1134,9 +1156,11 @@ def _resolve_bundled_payload(candidates_for: Callable[[pathlib.Path], List[pathl
 def resolve_bundled_node() -> Optional[str]:
     """Return the path to the bundled, signed Node.js runtime if present.
 
-    The packaged app ships an official notarized node under ``node-standalone`` (re-signed under the hardened
-    runtime by the build's signing pass). Prefer it over a PATH (e.g. Homebrew) node, which macOS code-signing
-    enforcement can SIGKILL when launched from the packaged process tree."""
+    The packaged app ships an official notarized node under ``node-standalone``
+    (re-signed under the hardened runtime by the build's signing pass). Prefer it
+    over a PATH (e.g. Homebrew) node, which macOS code-signing enforcement can
+    SIGKILL when launched from the packaged process tree.
+    """
     return _resolve_bundled_payload(embedded_node_candidates)
 
 
@@ -1354,9 +1378,11 @@ def subprocess_new_group_kwargs() -> dict:
 
 
 def install_shutdown_signal_handlers(handler) -> None:
-    """Register ``handler`` for the signals that ask a console process to shut down: SIGINT everywhere, SIGTERM on
-    POSIX. The platform-specific signal surface lives HERE, never in callers (checklist 15). The handler must only
-    set a flag/event — real teardown belongs on the caller's main thread, not inside a signal frame."""
+    """Register ``handler`` for the signals that ask a console process to shut
+    down: SIGINT everywhere, SIGTERM on POSIX. The platform-specific signal
+    surface lives HERE, never in callers (checklist 15). The handler must only
+    set a flag/event — real teardown belongs on the caller's main thread, not
+    inside a signal frame."""
     signal.signal(signal.SIGINT, handler)
     if not IS_WINDOWS:
         signal.signal(signal.SIGTERM, handler)

--- a/ouroboros/process_custody.py
+++ b/ouroboros/process_custody.py
@@ -34,7 +34,6 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 from ouroboros.platform_layer import (
-    _proc_start_ticks,
     kill_process_group_id,
     kill_process_tree,
     pid_is_alive,
@@ -128,7 +127,19 @@ def record_process(
         "pid": int(pid),
         "pgid": int(pgid or 0) if reap_process_group else 0,
         "fingerprint": {
-            "start_time": process_start_time(pid),
+            # DOWNGRADE-SAFE split: the unversioned field keeps the legacy ``ps``
+            # spelling an N-1 reader still understands (a rollback that reads a
+            # boot-qualified token here would mismatch every row and prune it
+            # WITHOUT killing, orphaning the process forever), while the current
+            # reader prefers the boot-qualified sibling below. One extra ``ps``
+            # per SPAWN (the write path always paid it before /proc-first); the
+            # hot sweep path stays subprocess-free.
+            "start_time": (legacy_start := process_start_time_legacy(pid)),
+            **(
+                {"start_time_boot": boot_start}
+                if (boot_start := process_start_time(pid)) and boot_start != legacy_start
+                else {}
+            ),
             # The LIVE command line (what the OS reports) is the reap-time
             # comparison anchor; the argv we passed may differ cosmetically.
             "cmd_sha256": _live_cmd_sha256(pid) or _cmd_sha256(cmd),
@@ -185,35 +196,37 @@ def spawn_supervised(
 
 
 def _legacy_start_matches(pid: int, recorded: str, current: str) -> bool:
-    """Accept a start-time token written BEFORE /proc-first, so the upgrade orphans no ledger row.
+    """Compare a recorded LEGACY spelling against a live boot-qualified token.
 
-    ``process_start_time`` now returns a boot-qualified ``"<ticks>.<boot8>"``. A row written
-    before that change carries the ``ps -o lstart=`` spelling instead, or — on the rare path
-    where ``ps`` itself failed — a BARE boot-relative tick count. Both are accepted, and only
-    here: this runs solely AFTER the current token already failed to match, so the extra ``ps``
-    stays off the reaper's hot path and a genuinely different process still fails every form.
-    A bare-tick row resolves against /proc directly even when the current primary token is the
-    ``ps`` spelling (boot id unreadable), so no legacy row shape is orphaned on a /proc host.
+    Runs solely AFTER the direct equalities already failed, so the one extra ``ps``
+    stays off the reaper's hot path and a genuinely different process still fails
+    every form. ``recorded`` is the ``ps -o lstart=`` field (the spelling the ledger
+    keeps writing for downgrade safety) or, from the one host class with no usable
+    ``ps``, a bare tick count — which ``process_start_time_legacy`` reproduces there,
+    so that shape resolves too. What this helper deliberately does NOT do is treat a
+    bare tick as the tick-half of a boot-qualified live token: ticks recur across
+    reboots, and a token carrying no boot id must never authorize a kill (a mismatch
+    prunes; it does not kill).
 
-    BOUNDED EXPOSURE, stated rather than hidden: the bare-tick form carries no boot id, so such a
-    row can still collide across a reboot exactly as it always could (same ticks, recycled pid,
-    same command line). No post-change token is written in that form — a /proc mint is
-    boot-qualified, a ``ps`` string, or separator-carrying — so the PRE-CHANGE window closes as the
-    ledger turns over. What does NOT close by turnover is the separator form itself, minted only
-    when the boot id AND ``ps`` both fail: two of those from different boots string-match on the
-    equality check above, before this helper is ever consulted. That is why the separator form is
-    the last resort rather than the boot-id-less default.
+    Residual, stated rather than hidden: the ``"<ticks>."`` separator form, minted
+    only when the boot id AND ``ps`` both fail, string-matches its cross-boot twin on
+    the direct equality BEFORE this helper is consulted. That is why the separator
+    form is the mint order's last resort rather than the boot-id-less default.
     """
     ticks, sep, _ = current.partition(".")
     if not (sep and ticks.isdigit()):
         # The current token IS the legacy ``ps`` form (no /proc, or the boot id was
-        # unreadable so ``ps`` won the mint order). Re-running ``ps`` would return the
-        # byte-identical value that already failed to match — but a recorded BARE-TICK
-        # row is still resolvable against /proc directly (0 on hosts without /proc,
-        # which never equals a digit row), at zero subprocess cost.
-        return recorded.isdigit() and recorded == str(_proc_start_ticks(pid))
-    if recorded.isdigit() and recorded == ticks:
-        return True  # pre-change bare-tick fallback row; the tick half of today's token
+        # unreadable so ``ps`` won the mint order): re-running ``ps`` would return the
+        # byte-identical value that already failed the equality above, and a bare-tick
+        # row deliberately does NOT resolve here — see below.
+        return False
+    # A token carrying NO boot id must never authorize a kill: boot-relative ticks
+    # recur across reboots, and a recycled pid + the same command hash is exactly the
+    # cross-boot collision this change exists to refuse. The one host class that ever
+    # MINTS bare ticks (no usable ``ps``) still resolves through
+    # ``process_start_time_legacy``, whose own fallback IS ``str(ticks)`` there; on a
+    # ``ps``-capable host a bare-tick row compares against the ``ps`` spelling, fails,
+    # and is PRUNED — the safe direction (prune, never kill).
     return bool(recorded) and process_start_time_legacy(pid) == recorded
 
 
@@ -230,11 +243,25 @@ def _fingerprint_matches(entry: Dict[str, Any]) -> bool:
     if pid <= 0 or not pid_is_alive(pid):
         return False
     fp = entry.get("fingerprint") if isinstance(entry.get("fingerprint"), dict) else {}
+    recorded_boot = str(fp.get("start_time_boot") or "")
     recorded_start = str(fp.get("start_time") or "")
-    if recorded_start:
+    if recorded_boot or recorded_start:
         live_start = process_start_time(pid)
-        if live_start and live_start != recorded_start and not _legacy_start_matches(
-            pid, recorded_start, live_start
+        if live_start and not (
+            # Preferred: the exact boot-qualified token of a row written by THIS line.
+            (recorded_boot and live_start == recorded_boot)
+            # Same-form equality (macOS/BSD ``ps`` rows, and every pre-upgrade row
+            # whose spelling the live mint still produces).
+            or live_start == recorded_start
+            # Compatibility spellings: a boot-qualified live token against the
+            # legacy ``ps`` field (boot id became readable mid-generation, or a
+            # pre-upgrade row) — one ``ps``, only on this already-mismatched path,
+            # and ONLY for rows carrying no boot sibling: a mismatched recorded
+            # boot token is POSITIVE evidence of another boot, and on a ``ps``-less
+            # host the legacy helper degrades to bare ticks, which would let a
+            # cross-boot recycled pid resolve through the fallback. Refuted boot
+            # evidence prunes; it never re-qualifies through a weaker spelling.
+            or (not recorded_boot and _legacy_start_matches(pid, recorded_start, live_start))
         ):
             return False
     recorded_cmd = str(fp.get("cmd_sha256") or "")
@@ -522,7 +549,8 @@ def reap_orphaned_processes(
         # the cheap path only ever KEEPS: an alive-but-RECYCLED same-session pid is
         # retained one generation (foreign next generation -> full fingerprint ->
         # prune), never killed. The skipped fingerprint only cost a `ps` per row on
-        # every 600s tick and startup sweep. This is the hot majority of the ledger:
+        # every 600s tick (the startup sweep sees prior-generation rows as
+        # foreign-session, so it saves nothing there). This is the hot majority of the ledger:
         # worker-pool members, the SyncManager, the claudexor daemon, the local-model
         # server and keep-services are all scope="session".
         #

--- a/ouroboros/process_custody.py
+++ b/ouroboros/process_custody.py
@@ -34,13 +34,15 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 from ouroboros.platform_layer import (
-    kill_process_tree,
+    _proc_start_ticks,
     kill_process_group_id,
+    kill_process_tree,
     pid_is_alive,
     process_command,
     process_group_id,
     process_group_is_alive,
     process_start_time,
+    process_start_time_legacy,
     subprocess_new_group_kwargs,
 )
 from ouroboros.utils import append_jsonl, utc_now_iso
@@ -182,12 +184,47 @@ def spawn_supervised(
     return proc
 
 
+def _legacy_start_matches(pid: int, recorded: str, current: str) -> bool:
+    """Accept a start-time token written BEFORE /proc-first, so the upgrade orphans no ledger row.
+
+    ``process_start_time`` now returns a boot-qualified ``"<ticks>.<boot8>"``. A row written
+    before that change carries the ``ps -o lstart=`` spelling instead, or — on the rare path
+    where ``ps`` itself failed — a BARE boot-relative tick count. Both are accepted, and only
+    here: this runs solely AFTER the current token already failed to match, so the extra ``ps``
+    stays off the reaper's hot path and a genuinely different process still fails every form.
+    A bare-tick row resolves against /proc directly even when the current primary token is the
+    ``ps`` spelling (boot id unreadable), so no legacy row shape is orphaned on a /proc host.
+
+    BOUNDED EXPOSURE, stated rather than hidden: the bare-tick form carries no boot id, so such a
+    row can still collide across a reboot exactly as it always could (same ticks, recycled pid,
+    same command line). No post-change token is written in that form — a /proc mint is
+    boot-qualified, a ``ps`` string, or separator-carrying — so the PRE-CHANGE window closes as the
+    ledger turns over. What does NOT close by turnover is the separator form itself, minted only
+    when the boot id AND ``ps`` both fail: two of those from different boots string-match on the
+    equality check above, before this helper is ever consulted. That is why the separator form is
+    the last resort rather than the boot-id-less default.
+    """
+    ticks, sep, _ = current.partition(".")
+    if not (sep and ticks.isdigit()):
+        # The current token IS the legacy ``ps`` form (no /proc, or the boot id was
+        # unreadable so ``ps`` won the mint order). Re-running ``ps`` would return the
+        # byte-identical value that already failed to match — but a recorded BARE-TICK
+        # row is still resolvable against /proc directly (0 on hosts without /proc,
+        # which never equals a digit row), at zero subprocess cost.
+        return recorded.isdigit() and recorded == str(_proc_start_ticks(pid))
+    if recorded.isdigit() and recorded == ticks:
+        return True  # pre-change bare-tick fallback row; the tick half of today's token
+    return bool(recorded) and process_start_time_legacy(pid) == recorded
+
+
 def _fingerprint_matches(entry: Dict[str, Any]) -> bool:
     """STRICT identity: the live process must still BE the recorded one.
 
     pid alive + same start_time (when we have one) + same command hash (when
     we have one). A recycled pid fails this and is left alone. We never match
-    by command-line class.
+    by command-line class. The start-time comparison is DUAL-FORMAT on Linux:
+    the cheap current representation first, and the pre-upgrade spelling only
+    once that mismatched (see ``_legacy_start_matches``).
     """
     pid = int(entry.get("pid") or 0)
     if pid <= 0 or not pid_is_alive(pid):
@@ -196,7 +233,9 @@ def _fingerprint_matches(entry: Dict[str, Any]) -> bool:
     recorded_start = str(fp.get("start_time") or "")
     if recorded_start:
         live_start = process_start_time(pid)
-        if live_start and live_start != recorded_start:
+        if live_start and live_start != recorded_start and not _legacy_start_matches(
+            pid, recorded_start, live_start
+        ):
             return False
     recorded_cmd = str(fp.get("cmd_sha256") or "")
     if recorded_cmd:

--- a/ouroboros/process_custody.py
+++ b/ouroboros/process_custody.py
@@ -516,6 +516,31 @@ def reap_orphaned_processes(
         pid = int(entry.get("pid") or 0)
         scope = str(entry.get("scope") or "task")
         same_session = str(entry.get("session_id") or "") == _SESSION_ID
+        # CHEAP PATH for the current generation's own session processes. The branch
+        # further down keeps every same-session session entry regardless of what the
+        # fingerprint said (``task_owner_gone`` is task-scope-only), so for a LIVE pid
+        # the cheap path only ever KEEPS: an alive-but-RECYCLED same-session pid is
+        # retained one generation (foreign next generation -> full fingerprint ->
+        # prune), never killed. The skipped fingerprint only cost a `ps` per row on
+        # every 600s tick and startup sweep. This is the hot majority of the ledger:
+        # worker-pool members, the SyncManager, the claudexor daemon, the local-model
+        # server and keep-services are all scope="session".
+        #
+        # A DEAD pid deliberately FALLS THROUGH instead of pruning here: a session
+        # service whose leader died while its process group is still alive is preserved
+        # today by ``_service_group_survives_leader``, and a prune-on-dead shortcut would
+        # throw that evidence away. Companions are excluded so the daemon-scope companion
+        # rules below stay the only authority on them even for a malformed session-scope
+        # row. This path only ever KEEPS — it can never authorize a kill.
+        if (
+            scope == "session"
+            and same_session
+            and pid > 0
+            and not str(entry.get("purpose") or "").startswith("companion:")
+            and pid_is_alive(pid)
+        ):
+            survivors.append(entry)
+            continue
         leader_matches = _fingerprint_matches(entry)
         group_survives = _service_group_survives_leader(entry)
         if not leader_matches and not group_survives:

--- a/server.py
+++ b/server.py
@@ -990,16 +990,12 @@ def _start_supervisor_liveness_watchdog(liveness: list, stop_event=None) -> None
         wedged_task = None
         while not _restart_requested.is_set() and not (stop_event is not None and stop_event.is_set()):
             time.sleep(interval)
-            # TWO clocks, deliberately: each half must read the SAME clock its own
-            # stamps were taken on. The liveness tick is monotonic (it measures an
-            # elapsed gap, and a wall-clock jump — NTP step, DST/timezone change,
-            # manual set, VM resume — must neither fabricate a stall nor mask one),
-            # while the chat-turn wedge compares against ``agent._last_activity_ts``,
-            # a WALL stamp (agent.py). Feeding a monotonic ``now`` into that half
-            # would make ``now - turn_ts`` hugely negative and silently disable wedge
-            # detection forever. Do not collapse these back into one variable.
+            # ONE clock: both halves measure an ELAPSED GAP against stamps taken on
+            # the monotonic clock (the loop-liveness tick here, and the chat-turn
+            # heartbeat in agent.py), so a wall-clock jump — NTP step, DST/timezone
+            # change, manual set, VM resume — can neither fabricate a stall/wedge
+            # nor mask a real one on either half.
             now = time.monotonic()
-            now_wall = time.time()
             # (1) Supervisor loop stall — new-message intake starvation.
             if _supervisor_loop_stalled(liveness[0], now, deadline):
                 if not loop_alerted:
@@ -1025,7 +1021,10 @@ def _start_supervisor_liveness_watchdog(liveness: list, stop_event=None) -> None
                                 is_progress=True,
                                 progress_meta={
                                     "task_incident": "supervisor_loop_stall",
-                                    "toast_once": f"supervisor-loop-stall:{int(liveness[0])}",
+                                    # pid disambiguates server GENERATIONS: the monotonic stamp alone can
+                                    # repeat at a similar uptime offset across restarts, and the browser's
+                                    # toast-dedupe set outlives this process while the page stays open.
+                                    "toast_once": f"supervisor-loop-stall:{os.getpid()}:{int(liveness[0])}",
                                 },
                             )
                     except Exception:
@@ -1039,9 +1038,9 @@ def _start_supervisor_liveness_watchdog(liveness: list, stop_event=None) -> None
                 busy, turn_task, turn_ts = chat_turn_liveness()
             except Exception:
                 busy, turn_task, turn_ts = (False, None, None)
-            if _chat_turn_wedged(busy, turn_ts, now_wall, deadline):
+            if _chat_turn_wedged(busy, turn_ts, now, deadline):
                 if wedged_task != turn_task:  # alert once per wedged turn
-                    _alert_chat_turn_wedge(turn_task, now_wall - (turn_ts or now_wall))
+                    _alert_chat_turn_wedge(turn_task, now - (turn_ts or now))
                     wedged_task = turn_task
             elif not busy:
                 wedged_task = None

--- a/server.py
+++ b/server.py
@@ -990,7 +990,16 @@ def _start_supervisor_liveness_watchdog(liveness: list, stop_event=None) -> None
         wedged_task = None
         while not _restart_requested.is_set() and not (stop_event is not None and stop_event.is_set()):
             time.sleep(interval)
-            now = time.time()
+            # TWO clocks, deliberately: each half must read the SAME clock its own
+            # stamps were taken on. The liveness tick is monotonic (it measures an
+            # elapsed gap, and a wall-clock jump — NTP step, DST/timezone change,
+            # manual set, VM resume — must neither fabricate a stall nor mask one),
+            # while the chat-turn wedge compares against ``agent._last_activity_ts``,
+            # a WALL stamp (agent.py). Feeding a monotonic ``now`` into that half
+            # would make ``now - turn_ts`` hugely negative and silently disable wedge
+            # detection forever. Do not collapse these back into one variable.
+            now = time.monotonic()
+            now_wall = time.time()
             # (1) Supervisor loop stall — new-message intake starvation.
             if _supervisor_loop_stalled(liveness[0], now, deadline):
                 if not loop_alerted:
@@ -1030,9 +1039,9 @@ def _start_supervisor_liveness_watchdog(liveness: list, stop_event=None) -> None
                 busy, turn_task, turn_ts = chat_turn_liveness()
             except Exception:
                 busy, turn_task, turn_ts = (False, None, None)
-            if _chat_turn_wedged(busy, turn_ts, now, deadline):
+            if _chat_turn_wedged(busy, turn_ts, now_wall, deadline):
                 if wedged_task != turn_task:  # alert once per wedged turn
-                    _alert_chat_turn_wedge(turn_task, now - (turn_ts or now))
+                    _alert_chat_turn_wedge(turn_task, now_wall - (turn_ts or now_wall))
                     wedged_task = turn_task
             elif not busy:
                 wedged_task = None
@@ -2187,13 +2196,15 @@ def _run_supervisor(settings: dict) -> None:
     _last_review_job_reconcile = [time.time()]
     # WS3: a dedicated watchdog thread (outside this loop, so it fires even if the
     # loop stalls) surfaces a wedge as an observable signal + owner alert instead
-    # of silent hours; the loop publishes a liveness tick each iteration.
-    _loop_liveness = [time.time()]
+    # of silent hours; the loop publishes a liveness tick each iteration. The tick
+    # is MONOTONIC: it is only ever read as an elapsed gap, so a wall-clock jump
+    # must not turn a healthy loop into a phantom stall (nor hide a real one).
+    _loop_liveness = [time.monotonic()]
     _watchdog_stop = threading.Event()  # per-generation: stops the watchdog when THIS loop exits
     _start_supervisor_liveness_watchdog(_loop_liveness, _watchdog_stop)
     while not _restart_requested.is_set():
         try:
-            _loop_liveness[0] = time.time()
+            _loop_liveness[0] = time.monotonic()
             rotate_chat_log_if_needed(DATA_DIR)
             # progress.jsonl rotates on the same supervisor tick (v6.90.x P2); its
             # readers (history backfill, SSE replay, api_logs_tail, TB ATIF) are

--- a/tests/test_process_custody.py
+++ b/tests/test_process_custody.py
@@ -782,3 +782,63 @@ def test_start_time_match_matrix(tmp_path, monkeypatch, live, recorded, expected
         assert process_custody._fingerprint_matches(entry) is expected, why
     finally:
         proc.kill(); proc.wait(timeout=5)
+
+
+# --- OB-07: cheap liveness for the current generation's own session rows ---
+
+
+@_POSIX_ONLY
+@pytest.mark.parametrize("purpose", ["live-session-service", "service:web", "workspace_service:api"])
+def test_reaper_skips_the_fingerprint_for_live_same_session_rows(tmp_path, monkeypatch, purpose):
+    """A live same-session session row is kept either way, so the `ps` is pure cost.
+
+    The counter is the assertion: worker-pool members, the SyncManager, the claudexor
+    daemon, the local-model server and keep-services are ALL scope="session", so this is
+    the hot majority of the ledger on every 600s tick and startup sweep.
+    """
+    calls = []
+    real = process_custody._fingerprint_matches
+    monkeypatch.setattr(
+        process_custody, "_fingerprint_matches",
+        lambda entry: (calls.append(entry.get("pid")), real(entry))[1],
+    )
+    proc = _sleeper(tmp_path, purpose, "session")
+    try:
+        reaped = reap_orphaned_processes(tmp_path)
+        assert proc.pid not in reaped
+        assert proc.poll() is None, "a live same-session service must be kept"
+        assert calls == [], f"no fingerprint should be computed for a live session row; got {calls}"
+        # and the row is still in the ledger for the next generation to judge
+        kept = [json.loads(line) for line in ledger_path(tmp_path).read_text().splitlines() if line.strip()]
+        assert [e["pid"] for e in kept] == [proc.pid]
+    finally:
+        proc.kill(); proc.wait(timeout=5)
+
+
+def test_reaper_keeps_dead_leader_session_service_with_a_live_group(tmp_path, monkeypatch):
+    """A DEAD pid must fall through to the group evidence, never take a prune shortcut.
+
+    A session service whose leader died while its process group is still alive is
+    preserved by ``_service_group_survives_leader``; pruning on a dead pid inside the
+    cheap path would have silently dropped that row and orphaned the group.
+    """
+    entry = {
+        "pid": 123,
+        "pgid": 456,
+        "purpose": "service:background-child",
+        "scope": "session",
+        "session_id": process_custody._SESSION_ID,  # CURRENT generation
+        "fingerprint": {"start_time": "gone", "cmd_sha256": "gone"},
+    }
+    rewritten = []
+    monkeypatch.setattr(process_custody, "_read_ledger", lambda _root: [entry])
+    monkeypatch.setattr(process_custody, "pid_is_alive", lambda _pid: False)  # leader is dead
+    monkeypatch.setattr(process_custody, "process_group_is_alive", lambda pgid: pgid == 456)
+    monkeypatch.setattr(
+        process_custody, "kill_process_group_id",
+        lambda pgid: pytest.fail(f"a surviving service group must not be killed (pgid={pgid})"),
+    )
+    monkeypatch.setattr(process_custody, "_rewrite_ledger", lambda _root, entries: rewritten.extend(entries))
+
+    assert reap_orphaned_processes(tmp_path) == []
+    assert rewritten == [entry], "the dead-leader row must survive on its group evidence"

--- a/tests/test_process_custody.py
+++ b/tests/test_process_custody.py
@@ -563,3 +563,222 @@ def test_installed_skill_names_is_disk_derived_and_none_on_failure(monkeypatch):
     monkeypatch.setattr(skl, "discover_skills",
                         lambda *a, **k: [SimpleNamespace(name="alpha"), SimpleNamespace(name="beta")])
     assert server._installed_skill_names() == {"alpha", "beta"}
+
+
+# --- OB-06: /proc-first start times, matched dual-format for pre-upgrade rows ---
+#
+# These call ``_fingerprint_matches`` DIRECTLY on purpose. The reaper's cheap
+# same-session liveness path would answer for a live session row before the
+# fingerprint is ever computed, so a reaper-level assertion would pass without
+# proving anything about the matcher.
+
+
+def _fingerprint_entry(tmp_path, *, start_time=None):
+    """A ledger entry for a real live process, with its start-time token overridden.
+
+    ``start_time=None`` records the host's own legacy (``ps``) token, which is exactly
+    what a pre-upgrade row on a Linux box would carry.
+    """
+    proc = _sleeper(tmp_path, "ob06-fingerprint", "task")
+    record = record_process(
+        tmp_path, pid=proc.pid, cmd=["sleep", "60"], purpose="ob06", scope="task",
+    )
+    if start_time is None:
+        start_time = process_custody.process_start_time_legacy(proc.pid)
+    return proc, dict(record, fingerprint=dict(record["fingerprint"], start_time=start_time))
+
+
+@_POSIX_ONLY
+def test_fingerprint_accepts_a_pre_upgrade_ps_start_time(tmp_path, monkeypatch):
+    """A row written before /proc-first carries the ``ps -o lstart=`` spelling.
+
+    After the upgrade the current token is boot-qualified, so recorded != current for
+    every pre-existing row. Without the dual-format match the whole existing ledger
+    would read as fingerprint-mismatched and be pruned on the next sweep.
+    """
+    if not process_custody.process_start_time_legacy(os.getpid()):
+        pytest.skip("no usable ps/lstart start-time token on this host")
+    proc, entry = _fingerprint_entry(tmp_path)
+    try:
+        assert entry["fingerprint"]["start_time"], "ps must answer for a live pid"
+        # Simulate the post-upgrade Linux world regardless of the host we run on.
+        monkeypatch.setattr(process_custody, "process_start_time", lambda pid: "4242.deadbeef")
+        assert process_custody._fingerprint_matches(entry) is True
+    finally:
+        proc.kill(); proc.wait(timeout=5)
+
+
+@_POSIX_ONLY
+def test_fingerprint_accepts_a_pre_upgrade_bare_tick_row(tmp_path, monkeypatch):
+    """The rare pre-change row where ``ps`` failed carries a BARE boot-relative tick.
+
+    It is accepted against the tick half of today's token — the bounded compatibility
+    the matcher documents. Nothing new is ever written in this form.
+    """
+    proc, entry = _fingerprint_entry(tmp_path, start_time="4242")
+    try:
+        monkeypatch.setattr(process_custody, "process_start_time", lambda pid: "4242.deadbeef")
+        assert process_custody._fingerprint_matches(entry) is True
+    finally:
+        proc.kill(); proc.wait(timeout=5)
+
+
+@_POSIX_ONLY
+def test_fingerprint_rejects_identical_ticks_from_another_boot(tmp_path, monkeypatch):
+    """Boot-relative ticks RECUR across reboots — the boot id is what makes them an identity.
+
+    Same tick count, different boot: a bare-tick token would have matched and authorized a
+    kill of an unrelated process that merely inherited the pid. The qualified token must not.
+    """
+    proc, entry = _fingerprint_entry(tmp_path, start_time="4242.aaaaaaaa")
+    try:
+        monkeypatch.setattr(process_custody, "process_start_time", lambda pid: "4242.bbbbbbbb")
+        assert process_custody._fingerprint_matches(entry) is False
+    finally:
+        proc.kill(); proc.wait(timeout=5)
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="/proc start times are Linux-only")
+def test_process_start_time_is_boot_qualified_on_linux():
+    """On Linux the token comes from /proc and carries the boot id, without spawning ``ps``."""
+    token = process_custody.process_start_time(os.getpid())
+    assert re.fullmatch(r"\d+\.[0-9a-f]{1,8}", token), token
+    assert token != process_custody.process_start_time_legacy(os.getpid())
+
+
+@_POSIX_ONLY
+def test_foreign_row_mismatch_costs_no_second_ps_without_proc(tmp_path, monkeypatch):
+    """On a host with no /proc the current token already IS the ``ps`` spelling.
+
+    Re-running ``ps`` there would return the byte-identical value that just failed to
+    match, so the mismatch path must refuse before paying for a second subprocess.
+    """
+    calls = []
+    real_legacy = process_custody.process_start_time_legacy
+    monkeypatch.setattr(
+        process_custody, "process_start_time_legacy",
+        lambda pid: (calls.append(pid), real_legacy(pid))[1],
+    )
+    monkeypatch.setattr(process_custody, "process_start_time", lambda pid: "Mon Aug 25 12:00:00 2026")
+    proc, entry = _fingerprint_entry(tmp_path, start_time="FOREIGN")
+    try:
+        assert process_custody._fingerprint_matches(entry) is False
+        assert calls == [], f"a legacy-form current token must not trigger a second ps; got {calls}"
+    finally:
+        proc.kill(); proc.wait(timeout=5)
+
+
+@_POSIX_ONLY
+def test_unreadable_boot_id_prefers_the_collision_free_ps_token(monkeypatch):
+    """With ticks but no boot id, ``ps`` wins — ``"<ticks>."`` is the LAST resort.
+
+    Two ``"<ticks>."`` tokens from different boots string-MATCH, which is the exact
+    cross-boot false positive this fix exists to prevent, and it sits on the kill path.
+    The ``ps`` wall-clock token cannot collide across boots, so it is preferred; the
+    separator form is reached only when ``ps`` has also failed.
+    """
+    from ouroboros import platform_layer
+
+    monkeypatch.setattr(platform_layer, "_BOOT_ID", "")
+    monkeypatch.setattr(platform_layer, "_proc_start_ticks", lambda pid: 4242)
+    monkeypatch.setattr(
+        pathlib.Path, "read_text",
+        lambda self, *a, **k: (_ for _ in ()).throw(OSError("no boot id here")),
+    )
+    monkeypatch.setattr(platform_layer, "process_start_time_legacy", lambda pid: "Mon Aug 25 12:00:00 2026")
+    assert platform_layer.process_start_time(os.getpid()) == "Mon Aug 25 12:00:00 2026"
+
+
+@_POSIX_ONLY
+def test_separator_form_is_the_last_resort_when_ps_also_fails(monkeypatch):
+    """Only once ``ps`` has ALSO failed does the token degrade to ``"<ticks>."``.
+
+    It still carries the separator so it can never be string-equal to a genuine
+    pre-change bare-tick row — the ambiguity the separator removes.
+    """
+    from ouroboros import platform_layer
+
+    monkeypatch.setattr(platform_layer, "_BOOT_ID", "")
+    monkeypatch.setattr(platform_layer, "_proc_start_ticks", lambda pid: 4242)
+    monkeypatch.setattr(
+        pathlib.Path, "read_text",
+        lambda self, *a, **k: (_ for _ in ()).throw(OSError("no boot id here")),
+    )
+    # ps failed, so the legacy helper degrades to its own bare-tick fallback.
+    monkeypatch.setattr(platform_layer, "process_start_time_legacy", lambda pid: "4242")
+    token = platform_layer.process_start_time(os.getpid())
+    assert token == "4242.", token
+    assert token != "4242", "a /proc token must never be confusable with a pre-change bare tick"
+
+
+@_POSIX_ONLY
+@pytest.mark.parametrize("boom", [
+    OSError("transient"),
+    UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte"),  # a ValueError: the fix-4 arm
+])
+def test_boot_id_read_failure_retries_then_latches(monkeypatch, boom):
+    """One transient boot-id read failure must not downgrade the whole server generation.
+
+    Both arms of the guard are covered: an OSError and a UnicodeDecodeError (a ValueError,
+    which an unguarded caller would let escape and abort a whole custody sweep).
+    """
+    from ouroboros import platform_layer
+
+    attempts = []
+
+    def _read(self, *a, **k):
+        attempts.append(str(self))
+        if len(attempts) == 1:
+            raise boom
+        return "aabbccdd-0000-0000-0000-000000000000\n"
+
+    monkeypatch.setattr(platform_layer, "_BOOT_ID", "")
+    monkeypatch.setattr(platform_layer, "_proc_start_ticks", lambda pid: 7)
+    monkeypatch.setattr(platform_layer, "process_start_time_legacy", lambda pid: "Mon Aug 25 12:00:00 2026")
+    monkeypatch.setattr(pathlib.Path, "read_text", _read)
+
+    # The failed read falls to the collision-free ps token, NOT to "7." (see the priority order).
+    assert platform_layer.process_start_time(os.getpid()) == "Mon Aug 25 12:00:00 2026"
+    assert platform_layer.process_start_time(os.getpid()) == "7.aabbccdd"   # retried, boot id now readable
+    assert len(attempts) == 2
+    assert platform_layer.process_start_time(os.getpid()) == "7.aabbccdd"   # latched
+    assert len(attempts) == 2, "a successful read must latch and stop re-reading"
+
+
+# The token forms a ledger row (or a live process) can carry, after the priority reorder:
+#   Q  boot-qualified "<ticks>.<boot8>"      — post-change, boot id readable
+#   Q2 same ticks, DIFFERENT boot            — the cross-boot impostor
+#   P  ps wall-clock string                  — pre-change, or post-change without a boot id
+#   S  "<ticks>."                            — post-change last resort (no boot id AND no ps)
+#   B  bare "<ticks>"                        — pre-change ps-failed fallback only
+_Q, _Q2, _P, _S, _B = "4242.aabbccdd", "4242.bbbbbbbb", "Mon Aug 25 12:00:00 2026", "4242.", "4242"
+
+
+@_POSIX_ONLY
+@pytest.mark.parametrize(("live", "recorded", "expected", "why"), [
+    (_Q, _Q, True, "same boot, same ticks"),
+    (_Q, _Q2, False, "SAME ticks from another boot must never match"),
+    (_Q, _P, True, "pre-change ps row still matches after the upgrade"),
+    (_Q, _B, True, "pre-change bare-tick fallback row still matches"),
+    (_Q, _S, False, "a row from a boot-id outage window mismatches after recovery (prunes, never kills)"),
+    (_P, _P, True, "no boot id on either side: the ps token is the identity"),
+    (_P, _Q, False, "a boot-qualified row mismatches once the boot id stops being readable"),
+    (_P, _B, True, "a bare-tick row resolves against /proc directly even when the primary token is ps"),
+    (_S, _S, True, "the disclosed last-resort collision: both sides degraded identically"),
+    (_S, _B, True, "pre-change bare tick still matches the tick half of the last-resort form"),
+    (_S, _P, False, "ps is broken here, so a ps-format row cannot be re-derived"),
+])
+def test_start_time_match_matrix(tmp_path, monkeypatch, live, recorded, expected, why):
+    """Every (live form x recorded form) pair the priority reorder can produce."""
+    # ``ps`` answers only while the live token is not itself a ps string; when the live token
+    # IS ps-shaped, re-running ps returns that same value (which is what fix 1 short-circuits).
+    monkeypatch.setattr(process_custody, "process_start_time_legacy",
+                        lambda pid: _P if live in (_Q, _P) else _B)
+    monkeypatch.setattr(process_custody, "process_start_time", lambda pid: live)
+    # simulated readable /proc: the direct bare-tick comparator sees today's tick count
+    monkeypatch.setattr(process_custody, "_proc_start_ticks", lambda pid: 4242)
+    proc, entry = _fingerprint_entry(tmp_path, start_time=recorded)
+    try:
+        assert process_custody._fingerprint_matches(entry) is expected, why
+    finally:
+        proc.kill(); proc.wait(timeout=5)

--- a/tests/test_process_custody.py
+++ b/tests/test_process_custody.py
@@ -585,7 +585,12 @@ def _fingerprint_entry(tmp_path, *, start_time=None):
     )
     if start_time is None:
         start_time = process_custody.process_start_time_legacy(proc.pid)
-    return proc, dict(record, fingerprint=dict(record["fingerprint"], start_time=start_time))
+    fp = dict(record["fingerprint"], start_time=start_time)
+    # The override simulates a PRE-change row: those carry no boot-qualified sibling
+    # (the current writer's `start_time_boot` would otherwise satisfy the boot-first
+    # equality and mask what the compatibility comparison under test actually does).
+    fp.pop("start_time_boot", None)
+    return proc, dict(record, fingerprint=fp)
 
 
 @_POSIX_ONLY
@@ -609,16 +614,21 @@ def test_fingerprint_accepts_a_pre_upgrade_ps_start_time(tmp_path, monkeypatch):
 
 
 @_POSIX_ONLY
-def test_fingerprint_accepts_a_pre_upgrade_bare_tick_row(tmp_path, monkeypatch):
-    """The rare pre-change row where ``ps`` failed carries a BARE boot-relative tick.
-
-    It is accepted against the tick half of today's token — the bounded compatibility
-    the matcher documents. Nothing new is ever written in this form.
+def test_fingerprint_refuses_a_bare_tick_row_on_a_ps_capable_host(tmp_path, monkeypatch):
+    """A recorded BARE tick (pre-change ps-failed fallback) must never authorize a kill:
+    ticks recur across reboots, so matching it against the tick half of a boot-qualified
+    live token is exactly the cross-boot collision the boot id exists to refuse. On a
+    ``ps``-capable host the row compares against the ``ps`` spelling, fails, and is
+    PRUNED — the safe direction. (The one host class that ever MINTS bare ticks has no
+    usable ``ps``; there ``process_start_time_legacy`` reproduces the bare tick and the
+    row still resolves — the matrix pins that arm.)
     """
     proc, entry = _fingerprint_entry(tmp_path, start_time="4242")
     try:
         monkeypatch.setattr(process_custody, "process_start_time", lambda pid: "4242.deadbeef")
-        assert process_custody._fingerprint_matches(entry) is True
+        monkeypatch.setattr(
+            process_custody, "process_start_time_legacy", lambda pid: "Mon Aug 25 12:00:00 2026")
+        assert process_custody._fingerprint_matches(entry) is False
     finally:
         proc.kill(); proc.wait(timeout=5)
 
@@ -638,11 +648,74 @@ def test_fingerprint_rejects_identical_ticks_from_another_boot(tmp_path, monkeyp
         proc.kill(); proc.wait(timeout=5)
 
 
+@_POSIX_ONLY
+def test_writer_keeps_the_legacy_spelling_downgrade_safe(tmp_path):
+    """Rollback safety (the durable-format hazard): the unversioned ``start_time``
+    field keeps the ``ps`` spelling an N−1 reader compares with its own
+    ``process_start_time`` — so after a managed-update ROLLBACK every row written by
+    this version still matches its live process (kill/prune reasoning intact) instead
+    of silently pruning WITHOUT a kill and orphaning the process forever. The
+    boot-qualified token rides the separate ``start_time_boot`` sibling, which an old
+    reader simply ignores."""
+    proc = _sleeper(tmp_path, "ob06-writer", "task")
+    try:
+        fp_row = record_process(
+            tmp_path, pid=proc.pid, cmd=["sleep", "60"], purpose="ob06w", scope="task",
+        )["fingerprint"]
+        legacy = process_custody.process_start_time_legacy(proc.pid)
+        assert fp_row["start_time"] == legacy, "the N-1 reader's comparison value"
+        boot = process_custody.process_start_time(proc.pid)
+        if boot and boot != legacy:  # Linux with a readable boot id
+            assert fp_row.get("start_time_boot") == boot
+        else:  # macOS/BSD: one spelling only, no redundant sibling
+            assert "start_time_boot" not in fp_row
+        # And the CURRENT reader accepts its own row (boot-first, no ps needed).
+        assert process_custody._fingerprint_matches(
+            {"pid": proc.pid, "fingerprint": fp_row}) is True
+    finally:
+        proc.kill(); proc.wait(timeout=5)
+
+
+@_POSIX_ONLY
+def test_sibling_free_row_falls_back_to_the_legacy_field(tmp_path, monkeypatch):
+    """The REACHABLE mid-generation case: the boot id was unreadable at mint (so the
+    row carries only the ``ps`` spelling, no boot sibling) and became readable by the
+    sweep — one ``ps`` on this already-mismatched path keeps the row instead of
+    pruning a live owned process."""
+    real_ps = process_custody.process_start_time_legacy(os.getpid())
+    if not real_ps or real_ps.isdigit():
+        pytest.skip("no usable ps/lstart start-time token on this host")
+    proc, entry = _fingerprint_entry(tmp_path, start_time=None)
+    try:
+        live_legacy = process_custody.process_start_time_legacy(proc.pid)
+        fp = {"start_time": live_legacy}
+        monkeypatch.setattr(process_custody, "process_start_time", lambda pid: "4242.aabbccdd")
+        assert process_custody._fingerprint_matches(dict(entry, fingerprint=fp)) is True
+    finally:
+        proc.kill(); proc.wait(timeout=5)
+
+
+@_POSIX_ONLY
+def test_refuted_boot_evidence_never_requalifies_through_bare_ticks(tmp_path, monkeypatch):
+    """A row minted on a ``ps``-less host carries a bare-tick ``start_time`` PLUS a
+    boot-qualified sibling. After a reboot, the mismatched sibling is positive evidence
+    of another boot; the legacy helper (which degrades to bare ticks there) must not
+    re-qualify the cross-boot recycled pid — the row prunes, never kills."""
+    proc, entry = _fingerprint_entry(tmp_path, start_time=None)
+    try:
+        fp = {"start_time": _B, "start_time_boot": _Q}
+        monkeypatch.setattr(process_custody, "process_start_time", lambda pid: _Q2)
+        monkeypatch.setattr(process_custody, "process_start_time_legacy", lambda pid: _B)
+        assert process_custody._fingerprint_matches(dict(entry, fingerprint=fp)) is False
+    finally:
+        proc.kill(); proc.wait(timeout=5)
+
+
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="/proc start times are Linux-only")
 def test_process_start_time_is_boot_qualified_on_linux():
     """On Linux the token comes from /proc and carries the boot id, without spawning ``ps``."""
     token = process_custody.process_start_time(os.getpid())
-    assert re.fullmatch(r"\d+\.[0-9a-f]{1,8}", token), token
+    assert re.fullmatch(r"\d+\.[0-9a-f]{1,32}", token), token
     assert token != process_custody.process_start_time_legacy(os.getpid())
 
 
@@ -653,6 +726,9 @@ def test_foreign_row_mismatch_costs_no_second_ps_without_proc(tmp_path, monkeypa
     Re-running ``ps`` there would return the byte-identical value that just failed to
     match, so the mismatch path must refuse before paying for a second subprocess.
     """
+    proc, entry = _fingerprint_entry(tmp_path, start_time="FOREIGN")
+    # The WRITE path legitimately pays one ``ps`` for the downgrade-safe legacy field;
+    # the claim under test is about the SWEEP's mismatch path, so count from here.
     calls = []
     real_legacy = process_custody.process_start_time_legacy
     monkeypatch.setattr(
@@ -660,7 +736,6 @@ def test_foreign_row_mismatch_costs_no_second_ps_without_proc(tmp_path, monkeypa
         lambda pid: (calls.append(pid), real_legacy(pid))[1],
     )
     monkeypatch.setattr(process_custody, "process_start_time", lambda pid: "Mon Aug 25 12:00:00 2026")
-    proc, entry = _fingerprint_entry(tmp_path, start_time="FOREIGN")
     try:
         assert process_custody._fingerprint_matches(entry) is False
         assert calls == [], f"a legacy-form current token must not trigger a second ps; got {calls}"
@@ -739,9 +814,9 @@ def test_boot_id_read_failure_retries_then_latches(monkeypatch, boom):
 
     # The failed read falls to the collision-free ps token, NOT to "7." (see the priority order).
     assert platform_layer.process_start_time(os.getpid()) == "Mon Aug 25 12:00:00 2026"
-    assert platform_layer.process_start_time(os.getpid()) == "7.aabbccdd"   # retried, boot id now readable
+    assert platform_layer.process_start_time(os.getpid()) == "7.aabbccdd000000000000000000000000"   # retried, boot id now readable
     assert len(attempts) == 2
-    assert platform_layer.process_start_time(os.getpid()) == "7.aabbccdd"   # latched
+    assert platform_layer.process_start_time(os.getpid()) == "7.aabbccdd000000000000000000000000"   # latched
     assert len(attempts) == 2, "a successful read must latch and stop re-reading"
 
 
@@ -759,11 +834,11 @@ _Q, _Q2, _P, _S, _B = "4242.aabbccdd", "4242.bbbbbbbb", "Mon Aug 25 12:00:00 202
     (_Q, _Q, True, "same boot, same ticks"),
     (_Q, _Q2, False, "SAME ticks from another boot must never match"),
     (_Q, _P, True, "pre-change ps row still matches after the upgrade"),
-    (_Q, _B, True, "pre-change bare-tick fallback row still matches"),
+    (_Q, _B, False, "a bare tick carries no boot id and must never authorize a kill (prunes)"),
     (_Q, _S, False, "a row from a boot-id outage window mismatches after recovery (prunes, never kills)"),
     (_P, _P, True, "no boot id on either side: the ps token is the identity"),
     (_P, _Q, False, "a boot-qualified row mismatches once the boot id stops being readable"),
-    (_P, _B, True, "a bare-tick row resolves against /proc directly even when the primary token is ps"),
+    (_P, _B, False, "a bare-tick row against a ps-form live token prunes (never a tick-half kill)"),
     (_S, _S, True, "the disclosed last-resort collision: both sides degraded identically"),
     (_S, _B, True, "pre-change bare tick still matches the tick half of the last-resort form"),
     (_S, _P, False, "ps is broken here, so a ps-format row cannot be re-derived"),
@@ -775,8 +850,6 @@ def test_start_time_match_matrix(tmp_path, monkeypatch, live, recorded, expected
     monkeypatch.setattr(process_custody, "process_start_time_legacy",
                         lambda pid: _P if live in (_Q, _P) else _B)
     monkeypatch.setattr(process_custody, "process_start_time", lambda pid: live)
-    # simulated readable /proc: the direct bare-tick comparator sees today's tick count
-    monkeypatch.setattr(process_custody, "_proc_start_ticks", lambda pid: 4242)
     proc, entry = _fingerprint_entry(tmp_path, start_time=recorded)
     try:
         assert process_custody._fingerprint_matches(entry) is expected, why

--- a/tests/test_ws3_wedge_resilience.py
+++ b/tests/test_ws3_wedge_resilience.py
@@ -44,7 +44,7 @@ def test_watchdog_noop_when_disabled(monkeypatch):
 
     monkeypatch.setenv("OUROBOROS_SUPERVISOR_LIVENESS_DEADLINE_SEC", "0")
     before = threading.active_count()
-    server._start_supervisor_liveness_watchdog([time.time()])
+    server._start_supervisor_liveness_watchdog([time.monotonic()])
     assert threading.active_count() == before  # no watchdog thread spawned
 
 
@@ -64,12 +64,13 @@ def test_watchdog_alerts_owner_once_on_stall(monkeypatch):
     monkeypatch.setattr("supervisor.state.append_jsonl", lambda *a, **k: None)
     stop = threading.Event()  # local per-test token; do NOT touch the global restart flag
     try:
-        server._start_supervisor_liveness_watchdog([time.time() - 100], stop)  # already stale
+        # The liveness tick is a MONOTONIC stamp (OB-03) — seed it on the same clock.
+        server._start_supervisor_liveness_watchdog([time.monotonic() - 100], stop)  # already stale
         end = time.time() + 6
         while not alerts and time.time() < end:
             time.sleep(0.1)
     finally:
-        stop.set()  # stop THIS watchdog thread (no cross-test leakage)
+        _stop_watchdog(stop)  # join it too: a leaked in-flight iteration outlives the monkeypatch
     assert len(alerts) == 1
     assert alerts[0][0] == 5 and "stalled" in alerts[0][1]
     assert alerts[0][2]["is_progress"] is True
@@ -128,12 +129,12 @@ def test_watchdog_alerts_on_chat_turn_wedge(monkeypatch):
         _busy=True, _current_task_id="wedged1", _last_activity_ts=time.time() - 100))
     stop = threading.Event()  # local per-test token
     try:
-        server._start_supervisor_liveness_watchdog([time.time()], stop)
+        server._start_supervisor_liveness_watchdog([time.monotonic()], stop)
         end = time.time() + 6
         while not any("wedged" in a[1] for a in alerts) and time.time() < end:
             time.sleep(0.1)
     finally:
-        stop.set()
+        _stop_watchdog(stop)  # join it too: a leaked in-flight iteration outlives the monkeypatch
     assert any("wedged" in a[1] for a in alerts)  # the chat-turn wedge was surfaced
     assert any(a[0] == 7 for a in alerts)
     wedge = next(a for a in alerts if "wedged" in a[1])
@@ -143,3 +144,145 @@ def test_watchdog_alerts_on_chat_turn_wedge(monkeypatch):
         "task_incident": "chat_turn_wedge",
         "toast_once": "wedged1:chat_turn_wedge",
     }
+
+
+# --- OB-03: the watchdog's two halves run on two different clocks ------------
+
+
+class _FakeServerClock:
+    """A controllable stand-in for the ``time`` module ``server`` reads.
+
+    Only the three calls the watchdog makes are driven (``sleep``/``time``/
+    ``monotonic``); everything else falls through to the real module. The TEST
+    HARNESS keeps the real clock — this module's own ``time`` is never patched —
+    so a simulated wall-clock jump cannot make the harness's own timeouts lie.
+    """
+
+    def __init__(self, *, wall: float, mono: float) -> None:
+        self.wall = wall
+        self.mono = mono
+        self.ticks = 0
+
+    def __getattr__(self, name):  # anything the watchdog does not drive stays real
+        return getattr(time, name)
+
+    def time(self) -> float:
+        return self.wall
+
+    def monotonic(self) -> float:
+        return self.mono
+
+    def sleep(self, _seconds: float) -> None:
+        self.ticks += 1
+        time.sleep(0.01)  # a REAL yield; the fake clock advances only when a test says so
+
+
+def _wait_until(predicate, budget: float = 6.0) -> None:
+    end = time.time() + budget  # real clock: the harness never rides the fake one
+    while not predicate() and time.time() < end:
+        time.sleep(0.01)
+
+
+def _stop_watchdog(stop: threading.Event) -> None:
+    """Set the token AND wait for the thread to leave the loop.
+
+    The watchdog re-reads the token only at the TOP of the loop, so an iteration
+    already in flight still completes its clock reads and checks. Returning before
+    that finishes would let it run against a torn-down monkeypatch — reading the
+    real ``time`` module against a fake liveness stamp — and emit a phantom alert
+    into whatever the next test has patched.
+    """
+    stop.set()
+    for thread in threading.enumerate():
+        if thread.name == "supervisor-liveness-watchdog":
+            thread.join(timeout=5)
+
+
+def _collect_alerts(monkeypatch, chat_id: int) -> list:
+    alerts: list = []
+
+    class _Bridge:
+        def send_message(self, cid, text, *a, **k):
+            alerts.append((cid, text, k))
+            return (True, "")
+
+    monkeypatch.setattr("supervisor.message_bus.get_bridge", lambda: _Bridge())
+    monkeypatch.setattr("supervisor.state.load_state", lambda: {"owner_chat_id": chat_id})
+    monkeypatch.setattr("supervisor.state.append_jsonl", lambda *a, **k: None)
+    return alerts
+
+
+def test_wall_clock_jump_neither_fabricates_nor_masks_a_supervisor_stall(monkeypatch):
+    """OB-03: the stall half is measured on ``time.monotonic()``.
+
+    The liveness tick and its comparison used to both be ``time.time()``, so an
+    ordinary wall-clock step — NTP correction, DST/timezone change, manual set, a
+    resumed VM — was indistinguishable from an unresponsive supervisor loop. Both
+    directions are pinned: a forward jump must not INVENT a stall, and a backward
+    jump must not MASK a real one.
+    """
+    import server
+    import supervisor.workers as w
+
+    monkeypatch.setenv("OUROBOROS_SUPERVISOR_LIVENESS_DEADLINE_SEC", "1")
+    monkeypatch.setattr(w, "_chat_agent", None)  # isolate the stall half
+    alerts = _collect_alerts(monkeypatch, 11)
+
+    boot_mono = 500.0
+    wall = 1_700_000_000.0
+    clock = _FakeServerClock(wall=wall, mono=boot_mono)
+    monkeypatch.setattr(server, "time", clock)
+    stop = threading.Event()  # local per-test token
+    try:
+        # The loop ticked "just now" on the monotonic clock — it is healthy.
+        server._start_supervisor_liveness_watchdog([boot_mono], stop)
+        # Now the wall clock steps an hour forward while the loop keeps ticking.
+        clock.wall = wall + 3600.0
+        _wait_until(lambda: clock.ticks >= 3)
+        assert alerts == [], "a wall-clock jump must not fabricate a supervisor stall"
+
+        # A genuine stall (100s of MONOTONIC silence) is still caught, and a
+        # backward wall step cannot hide it.
+        clock.wall = wall - 86_400.0
+        clock.mono = boot_mono + 100.0
+        _wait_until(lambda: alerts)
+    finally:
+        _stop_watchdog(stop)
+    assert len(alerts) == 1
+    assert alerts[0][0] == 11 and "stalled" in alerts[0][1]
+    assert alerts[0][2]["progress_meta"]["task_incident"] == "supervisor_loop_stall"
+
+
+def test_wedge_half_stays_on_the_wall_clock_under_a_monotonic_tick(monkeypatch):
+    """OB-03 regression: the wedge half must keep comparing WALL stamps.
+
+    ``agent._last_activity_ts`` is a ``time.time()`` stamp. Swapping the whole
+    watchdog to one monotonic ``now`` makes ``now - turn_ts`` a large NEGATIVE
+    number on any host whose uptime is shorter than the Unix epoch — i.e. every
+    host — so ``_chat_turn_wedged`` would answer False forever and this alert
+    would silently never fire again. That is the split this test defends.
+    """
+    import types
+
+    import server
+    import supervisor.workers as w
+
+    monkeypatch.setenv("OUROBOROS_SUPERVISOR_LIVENESS_DEADLINE_SEC", "1")
+    alerts = _collect_alerts(monkeypatch, 13)
+
+    wall = 1_700_000_000.0
+    clock = _FakeServerClock(wall=wall, mono=42.0)  # a freshly booted host
+    monkeypatch.setattr(server, "time", clock)
+    monkeypatch.setattr(w, "_chat_agent", types.SimpleNamespace(
+        _busy=True, _current_task_id="wedged-split", _last_activity_ts=wall - 100.0))
+    stop = threading.Event()  # local per-test token
+    try:
+        # Liveness tick == the current monotonic reading: the loop is HEALTHY.
+        server._start_supervisor_liveness_watchdog([clock.mono], stop)
+        _wait_until(lambda: alerts)
+    finally:
+        _stop_watchdog(stop)
+    assert alerts, "a wall-stale chat turn must still be detected under a monotonic tick"
+    assert "wedged" in alerts[0][1]
+    assert alerts[0][2]["task_id"] == "wedged-split"
+    assert not any("stalled" in a[1] for a in alerts)  # the healthy tick raised nothing

--- a/tests/test_ws3_wedge_resilience.py
+++ b/tests/test_ws3_wedge_resilience.py
@@ -125,8 +125,9 @@ def test_watchdog_alerts_on_chat_turn_wedge(monkeypatch):
     monkeypatch.setattr("supervisor.message_bus.get_bridge", lambda: _Bridge())
     monkeypatch.setattr("supervisor.state.load_state", lambda: {"owner_chat_id": 7})
     monkeypatch.setattr("supervisor.state.append_jsonl", lambda *a, **k: None)
+    # The heartbeat stamp is MONOTONIC (OB-03) — seed it on the same clock.
     monkeypatch.setattr(w, "_chat_agent", types.SimpleNamespace(
-        _busy=True, _current_task_id="wedged1", _last_activity_ts=time.time() - 100))
+        _busy=True, _current_task_id="wedged1", _last_activity_ts=time.monotonic() - 100))
     stop = threading.Event()  # local per-test token
     try:
         server._start_supervisor_liveness_watchdog([time.monotonic()], stop)
@@ -146,7 +147,7 @@ def test_watchdog_alerts_on_chat_turn_wedge(monkeypatch):
     }
 
 
-# --- OB-03: the watchdog's two halves run on two different clocks ------------
+# --- OB-03: both watchdog halves share the one monotonic clock ---------------
 
 
 class _FakeServerClock:
@@ -253,15 +254,11 @@ def test_wall_clock_jump_neither_fabricates_nor_masks_a_supervisor_stall(monkeyp
     assert alerts[0][2]["progress_meta"]["task_incident"] == "supervisor_loop_stall"
 
 
-def test_wedge_half_stays_on_the_wall_clock_under_a_monotonic_tick(monkeypatch):
-    """OB-03 regression: the wedge half must keep comparing WALL stamps.
-
-    ``agent._last_activity_ts`` is a ``time.time()`` stamp. Swapping the whole
-    watchdog to one monotonic ``now`` makes ``now - turn_ts`` a large NEGATIVE
-    number on any host whose uptime is shorter than the Unix epoch — i.e. every
-    host — so ``_chat_turn_wedged`` would answer False forever and this alert
-    would silently never fire again. That is the split this test defends.
-    """
+def test_wall_clock_jump_neither_fabricates_nor_masks_a_chat_turn_wedge(monkeypatch):
+    """OB-03, the wedge half — the CONTRACT, not the implementation: a silent chat
+    turn is detected, and a wall-clock jump neither fabricates a wedge nor masks one.
+    ``agent._last_activity_ts`` is a monotonic stamp (agent.py), compared against the
+    same monotonic ``now`` as the stall half — one clock, one class."""
     import types
 
     import server
@@ -270,19 +267,57 @@ def test_wedge_half_stays_on_the_wall_clock_under_a_monotonic_tick(monkeypatch):
     monkeypatch.setenv("OUROBOROS_SUPERVISOR_LIVENESS_DEADLINE_SEC", "1")
     alerts = _collect_alerts(monkeypatch, 13)
 
+    boot_mono = 500.0
     wall = 1_700_000_000.0
-    clock = _FakeServerClock(wall=wall, mono=42.0)  # a freshly booted host
+    clock = _FakeServerClock(wall=wall, mono=boot_mono)
     monkeypatch.setattr(server, "time", clock)
-    monkeypatch.setattr(w, "_chat_agent", types.SimpleNamespace(
-        _busy=True, _current_task_id="wedged-split", _last_activity_ts=wall - 100.0))
+    agent_stub = types.SimpleNamespace(
+        _busy=True, _current_task_id="wedged-mono", _last_activity_ts=boot_mono)
+    monkeypatch.setattr(w, "_chat_agent", agent_stub)
     stop = threading.Event()  # local per-test token
     try:
-        # Liveness tick == the current monotonic reading: the loop is HEALTHY.
-        server._start_supervisor_liveness_watchdog([clock.mono], stop)
+        server._start_supervisor_liveness_watchdog([boot_mono], stop)
+        # The turn heartbeat is fresh; an hour-forward WALL step must not invent a
+        # wedge (pre-fix, a wall-fed comparison fabricated exactly this alert).
+        clock.wall = wall + 3600.0
+        _wait_until(lambda: clock.ticks >= 3)
+        assert alerts == [], "a wall-clock jump must not fabricate a chat-turn wedge"
+
+        # A genuine wedge: 100s of MONOTONIC heartbeat silence while the loop's own
+        # tick stays healthy; a backward wall step cannot hide it.
+        clock.wall = wall - 86_400.0
+        clock.mono = boot_mono + 100.0
+        stop_liveness = [clock.mono]  # loop keeps ticking; only the TURN is silent
+        _stop_watchdog(stop)
+        stop = threading.Event()
+        alerts.clear()
+        server._start_supervisor_liveness_watchdog(stop_liveness, stop)
         _wait_until(lambda: alerts)
     finally:
         _stop_watchdog(stop)
-    assert alerts, "a wall-stale chat turn must still be detected under a monotonic tick"
+    assert alerts, "a heartbeat-silent chat turn must be detected under any wall clock"
     assert "wedged" in alerts[0][1]
-    assert alerts[0][2]["task_id"] == "wedged-split"
+    assert alerts[0][2]["task_id"] == "wedged-mono"
     assert not any("stalled" in a[1] for a in alerts)  # the healthy tick raised nothing
+
+
+def test_watchdog_and_heartbeat_writers_share_the_monotonic_clock():
+    """Source-level pin of the PRODUCTION writers (the behavioural tests above feed
+    hand-built stamps, so a writer regressed to ``time.time()`` would leave them
+    green): the supervisor loop's two liveness stamps and the direct-chat turn's two
+    heartbeat stamps must all be taken on ``time.monotonic()``. The idiom follows
+    test_server_shutdown.py's existing ``inspect.getsource`` pin of _run_supervisor.
+    """
+    import inspect
+    import re
+
+    import server
+    from ouroboros.agent import OuroborosAgent
+
+    sup_src = inspect.getsource(server._run_supervisor)
+    liveness_writes = re.findall(r"_loop_liveness(?:\[0\])?\s*=\s*\[?time\.(\w+)\(\)", sup_src)
+    assert liveness_writes and set(liveness_writes) == {"monotonic"}, liveness_writes
+
+    agent_src = inspect.getsource(OuroborosAgent)
+    heartbeat_writes = re.findall(r"_last_activity_ts\s*=\s*time\.(\w+)\(\)", agent_src)
+    assert heartbeat_writes and set(heartbeat_writes) == {"monotonic"}, heartbeat_writes


### PR DESCRIPTION
Supersedes #348 by @kazzand. His three commits open this branch with authorship untouched; this successor PR exists only because maintainer edits cannot be pushed to his fork branch (the fork's parent is a different repository in the network, and GitHub's allow-maintainer-edits does not cross that boundary).

What his work fixes, kept in full: a recycled pid plus a coarse start time could authorize killing an unrelated process; the boot-qualified start-time fingerprint refuses that, liveness moves to /proc-first reads, and the supervisor watchdog gets a cheap same-session liveness path.

The maintainer rework on top (one commit, rationale in its message):

- Downgrade-safe fingerprint pair: `start_time` keeps the legacy `ps` spelling an N-1 reader understands (a rollback would otherwise orphan every row), and the boot-qualified token lives in the new `start_time_boot` sibling, omitted when it would duplicate the legacy spelling.
- A bare tick never authorizes a kill, and refuted boot evidence never re-qualifies through the legacy fallback: a row carrying a boot sibling is judged by boot evidence alone (a mismatched sibling is positive proof of another boot and prunes, never kills). Disclosed residuals: pre-upgrade sibling-free bare-tick rows on the one host class that mints them (no usable `ps`), and the `"<ticks>."` cross-boot twin minted only when boot id AND `ps` both fail.
- Clock unification finished: the last two wall-clock writers of the liveness fields move to `time.monotonic()`, the wedge half compares on the same clock, and the stall toast key gains the pid so a second stall in one process is not deduplicated away.
- Full boot UUID (the 8-hex truncation bought only collision odds).

Tests pin the rollback matrix, the refuted-boot-evidence prune, the writer pair (source-level), and wall-clock-jump immunity. Version carriers are byte-neutral against the target branch.
