### PR TITLE
Web UI: dialogs above every overlay; bounded per-task chat ledgers

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,7 @@ launcher.py (PyWebView)       ← desktop window, release-reviewed outer shell (
 server.py (Starlette+uvicorn) ← HTTP + WebSocket on configurable host:port (default localhost:8765; Docker/non-loopback supported via OUROBOROS_SERVER_HOST=0.0.0.0)
   │
   ├── web/                     ← Web UI (SPA with ES modules in web/modules/)
-  │   └── modules/review_presentation.js, review_dom_patch.js, and harness_presentation.js ← Review Checkpoint grouping/status, keyed DOM reconciliation, and neutral harness identity presentation; read-side only
+  │   └── modules/review_presentation.js, review_dom_patch.js, and harness_presentation.js ← Review Checkpoint grouping/status, keyed DOM reconciliation, and neutral harness identity presentation; read-side only. modules/chat_ledgers.js ← bounded per-task presentation ledgers for a chat instance (live-card cap with finished-only DOM-and-record eviction, job-keyed review-detail FIFO, terminal-activity keepers) — extracted from chat.js at its shrink-only byte-ratchet boundary
   │
   ├── supervisor/              ← Background thread inside server.py
   │   ├── active_activity.py   ← In-memory thread-safe registry (`DirectActivityRegistry`, `track_direct_activity`) for in-flight direct and ephemeral chat turns; feeds `/api/state` (`active_direct_turns`) and WS typing frames with `activity_id`, `client_message_id`, `phase`, and `kind` without creating supervisor queue records

--- a/ouroboros/size_ratchet_manifest.py
+++ b/ouroboros/size_ratchet_manifest.py
@@ -214,10 +214,10 @@ BAND_PATHS = {
     "web/modules/harness_accounts.js": None,
     "web/modules/log_events.js": None,
     "web/modules/onboarding_wizard.js": "Shrank INTO the band: the Claude Runtime onboarding card and its /api/claude-code/* polling were deleted with the retired transport (owner-approved Q4); no new content was added.",
-    "web/modules/review_presentation.js": "Review Checkpoint read-side grouping, lifecycle/verdict separation, and keyed disclosure reconciliation remain one pure adapter below the 1500-line band cap.",
     "web/modules/reviewer_slots.js": "Owner-approved 5A editor: per-row Direct model / Configured subagent source picker with read-only derived disclosure replaces the legacy Claude-SDK advisory input in the same module that owns reviewer-row editing.",
     "web/modules/settings.js": None,
     "web/modules/widgets.js": None,
+    "web/tests/chat_instance_dom.test.js": "Entered the band with the issue-135 ledger-eviction integration test: the in-file DOM stub harness is the one place a real createChatInstance can be driven end to end, and the eviction contract (finished cards leave the transcript with their records at the cap) belongs beside the other instance-level DOM pins.",
     "web/tests/harness_login_cards.test.js": "Login-card suite grew past 1000 lines with the name-the-account face cases (agy pickup, issue #232); split when the next face lands.",
     "web/tests/review_presentation.test.js": "Review Checkpoint lifecycle and verdict reconciliation remain covered by one focused presentation suite.",
 }
@@ -235,5 +235,5 @@ BYTE_DEBT = {
     "ouroboros/loop.py": 284435,
     "tests/test_delegated_subagent_transport.py": 320337,
     "tests/test_devtools_benchmarks.py": 328116,
-    "web/modules/chat.js": 208394,
+    "web/modules/chat.js": 208366,
 }

--- a/tests/test_web_dialogs_static.py
+++ b/tests/test_web_dialogs_static.py
@@ -81,3 +81,27 @@ def test_confirm_dialog_offers_the_alert_mode() -> None:
     source = (WEB_MODULES / "confirm_dialog.js").read_text(encoding="utf-8")
     assert "alert = false" in source
     assert "openConfirmDialog" in source
+
+
+def test_confirm_dialog_backdrop_stacks_above_every_overlay() -> None:
+    """Dialogs must render OVER the reconnect shade — not under it, visible
+    through the tint but unclickable (issue #146). Static pin of the layer
+    order; the cross-element stack is decided by z-index alone because both
+    are body-level siblings. (The former .update-dialog-overlay was retired
+    by the Updates-tab redesign; the reconnect shade is the one full-screen
+    overlay left at the 1000 layer.)"""
+    css = (REPO_ROOT / "web" / "style.css").read_text(encoding="utf-8")
+
+    def effective_z(selector_re: str) -> int:
+        # Cascade-honest: for equal-specificity selector blocks the LAST
+        # declaration wins, so the pin reads the final value, not the max.
+        found = []
+        for block in re.finditer(selector_re + r"[^{]*{[^}]*}", css):
+            m = re.search(r"z-index:\s*(\d+)", block.group(0))
+            if m:
+                found.append(int(m.group(1)))
+        assert found, f"no z-index found for {selector_re}"
+        return found[-1]
+
+    confirm = effective_z(r"\.confirm-dialog-backdrop")
+    assert confirm > effective_z(r"#reconnect-overlay")

--- a/web/modules/chat.js
+++ b/web/modules/chat.js
@@ -38,6 +38,7 @@ import {
     resumeTaskAction,
     taskControlBusy,
 } from './task_control_menu.js';
+import { BoundedDetailMap, createChatLedgers } from './chat_ledgers.js';
 import { openConfirmDialog } from './confirm_dialog.js';
 import {
     captureLiveCardPhaseState,
@@ -493,7 +494,7 @@ export function createChatInstance({
     const markReviewAnchor = (r, on = false) => setReviewAnchor(r, on, setLiveCardPhase);
     const explicitCardExpansion = new Map();
     const reviewDisclosureByTask = new Map();
-    const skillReviewDetailStore = new Map();
+    const skillReviewDetailStore = new BoundedDetailMap();
     const reviewHydrator = createReviewHydrator({
         fetchDetail: fetchTaskDetailStrict,
         applyDetail: (id, detail) => !destroyed && attachTaskDetailReviews(id, detail),
@@ -513,7 +514,6 @@ export function createChatInstance({
     // Bounded conclusions block late root typing and stale state snapshots; reusable
     // logical task slots are cleared whenever their cycle settles.
     const concludedDirectActivities = new Map();
-    const CONCLUDED_ACTIVITY_LEDGER_MAX = 200;
     // Retryable queue-loss candidates plus process-local single-flight reads.
     const missingManagedTaskIds = new Set();
     const managedTaskDetailReads = new Set();
@@ -529,27 +529,43 @@ export function createChatInstance({
         }
     }
 
-    function recordConcludedActivity(activityId) {
-        const aid = taskKey(activityId);
-        if (!aid) return;
-        missingManagedTaskIds.delete(aid);
-        concludedDirectActivities.delete(aid);
-        concludedDirectActivities.set(aid, Date.now());
-        while (concludedDirectActivities.size > CONCLUDED_ACTIVITY_LEDGER_MAX) {
-            const oldest = concludedDirectActivities.keys().next().value;
-            concludedDirectActivities.delete(oldest);
-        }
-    }
-    function recordTerminalActivity(taskId) {
-        const id = taskKey(taskId);
-        if (!id) return;
-        activeDirectActivities.delete(id);
-        missingManagedTaskIds.delete(id);
-        if (REUSABLE_TASK_IDS.has(id)) concludedDirectActivities.delete(id);
-        else recordConcludedActivity(id);
-    }
     // Finished task ids hidden from routine syncs until reload/reconnect rebuilds history.
     const retiredTaskIds = new Set();
+    // `cancelable` marker (queue tasks the cancel endpoint can genuinely reach).
+    // Learned from live WS frames and history replay alike, possibly before the
+    // card exists, so it lives beside the card records rather than on them.
+    const cancelableTaskIds = new Set();
+    // Bounded per-task ledger keepers (issue #135), extracted to chat_ledgers.js
+    // at chat.js's shrink-only byte-ratchet boundary; destructuring keeps the
+    // original call names.
+    const subagentChildParents = new Map();
+    const subagentTerminalChildren = new Set();
+    const {
+        recordConcludedActivity, recordTerminalActivity,
+        scheduleTaskUiCleanup, evictFinishedCardsOverCap,
+    } = createChatLedgers({
+        taskKey,
+        liveCardRecords,
+        taskUiStates,
+        retiredTaskIds,
+        explicitCardExpansion,
+        reviewDisclosureByTask,
+        skillReviewDetailStore,
+        pendingSuggestedNames,
+        cancelableTaskIds,
+        concludedDirectActivities,
+        activeDirectActivities,
+        missingManagedTaskIds,
+        subagentChildParents,
+        reviewHydrator,
+    });
+    function runLedgerEviction() {
+        withStableViewport(() => {
+            for (const evictedId of evictFinishedCardsOverCap()) {
+                if (activeLiveGroupId === evictedId) activeLiveGroupId = '';
+            }
+        });
+    }
     // The owner's last main-chat request, handed to the next live card it spawns so a
     // "turn into project" conversion can name the project from it (P1).
     let _pendingCardObjective = '';
@@ -814,19 +830,6 @@ export function createChatInstance({
         return createIfMissing ? createTaskUiState(taskId) : null;
     }
 
-    function scheduleTaskUiCleanup(taskState, delayMs = 120000) {
-        if (!taskState) return;
-        if (taskState.cleanupTimer) clearTimeout(taskState.cleanupTimer);
-        taskState.cleanupTimer = setTimeout(() => {
-            taskUiStates.delete(taskState.taskId);
-            // Keep the finished card interactive, but mark it retired so routine
-            // syncs do not rebuild duplicates. Reload/reconnect clears this set.
-            if (!REUSABLE_TASK_IDS.has(taskState.taskId) && taskState.taskId !== '') {
-                retiredTaskIds.add(taskState.taskId);
-            }
-        }, delayMs);
-    }
-
     function bufferLiveUpdate(taskState, summary, ts, dedupeKey = '', rawTs = '') {
         if (!taskState || !summary) return;
         taskState.bufferedLiveUpdates.push({
@@ -964,11 +967,6 @@ export function createChatInstance({
     }
 
     // v6.82 (P5): task ids whose progress carried the supervisor's host-attested
-    // `cancelable` marker (queue tasks the cancel endpoint can genuinely reach).
-    // Learned from live WS frames and history replay alike, possibly before the
-    // card exists, so it lives beside the card records rather than on them.
-    const cancelableTaskIds = new Set();
-
     function queueTaskLiveUpdate(summary, taskId, ts, dedupeKey = '', rawTs = '') {
         return withStableViewport(() => queueTaskLiveUpdateMutation(
             summary, taskId, ts, dedupeKey, rawTs,
@@ -1240,7 +1238,9 @@ export function createChatInstance({
     // so the main chat is freed — the card stops being a busy red task and
     // recolors to the project fuchsia. Plain wording (no "ack"); click opens the panel.
     function markCardConverted(record, project) {
-        return withStableViewport(() => markCardConvertedMutation(record, project));
+        const result = withStableViewport(() => markCardConvertedMutation(record, project));
+        runLedgerEviction();
+        return result;
     }
 
     function markCardConvertedMutation(record, project) {
@@ -1549,6 +1549,7 @@ export function createChatInstance({
             }
         });
         liveCardRecords.set(normalizedGroupId, record);
+        runLedgerEviction();
         // Cluster B: apply a name that arrived (task_named) before this card existed.
         const _pendingName = pendingSuggestedNames.get(normalizedGroupId);
         if (_pendingName && !record.isSubagent) {
@@ -1869,9 +1870,11 @@ export function createChatInstance({
     }
 
     function applyLiveCardState(summary, groupId, ts, dedupeKey = '', options = {}) {
-        return withStableViewport(() => applyLiveCardStateMutation(
+        const result = withStableViewport(() => applyLiveCardStateMutation(
             summary, groupId, ts, dedupeKey, options,
         ));
+        runLedgerEviction();
+        return result;
     }
 
     function applyLiveCardStateMutation(summary, groupId, ts, dedupeKey = '', { suppressDomInsert = false, rawTs = '' } = {}) {
@@ -2070,7 +2073,11 @@ export function createChatInstance({
     }
 
     function finishLiveCard(groupId = '', phase = '') {
-        return withStableViewport(() => finishLiveCardMutation(groupId, phase));
+        const result = withStableViewport(() => finishLiveCardMutation(groupId, phase));
+        // A settle can push the finished population over the cap without any
+        // new card being created; keep the bound maintained, not edge-triggered.
+        runLedgerEviction();
+        return result;
     }
 
     function finishLiveCardMutation(groupId = '', phase = '') {
@@ -2173,10 +2180,10 @@ export function createChatInstance({
     // child task_id -> { parentId, role }, learned from subagent lifecycle pings.
     // Child cards are mounted under the parent card, but their phase/terminal
     // state is independent so a finished child cannot mark the parent done.
-    const subagentChildParents = new Map();
+
     // Children whose card has reached a terminal phase — late non-lifecycle
     // progress for these must NOT revive it back to "working".
-    const subagentTerminalChildren = new Set();
+
 
     // E2 (v6.39 UI): merge a subagent's parent/role/model, PRESERVING a previously-seen model
     // when a later (model-less) event — e.g. a synthesized terminal — updates the entry, so the

--- a/web/modules/chat_ledgers.js
+++ b/web/modules/chat_ledgers.js
@@ -1,0 +1,174 @@
+// Bounded per-task presentation ledgers for a chat instance (issue #135).
+// Extracted from chat.js at its shrink-only byte-ratchet boundary: the
+// always-alive Main instance accumulated liveCardRecords and its per-task
+// satellites forever (destroy() — the only cleanup — never runs for Main).
+// chat.js wires its instance Maps in once and keeps the original call names
+// via destructuring; every keeper mutates those same Maps in place.
+import { REUSABLE_TASK_IDS } from './task_control_menu.js';
+
+// Caps mirror the capped neighbors already in chat.js (persistedHistory 200,
+// pendingSuggestedNames 100): records of UNFINISHED tasks are never evicted.
+export const LIVE_CARD_RECORDS_CAP = 200;
+export const SKILL_REVIEW_DETAIL_CAP = 200;
+export const CONCLUDED_ACTIVITY_LEDGER_MAX = 200;
+export const RETIRED_TASK_IDS_CAP = 2000;
+
+// The job-keyed review-detail cache IS a Map subclass, not a facade: its one
+// consumer type-gates on `store instanceof Map` (skill_review_card.js) and
+// silently discards anything else, so a wrapper object would disable both the
+// cache and the cap. Every insert trims FIFO on the store's own key space.
+export class BoundedDetailMap extends Map {
+    set(key, value) {
+        super.set(key, value);
+        while (this.size > SKILL_REVIEW_DETAIL_CAP) {
+            this.delete(this.keys().next().value);
+        }
+        return this;
+    }
+}
+
+export function createChatLedgers({
+    taskKey,
+    liveCardRecords,
+    taskUiStates,
+    retiredTaskIds,
+    explicitCardExpansion,
+    reviewDisclosureByTask,
+    skillReviewDetailStore,
+    pendingSuggestedNames,
+    cancelableTaskIds,
+    concludedDirectActivities,
+    activeDirectActivities,
+    missingManagedTaskIds,
+    subagentChildParents = null,
+    reviewHydrator = null,
+}) {
+    function retireId(id) {
+        // Bounded anti-duplicate memory: FIFO past the cap (mirrors the
+        // seenMessageKeys 2000 idiom). Ids old enough to be evicted here are
+        // far outside the history-replay window, so losing the marker cannot
+        // mint a duplicate beside a live card.
+        if (REUSABLE_TASK_IDS.has(id) || id === '') return;
+        retiredTaskIds.delete(id);
+        retiredTaskIds.add(id);
+        while (retiredTaskIds.size > RETIRED_TASK_IDS_CAP) {
+            retiredTaskIds.delete(retiredTaskIds.keys().next().value);
+        }
+    }
+
+    function recordConcludedActivity(activityId) {
+        const aid = taskKey(activityId);
+        if (!aid) return;
+        missingManagedTaskIds.delete(aid);
+        concludedDirectActivities.delete(aid);
+        concludedDirectActivities.set(aid, Date.now());
+        while (concludedDirectActivities.size > CONCLUDED_ACTIVITY_LEDGER_MAX) {
+            const oldest = concludedDirectActivities.keys().next().value;
+            concludedDirectActivities.delete(oldest);
+        }
+    }
+
+    function recordTerminalActivity(taskId) {
+        const id = taskKey(taskId);
+        if (!id) return;
+        activeDirectActivities.delete(id);
+        missingManagedTaskIds.delete(id);
+        if (REUSABLE_TASK_IDS.has(id)) concludedDirectActivities.delete(id);
+        else recordConcludedActivity(id);
+    }
+
+    function scheduleTaskUiCleanup(taskState, delayMs = 120000) {
+        if (!taskState) return;
+        if (taskState.cleanupTimer) clearTimeout(taskState.cleanupTimer);
+        taskState.cleanupTimer = setTimeout(() => {
+            taskUiStates.delete(taskState.taskId);
+            // Keep the finished card interactive, but mark it retired so routine
+            // syncs do not rebuild duplicates. Reload/reconnect clears this set.
+            retireId(taskState.taskId);
+        }, delayMs);
+    }
+
+    function descendantRecordIds(rootId) {
+        // BFS over the whole lineage: subagent trees nest (depth 3 by default),
+        // so eligibility and cascade must see grandchildren, not only children.
+        if (!subagentChildParents) return [];
+        const ids = [];
+        const visited = new Set([rootId]);
+        const queue = [rootId];
+        while (queue.length) {
+            const current = queue.shift();
+            for (const [childId, meta] of subagentChildParents) {
+                // The visited set terminates on cyclic lineage metadata (two
+                // individually valid frames can form A -> B -> A).
+                if (meta?.parentId !== current || visited.has(childId)) continue;
+                visited.add(childId);
+                if (liveCardRecords.has(childId)) ids.push(childId);
+                queue.push(childId);
+            }
+        }
+        return ids;
+    }
+
+    function evictionBlocked(recordId) {
+        const record = liveCardRecords.get(recordId);
+        if (!record?.finished) return true; // unfinished work is never evicted
+        // A converted card is the task's project pointer — keep it.
+        return record?.root?.dataset?.projectCreated === '1';
+    }
+
+    function evictOne(victimId) {
+        const record = liveCardRecords.get(victimId);
+        const taskState = taskUiStates.get(victimId);
+        if (taskState?.cleanupTimer) clearTimeout(taskState.cleanupTimer);
+        taskUiStates.delete(victimId);
+        record?.root?.remove?.();
+        liveCardRecords.delete(victimId);
+        retireId(victimId);
+        explicitCardExpansion.delete(victimId);
+        reviewDisclosureByTask.delete(victimId);
+        pendingSuggestedNames.delete(victimId);
+        cancelableTaskIds.delete(victimId);
+        // Forget hydration state too: a late reference may legitimately
+        // recreate the card, and a stale appliedRevision would make that
+        // fresh card short-circuit into a permanently blank Reviews block.
+        reviewHydrator?.drop?.(victimId);
+        return victimId;
+    }
+
+    function evictFinishedCardsOverCap() {
+        const evicted = [];
+        while (liveCardRecords.size > LIVE_CARD_RECORDS_CAP) {
+            let victimId = null;
+            for (const [id] of liveCardRecords) {
+                // The victim and its ENTIRE live lineage must be evictable:
+                // an unfinished or converted descendant anywhere below keeps
+                // the whole composite (its DOM nests under this root).
+                if (evictionBlocked(id)) continue;
+                if (descendantRecordIds(id).some(evictionBlocked)) continue;
+                victimId = id;
+                break;
+            }
+            if (victimId === null) break;
+            // Same shape as chat.js's ephemeral-conversion cleanup: the DOM card
+            // goes WITH its record (card handlers close over the record, so a
+            // kept card would pin it in memory anyway), and the retired id makes
+            // a late frame mint at most one fresh card instead of a duplicate
+            // beside a zombie. Matches what a reload already shows the user:
+            // history rebuilds only the recent window.
+            const lineage = descendantRecordIds(victimId);
+            evicted.push(evictOne(victimId));
+            // The victim subtree carried every descendant's DOM; evict their
+            // records with it so nothing keeps pointing at detached nodes
+            // (the victim guard above proved the whole lineage evictable).
+            for (const descendantId of lineage) evicted.push(evictOne(descendantId));
+        }
+        return evicted;
+    }
+
+    return {
+        recordConcludedActivity,
+        recordTerminalActivity,
+        scheduleTaskUiCleanup,
+        evictFinishedCardsOverCap,
+    };
+}

--- a/web/modules/review_presentation.js
+++ b/web/modules/review_presentation.js
@@ -1087,15 +1087,23 @@ export function createReviewHydrator({ fetchDetail, applyDetail, onState = () =>
             .then((detail) => {
                 // The strict seam rejects failures; null means genuinely absent (404).
                 if (detail === null || detail === undefined) return false;
+                // drop() may have evicted this task mid-flight: applying a
+                // detached request would repaint (or recreate) a card the
+                // caller just removed.
+                if (states.get(taskId) !== state) return false;
                 return write(() => applyDetail(taskId, detail));
             })
             .then((applied) => {
+                if (states.get(taskId) !== state) return applied;
                 if (applied !== false && revision !== null) state.appliedRevision = revision;
                 state.everApplied = true;
                 notify('idle');
                 return applied;
             })
             .catch(() => {
+                // Same identity bail as the success path: a dropped/evicted
+                // task's failing fetch must not flip a recreated card to error.
+                if (states.get(taskId) !== state) return false;
                 notify('error');
                 return false;
             })
@@ -1114,6 +1122,13 @@ export function createReviewHydrator({ fetchDetail, applyDetail, onState = () =>
     };
 
     return {
+        drop(taskIdValue) {
+            // Eviction hook for callers that bound their per-task presentation
+            // state: forget this task's hydration state entirely, so a later
+            // recreated card hydrates fresh instead of short-circuiting on a
+            // stale appliedRevision.
+            states.delete(text(taskIdValue));
+        },
         hydrate(taskIdValue, revisionValue = null, { onDomWrite = null } = {}) {
             const taskId = text(taskIdValue);
             if (!taskId) return Promise.resolve(false);

--- a/web/style.css
+++ b/web/style.css
@@ -5060,6 +5060,16 @@ textarea.chat-input::placeholder { color: var(--text-muted); }
     gap: 12px;
 }
 
+/* Confirm/input/alert dialogs must stay usable over EVERY overlay — the
+   reconnect shade sits at 1000 (the Panic confirm is the canonical case: it
+   must be clickable while the socket is down). Content modals
+   (:where(.marketplace-modal-backdrop), 90) deliberately stay under the
+   shade — their actions need a live connection anyway. Overlay scale:
+   modals 90 · toasts/menus 120 · reconnect 1000 · dialogs 1100. */
+.confirm-dialog-backdrop {
+    z-index: 1100;
+}
+
 .confirm-dialog {
     max-width: 520px;
 }

--- a/web/tests/chat_instance_dom.test.js
+++ b/web/tests/chat_instance_dom.test.js
@@ -998,3 +998,77 @@ test('history replay keeps an ownerless duplicate acknowledgement without a task
         restoreDom(prior);
     }
 });
+
+
+test('finished task cards over the ledger cap leave the transcript with their records', async () => {
+    const { prior, mount } = installDom();
+    const handlers = new Map();
+    const ws = {
+        on(type, fn) { handlers.set(type, fn); return () => handlers.delete(type); },
+        isConnected: () => true,
+        send() {},
+    };
+    let generation = 0;
+    const stateSnapshots = {
+        begin: () => ({ generation: ++generation, requestedAt: Date.now() }),
+        isCurrent: () => true,
+        apply() {},
+    };
+    let instance;
+    try {
+        instance = createChatInstance({
+            ws,
+            state: { activePage: 'chat', projectChatIds: new Set(), unreadCount: 0 },
+            updateUnreadBadge() {}, stateSnapshots, chatId: 2, idPrefix: 'chat', mountEl: mount,
+            asPanel: true,
+        });
+        const messages = globalThis.document.byId.get('chat-messages');
+        const cardFor = (id) => messages.children.find((node) => node.dataset.taskId === id);
+        const seal = (id, second) => {
+            const ts = `2026-08-24T01:${String(Math.floor(second / 60)).padStart(2, '0')}:${String(second % 60).padStart(2, '0')}Z`;
+            handlers.get('chat')({
+                chat_id: 2, role: 'system', is_progress: true,
+                task_id: id, content: 'working', ts,
+            });
+            handlers.get('chat')({
+                chat_id: 2, role: 'system', is_progress: true,
+                task_id: id, content: 'done', task_terminal_status: 'completed',
+                outcome_axes: { execution: 'ok' }, ts,
+            });
+        };
+
+        seal('cap-smoke', 0);
+        assert.equal(cardFor('cap-smoke')?.dataset.finished, '1',
+            'driver smoke: the terminal frame seals the card');
+
+        for (let i = 0; i < 210; i += 1) seal(`cap-t${i}`, i + 1);
+
+        assert.equal(cardFor('cap-smoke'), undefined, 'the oldest finished card left the DOM');
+        assert.equal(cardFor('cap-t0'), undefined, 'early finished cards left the DOM');
+        assert.ok(cardFor('cap-t209'), 'the newest card is present');
+        const taskCards = messages.children.filter((node) => node.dataset.taskId);
+        assert.ok(taskCards.length <= 200, `bounded card set, saw ${taskCards.length}`);
+
+        // The cap is MAINTAINED, not only insertion-triggered: grow the map
+        // with unfinished work past the cap, then settle one OLD task — the
+        // finish transition itself must evict it (it is the only finished one).
+        for (let i = 0; i < 210; i += 1) {
+            handlers.get('chat')({
+                chat_id: 2, role: 'system', is_progress: true,
+                task_id: `live-t${i}`, content: 'working',
+                ts: `2026-08-24T02:${String(Math.floor(i / 60)).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}Z`,
+            });
+        }
+        assert.ok(cardFor('live-t0'), 'unfinished cards are never evicted');
+        handlers.get('chat')({
+            chat_id: 2, role: 'system', is_progress: true,
+            task_id: 'live-t0', content: 'done', task_terminal_status: 'completed',
+            outcome_axes: { execution: 'ok' }, ts: '2026-08-24T02:05:00Z',
+        });
+        assert.equal(cardFor('live-t0'), undefined,
+            'settling over the cap evicts on the finish transition itself');
+    } finally {
+        instance?.destroy();
+        restoreDom(prior);
+    }
+});

--- a/web/tests/chat_ledgers.test.js
+++ b/web/tests/chat_ledgers.test.js
@@ -1,0 +1,281 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+    BoundedDetailMap,
+    CONCLUDED_ACTIVITY_LEDGER_MAX,
+    LIVE_CARD_RECORDS_CAP,
+    RETIRED_TASK_IDS_CAP,
+    SKILL_REVIEW_DETAIL_CAP,
+    createChatLedgers,
+} from '../modules/chat_ledgers.js';
+import { loadSkillReviewDetail } from '../modules/skill_review_card.js';
+
+function build() {
+    const maps = {
+        taskKey: (value) => String(value || '').trim(),
+        liveCardRecords: new Map(),
+        taskUiStates: new Map(),
+        retiredTaskIds: new Set(),
+        explicitCardExpansion: new Map(),
+        reviewDisclosureByTask: new Map(),
+        skillReviewDetailStore: new Map(),
+        pendingSuggestedNames: new Map(),
+        cancelableTaskIds: new Set(),
+        concludedDirectActivities: new Map(),
+        activeDirectActivities: new Map(),
+        missingManagedTaskIds: new Set(),
+        subagentChildParents: new Map(),
+    };
+    return { maps, ledgers: createChatLedgers(maps) };
+}
+
+const record = (finished) => ({
+    finished,
+    root: { removed: false, remove() { this.removed = true; } },
+});
+
+test('no eviction at or under the cap', () => {
+    const { maps, ledgers } = build();
+    for (let i = 0; i < LIVE_CARD_RECORDS_CAP; i += 1) maps.liveCardRecords.set(`t${i}`, record(true));
+    assert.deepEqual(ledgers.evictFinishedCardsOverCap(), []);
+    assert.equal(maps.liveCardRecords.size, LIVE_CARD_RECORDS_CAP);
+});
+
+test('over cap: the oldest FINISHED record goes, with its DOM and satellites', () => {
+    const { maps, ledgers } = build();
+    maps.liveCardRecords.set('unfinished-oldest', record(false));
+    for (let i = 0; i < LIVE_CARD_RECORDS_CAP; i += 1) maps.liveCardRecords.set(`t${i}`, record(true));
+    const victim = maps.liveCardRecords.get('t0');
+    maps.explicitCardExpansion.set('t0', true);
+    maps.reviewDisclosureByTask.set('t0', {});
+    maps.pendingSuggestedNames.set('t0', 'name');
+    maps.cancelableTaskIds.add('t0');
+    const timer = setTimeout(() => {}, 60000);
+    maps.taskUiStates.set('t0', { taskId: 't0', cleanupTimer: timer });
+
+    const evicted = ledgers.evictFinishedCardsOverCap();
+
+    assert.deepEqual(evicted, ['t0'], 'oldest finished, never the older unfinished one');
+    assert.equal(victim.root.removed, true, 'the DOM card leaves with the record');
+    assert.equal(maps.liveCardRecords.has('t0'), false);
+    assert.equal(maps.liveCardRecords.has('unfinished-oldest'), true);
+    assert.equal(maps.retiredTaskIds.has('t0'), true);
+    assert.equal(maps.explicitCardExpansion.has('t0'), false);
+    assert.equal(maps.reviewDisclosureByTask.has('t0'), false);
+    assert.equal(maps.pendingSuggestedNames.has('t0'), false);
+    assert.equal(maps.cancelableTaskIds.has('t0'), false);
+    assert.equal(maps.taskUiStates.has('t0'), false);
+    assert.equal(maps.liveCardRecords.size, LIVE_CARD_RECORDS_CAP);
+});
+
+test('all-unfinished over cap evicts nothing', () => {
+    const { maps, ledgers } = build();
+    for (let i = 0; i < LIVE_CARD_RECORDS_CAP + 5; i += 1) maps.liveCardRecords.set(`t${i}`, record(false));
+    assert.deepEqual(ledgers.evictFinishedCardsOverCap(), []);
+    assert.equal(maps.liveCardRecords.size, LIVE_CARD_RECORDS_CAP + 5);
+});
+
+test('a reusable logical slot id is never retired on eviction', () => {
+    const { maps, ledgers } = build();
+    maps.liveCardRecords.set('active', record(true));
+    for (let i = 0; i < LIVE_CARD_RECORDS_CAP; i += 1) maps.liveCardRecords.set(`t${i}`, record(true));
+    const evicted = ledgers.evictFinishedCardsOverCap();
+    assert.deepEqual(evicted, ['active']);
+    assert.equal(maps.retiredTaskIds.has('active'), false);
+});
+
+test('the job-keyed review-detail store is a bounded Map on its own keys', () => {
+    const store = new BoundedDetailMap();
+    for (let i = 0; i < SKILL_REVIEW_DETAIL_CAP + 3; i += 1) {
+        store.set(`skill:job-${i}`, { heavy: i });
+    }
+    assert.ok(store instanceof Map, 'the consumer type-gates on instanceof Map');
+    assert.equal(store.size, SKILL_REVIEW_DETAIL_CAP);
+    assert.equal(store.has('skill:job-0'), false);
+    assert.equal(store.has(`skill:job-${SKILL_REVIEW_DETAIL_CAP + 2}`), true);
+});
+
+test('scheduleTaskUiCleanup clears state and retires the id (moved verbatim)', async () => {
+    const { maps, ledgers } = build();
+    const state = { taskId: 't-done', cleanupTimer: null };
+    maps.taskUiStates.set('t-done', state);
+    ledgers.scheduleTaskUiCleanup(state, 1);
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    assert.equal(maps.taskUiStates.has('t-done'), false);
+    assert.equal(maps.retiredTaskIds.has('t-done'), true);
+});
+
+test('recordTerminalActivity: normal ids conclude, reusable slots reset', () => {
+    const { maps, ledgers } = build();
+    maps.activeDirectActivities.set('t1', {});
+    maps.missingManagedTaskIds.add('t1');
+    ledgers.recordTerminalActivity('t1');
+    assert.equal(maps.activeDirectActivities.has('t1'), false);
+    assert.equal(maps.missingManagedTaskIds.has('t1'), false);
+    assert.equal(maps.concludedDirectActivities.has('t1'), true);
+
+    maps.concludedDirectActivities.set('active', Date.now());
+    ledgers.recordTerminalActivity('active');
+    assert.equal(maps.concludedDirectActivities.has('active'), false);
+});
+
+test('concluded-activity ledger keeps its 200-entry cap', () => {
+    const { maps, ledgers } = build();
+    for (let i = 0; i < CONCLUDED_ACTIVITY_LEDGER_MAX + 4; i += 1) {
+        ledgers.recordConcludedActivity(`a${i}`);
+    }
+    assert.equal(maps.concludedDirectActivities.size, CONCLUDED_ACTIVITY_LEDGER_MAX);
+    assert.equal(maps.concludedDirectActivities.has('a0'), false);
+});
+
+
+test('the real detail-load consumer accepts and writes the bounded store', async () => {
+    const store = new BoundedDetailMap();
+    const full = { dataset: {}, innerHTML: '', textContent: '', replaceChildren() {} };
+    const state = await loadSkillReviewDetail(
+        full,
+        { skill: 'alpha', jobId: 'job-1' },
+        {
+            store,
+            fetchImpl: async () => ({ ok: true, json: async () => ({ markdown: '# detail' }) }),
+            render: () => '<h1>detail</h1>',
+            onDomWrite: (fn) => fn(),
+        },
+    );
+    assert.equal(state, 'loaded');
+    assert.equal(store.size, 1, 'the consumer must not silently discard the bounded store');
+    assert.equal([...store.values()][0].state, 'loaded');
+});
+
+test('eviction spares converted project chips and unfinished-child parents', () => {
+    const { maps, ledgers } = build();
+    const converted = record(true);
+    converted.root.dataset = { projectCreated: '1' };
+    maps.liveCardRecords.set('converted', converted);
+    maps.liveCardRecords.set('parent', record(true));
+    maps.liveCardRecords.set('child-live', record(false));
+    maps.subagentChildParents.set('child-live', { parentId: 'parent' });
+    for (let i = 0; i < LIVE_CARD_RECORDS_CAP; i += 1) maps.liveCardRecords.set(`t${i}`, record(true));
+
+    const evicted = ledgers.evictFinishedCardsOverCap();
+
+    assert.ok(!evicted.includes('converted'), 'a project chip is never evicted');
+    assert.ok(!evicted.includes('parent'), 'a parent with unfinished children is composite in-flight work');
+    assert.deepEqual(evicted, ['t0', 't1', 't2']);
+});
+
+test('evicting a finished parent cascades its finished child records', () => {
+    const { maps, ledgers } = build();
+    maps.liveCardRecords.set('parent', record(true));
+    maps.liveCardRecords.set('child-a', record(true));
+    maps.subagentChildParents.set('child-a', { parentId: 'parent' });
+    for (let i = 0; i < LIVE_CARD_RECORDS_CAP; i += 1) maps.liveCardRecords.set(`t${i}`, record(true));
+
+    const evicted = ledgers.evictFinishedCardsOverCap();
+
+    assert.deepEqual(evicted.slice(0, 2), ['parent', 'child-a'],
+        'the parent subtree carried the child DOM; the child record goes with it');
+    assert.equal(maps.liveCardRecords.has('child-a'), false);
+});
+
+test('the retired-id memory is bounded FIFO', () => {
+    const { maps, ledgers } = build();
+    for (let i = 0; i < RETIRED_TASK_IDS_CAP + LIVE_CARD_RECORDS_CAP + 10; i += 1) {
+        maps.liveCardRecords.set(`t${i}`, record(true));
+    }
+    ledgers.evictFinishedCardsOverCap();
+    assert.ok(maps.retiredTaskIds.size <= RETIRED_TASK_IDS_CAP);
+});
+
+test('eviction forgets hydration state so a recreated card hydrates fresh', () => {
+    const { maps } = build();
+    const dropped = [];
+    const ledgers = createChatLedgers({ ...maps, reviewHydrator: { drop: (id) => dropped.push(id) } });
+    for (let i = 0; i < LIVE_CARD_RECORDS_CAP + 1; i += 1) maps.liveCardRecords.set(`t${i}`, record(true));
+    assert.deepEqual(ledgers.evictFinishedCardsOverCap(), ['t0']);
+    assert.deepEqual(dropped, ['t0']);
+});
+
+test('a dropped hydration cannot apply its in-flight detail afterwards', async () => {
+    const { createReviewHydrator } = await import('../modules/review_presentation.js');
+    const applied = [];
+    let release;
+    const gate = new Promise((resolve) => { release = resolve; });
+    const hydrator = createReviewHydrator({
+        fetchDetail: async () => { await gate; return { plan_review_state: {} }; },
+        applyDetail: (id) => { applied.push(id); return true; },
+    });
+    const pending = hydrator.hydrate('t-evicted', 7);
+    hydrator.drop('t-evicted');
+    release();
+    await pending;
+    assert.deepEqual(applied, [], 'detail resolved after drop() must not apply');
+});
+
+
+test('a dropped hydration cannot flip status to error afterwards either', async () => {
+    const { createReviewHydrator } = await import('../modules/review_presentation.js');
+    const statuses = [];
+    let reject;
+    const gate = new Promise((_resolve, rej) => { reject = rej; });
+    const hydrator = createReviewHydrator({
+        fetchDetail: async () => { await gate; },
+        applyDetail: () => true,
+        onState: (id, status) => statuses.push(`${id}:${status}`),
+    });
+    const pending = hydrator.hydrate('t-evicted', 7);
+    hydrator.drop('t-evicted');
+    reject(new Error('late transport failure'));
+    await pending;
+    assert.deepEqual(statuses, ['t-evicted:loading'],
+        'the rejection path honors the same identity bail as success');
+});
+
+test('eviction eligibility and cascade see the WHOLE lineage, not only children', () => {
+    const { maps, ledgers } = build();
+    // Composite A: finished parent -> finished child -> UNFINISHED grandchild.
+    maps.liveCardRecords.set('a-parent', record(true));
+    maps.liveCardRecords.set('a-child', record(true));
+    maps.liveCardRecords.set('a-grand', record(false));
+    maps.subagentChildParents.set('a-child', { parentId: 'a-parent' });
+    maps.subagentChildParents.set('a-grand', { parentId: 'a-child' });
+    // Composite B: finished parent -> CONVERTED (project chip) child.
+    const chip = record(true);
+    chip.root.dataset = { projectCreated: '1' };
+    maps.liveCardRecords.set('b-parent', record(true));
+    maps.liveCardRecords.set('b-chip', chip);
+    maps.subagentChildParents.set('b-chip', { parentId: 'b-parent' });
+    // Composite C: fully finished two-level tree — the only legal victim.
+    maps.liveCardRecords.set('c-parent', record(true));
+    maps.liveCardRecords.set('c-child', record(true));
+    maps.liveCardRecords.set('c-grand', record(true));
+    maps.subagentChildParents.set('c-child', { parentId: 'c-parent' });
+    maps.subagentChildParents.set('c-grand', { parentId: 'c-child' });
+    for (let i = 0; i < LIVE_CARD_RECORDS_CAP; i += 1) maps.liveCardRecords.set(`t${i}`, record(false));
+
+    const evicted = ledgers.evictFinishedCardsOverCap();
+
+    assert.deepEqual(evicted, ['c-parent', 'c-child', 'c-grand'],
+        'whole-lineage cascade of the one evictable composite, in tree order');
+    assert.ok(maps.liveCardRecords.has('a-parent'), 'unfinished grandchild protects the composite');
+    assert.ok(maps.liveCardRecords.has('a-child'), 'and its intermediate child');
+    assert.ok(maps.liveCardRecords.has('b-parent'), 'a converted descendant protects its parent');
+    assert.ok(maps.liveCardRecords.has('b-chip'), 'the chip itself is never evicted');
+});
+
+
+test('cyclic lineage metadata terminates instead of hanging the eviction scan', () => {
+    const { maps, ledgers } = build();
+    maps.liveCardRecords.set('cyc-a', record(true));
+    maps.liveCardRecords.set('cyc-b', record(true));
+    maps.subagentChildParents.set('cyc-b', { parentId: 'cyc-a' });
+    maps.subagentChildParents.set('cyc-a', { parentId: 'cyc-b' });
+    for (let i = 0; i < LIVE_CARD_RECORDS_CAP; i += 1) maps.liveCardRecords.set(`t${i}`, record(false));
+
+    const evicted = ledgers.evictFinishedCardsOverCap();
+
+    assert.deepEqual(evicted, ['cyc-a', 'cyc-b'],
+        'the cycle is walked once, evicted once, and the scan returns');
+    assert.equal(maps.liveCardRecords.size, LIVE_CARD_RECORDS_CAP);
+});


### PR DESCRIPTION
Fixes #146, fixes #135 (quick-wins sprint, web-UI stream).

- **#146**: `.confirm-dialog-backdrop { z-index: 1100 }` — confirm/input/alert dialogs (Panic confirmation included) now stack above the reconnect shade and the update overlay instead of rendering under them, visible but unclickable. Content modals deliberately stay under the shade. Static z-order test pins the layer scale; disclosed side effect: toasts (120) render under an open dialog.
- **#135**: new `web/modules/chat_ledgers.js` bounds the always-alive Main instance's per-task state. `liveCardRecords` capped at 200 — the oldest *finished* card is evicted together with its DOM node (in-repo ephemeral-conversion precedent; reload-parity for the user), cascading its task-keyed satellites, retiring the id, and dropping the review hydrator's per-task state. The job-keyed `skillReviewDetailStore` (heavy payload cache) is bounded at its write seam via a facade, so click-driven loads are capped too. `recordConcludedActivity`/`recordTerminalActivity`/`scheduleTaskUiCleanup` moved verbatim; `chat.js` net-shrinks under its shrink-only byte ratchet (224244 → 224061 bytes; manifest regenerated). `pendingUserBubbles` deliberately NOT capped — verified non-leak, and a cap would break the delivered-transition (details in the commit message).

## Testing
705 web node tests (incl. new unit + DOM-integration suites driving 210 sealed tasks and a settle-over-cap scenario), `tests/test_web_dialogs_static.py`, size-ratchet lane — all green.

## Status
Draft while the sprint's multi-model review cycle converges: the adversarial round (codex gpt-5.6-sol, tests executed) is done and folded in; the triad (gpt-5.6-sol / claude-fable-5 / grok-4.6) + whole-repo scope review are in flight. Undrafted at the final reviewed SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)