### PR TITLE
Chat plumbing: honest history --limit end to end; delete the dead log poll queue

### DIFF
--- a/ouroboros/cli.py
+++ b/ouroboros/cli.py
@@ -290,7 +290,10 @@ def _chat_send_command(args: argparse.Namespace) -> int:
 
 
 def _chat_history_command(args: argparse.Namespace) -> int:
-    _print_json(_client(args).request("GET", f"/api/chat/history?limit={int(args.limit)}"))
+    # `n_human` is the explicit quota for the conversation (non-progress) rows;
+    # the server separately honors legacy `limit` as its n_human default so
+    # already-shipped CLIs are covered too.
+    _print_json(_client(args).request("GET", f"/api/chat/history?n_human={int(args.limit)}"))
     return 0
 
 
@@ -552,7 +555,12 @@ def build_parser() -> argparse.ArgumentParser:
     chat_send.add_argument("text", nargs=argparse.REMAINDER)
     chat_send.set_defaults(func=_chat_send_command)
     chat_history = chat_sub.add_parser("history")
-    chat_history.add_argument("--limit", type=int, default=100)
+    chat_history.add_argument(
+        "--limit", type=int, default=150,
+        help="conversation rows to fetch (server quota n_human: non-progress rows, "
+             "task summaries included; default matches the server's own 150, "
+             "clamped to the server cap)",
+    )
     chat_history.set_defaults(func=_chat_history_command)
 
     logs = subparsers.add_parser("logs", help="read runtime logs")

--- a/ouroboros/gateway/history.py
+++ b/ouroboros/gateway/history.py
@@ -1479,9 +1479,11 @@ def make_chat_history_endpoint(data_dir: pathlib.Path):
         # Separate per-type quotas so a burst of progress/telemetry can never evict
         # the user's real conversation from a single combined tail. Defaults are
         # the module-level window constants — the web client's default request
-        # sends no quota params. (`limit` is still accepted for backward-compat
-        # but no longer governs the slice.)
-        n_human = _int_param("n_human", _DEFAULT_N_HUMAN, _MAX_N_HUMAN)
+        # sends no quota params. The legacy `limit` parameter (shipped CLIs sent
+        # it while the server ignored it) is honored as the n_human default, so
+        # an old client that asks for N human rows finally gets N, within cap;
+        # an explicit n_human still wins.
+        n_human = _int_param("n_human", _int_param("limit", _DEFAULT_N_HUMAN, _MAX_N_HUMAN), _MAX_N_HUMAN)
         n_progress = _int_param("n_progress", _DEFAULT_N_PROGRESS, _MAX_N_PROGRESS)
         # Multi-project thread filter (v6.32.0): each chat fetches its own
         # history. Default 1 = main chat (legacy rows without chat_id are main).

--- a/ouroboros/size_ratchet_manifest.py
+++ b/ouroboros/size_ratchet_manifest.py
@@ -142,7 +142,6 @@ BAND_PATHS = {
     "ouroboros/consciousness.py": "Durable Background Consciousness observation inbox and bounded truthful replay",
     "ouroboros/extension_process_runner.py": None,
     "ouroboros/gateway/control.py": "Entered the band from 966 lines: the update-flow redesign added the shared stash-first prologue (_stash_local_work_fenced/_unwind_stashed_update) and the review-wave affordability floor to the update apply orchestration (update-flow-redesign sprint, Q9/Q10 owner decisions).",
-    "ouroboros/gateway/history.py": None,
     "ouroboros/gateway/settings.py": "Retiring persistent auto-Low removed the former giant debt; the remaining owner and reviewer settings endpoints stay centralized while tracked in the shrinking band.",
     "ouroboros/marketplace/ouroboroshub.py": "Entered the band from 373 lines: the hubflow sprint added the adopt transaction (eligibility prelude, CAS re-verification, move-aside + state-quintet snapshot, verified rollback with per-step error collection, retention finalize) beside the existing install/update flows (hubflow sprint, adopt-in-ouroboroshub owner decision D4).",
     "ouroboros/mcp_client.py": "E5+s2r2 (#447): nextCursor pagination, injective 12-hex slugs, and disclosed collision/pagination omissions grew the MCP client past 1000 lines",

--- a/supervisor/message_bus.py
+++ b/supervisor/message_bus.py
@@ -152,7 +152,6 @@ class LocalChatBridge:
 
     def __init__(self, settings: Optional[Dict[str, Any]] = None):
         self._inbox = queue.Queue()   # user -> agent
-        self._log_queue: queue.Queue = queue.Queue(maxsize=1000)
         self._update_counter = 0
         self._broadcast_fn = None  # set by server.py for WebSocket streaming
         # A2A response subscriptions: {subscription_id: (chat_id, callback)}
@@ -903,17 +902,6 @@ class LocalChatBridge:
 
     def push_log(self, event: dict):
         """Stream append_jsonl events to UI."""
-        try:
-            self._log_queue.put_nowait(event)
-        except queue.Full:
-            try:
-                self._log_queue.get_nowait()
-            except queue.Empty:
-                pass
-            try:
-                self._log_queue.put_nowait(event)
-            except queue.Full:
-                pass
         if self._broadcast_fn and not is_a2a_chat_id(event.get("chat_id")):
             # Task-scoped events arrive already addressed
             # (supervisor/log_addressing.py); an unaddressable event keeps the
@@ -922,16 +910,6 @@ class LocalChatBridge:
             frame = {"type": "log", "data": event, "chat_id": int(event.get("chat_id") or 0)}
             stamp_project_thread(DATA_DIR, frame)
             self._broadcast_fn(frame)
-
-    def ui_poll_logs(self) -> list:
-        """Drain pending log events for the web UI."""
-        batch = []
-        for _ in range(50):
-            try:
-                batch.append(self._log_queue.get_nowait())
-            except queue.Empty:
-                break
-        return batch
 
     def ui_send(
         self,

--- a/tests/test_chat_history_quotas.py
+++ b/tests/test_chat_history_quotas.py
@@ -977,3 +977,22 @@ def test_recent_child_final_keeps_lineage_fields(tmp_path):
     row = next(m for m in _run(tmp_path, {}) if m.get("task_id") == "child2")
     assert row["delegation_role"] == "subagent"
     assert row["parent_task_id"] == "root"
+
+
+def test_legacy_limit_governs_human_quota_when_n_human_absent(tmp_path):
+    """The legacy `limit` parameter is the n_human DEFAULT, so shipped CLIs that
+    always sent it stop getting a placebo; an explicit n_human still wins."""
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    chat_lines = [
+        json.dumps({"ts": f"2026-06-05T00:00:0{i}Z",
+                    "direction": "in" if i % 2 == 0 else "out", "text": f"human-{i}"})
+        for i in range(5)
+    ]
+    (logs / "chat.jsonl").write_text("\n".join(chat_lines) + "\n", encoding="utf-8")
+
+    legacy_only = _run(tmp_path, {"limit": "2"})
+    assert [m["text"] for m in legacy_only] == ["human-3", "human-4"]
+
+    explicit_wins = _run(tmp_path, {"limit": "2", "n_human": "3"})
+    assert [m["text"] for m in explicit_wins] == ["human-2", "human-3", "human-4"]

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -51,3 +51,28 @@ def test_settings_context_mode_posts_owner_endpoint(monkeypatch):
 
     assert result == 0
     assert seen["request"] == ("POST", "/api/owner/context-mode", {"mode": "low"})
+
+
+def test_chat_history_limit_maps_to_n_human(monkeypatch, capsys):
+    """`chat history --limit N` requests the quota the server actually honors.
+
+    The CLI sends the explicit `n_human` quota (the server separately honors
+    legacy `limit` as a fallback default for already-shipped clients), so the
+    flag is no longer a placebo (issue #172).
+    """
+    from ouroboros import cli
+
+    seen = {}
+
+    class FakeClient:
+        def request(self, method, path, body=None):
+            seen["request"] = (method, path)
+            return {"messages": []}
+
+    monkeypatch.setattr(cli, "_client", lambda _args, **_kwargs: FakeClient())
+
+    result = cli._chat_history_command(SimpleNamespace(limit=25))
+
+    assert result == 0
+    assert seen["request"] == ("GET", "/api/chat/history?n_human=25")
+    capsys.readouterr()

--- a/web/modules/api_client.js
+++ b/web/modules/api_client.js
@@ -241,7 +241,6 @@ export const apiClient = {
         `/api/owner/skills/${encodeURIComponent(skill)}/presence-runtime`,
         payload,
     ),
-    chatHistory: (limit = 1000) => fetchJson(`/api/chat/history?limit=${encodeURIComponent(limit)}`, { cache: 'no-store' }),
     projectFromTask: (taskId, id, name, objectiveHint = '') => jsonPost('/api/projects/from-task', { task_id: taskId, id, name, objective_hint: objectiveHint }),
     /** @param {import('./api_types.js').ProjectCreateRequest} payload */
     projectCreate: (payload) => jsonPost('/api/projects', payload),


### PR DESCRIPTION
Fixes #172, fixes #356 (quick-wins sprint, chat-plumbing stream).

- **#172**: `GET /api/chat/history` ignored the legacy `limit` parameter while every shipped CLI kept sending it — a placebo flag. Closed on both sides: the server now honors legacy `limit` as the *default* for `n_human` (explicit `n_human` wins), the CLI requests `n_human` directly (default raised 100 → 150 to match the server's own window), and the caller-less `api_client.chatHistory()` helper is deleted outright.
- **#356**: `LocalChatBridge._log_queue` (1000-slot drop-oldest churn on every event, A2A copies included) fed a poll drain — `ui_poll_logs` — that has zero callers repo-wide. All three pieces deleted; the WebSocket broadcast in `push_log` remains the one delivery path. `message_bus.py` drops below the 1001-line band; size-ratchet manifest regenerated.

## Testing
`test_message_bus`, `test_log_forwarding`, `test_cli_entrypoint`, `test_chat_history_quotas` (new legacy-fallback + precedence tests), `test_gateway_history`, size-ratchet lane — all green.

## Status
Draft while the sprint's multi-model review cycle converges: the adversarial round (codex gpt-5.6-sol, tests executed) is done and folded in; the triad (gpt-5.6-sol / claude-fable-5 / grok-4.6) + whole-repo scope review are in flight. Undrafted at the final reviewed SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)