### PR TITLE
Clean up Playwright handles after timed-out browser tools

### DIFF
--- a/ouroboros/loop_tool_execution.py
+++ b/ouroboros/loop_tool_execution.py
@@ -2,17 +2,16 @@
 
 from __future__ import annotations
 
+import concurrent.futures
+import contextvars
 import json
+import logging
 import os
 import pathlib
 import re
 import time
-import concurrent.futures
-import contextvars
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Callable, Dict, List, Optional
-
-import logging
 
 from ouroboros.config import (
     NESTED_SETTLEMENT_MARGIN_SEC,
@@ -22,13 +21,19 @@ from ouroboros.config import (
 from ouroboros.deadline_utils import deadline_remaining_sec
 from ouroboros.observability import new_call_id, persist_call
 from ouroboros.tool_capabilities import (
-    READ_ONLY_PARALLEL_TOOLS,
-    PARALLEL_SAFE_ENQUEUE_TOOLS,
     FOREGROUND_MUTATIVE_TOOLS,
+    PARALLEL_SAFE_ENQUEUE_TOOLS,
+    READ_ONLY_PARALLEL_TOOLS,
     REVIEWED_MUTATIVE_TOOLS,
     STATEFUL_BROWSER_TOOLS,
-    UNTRUNCATED_TOOL_RESULTS as _UNTRUNCATED_TOOL_RESULTS,
+)
+from ouroboros.tool_capabilities import (
     UNTRUNCATED_REPO_READ_PATHS as _UNTRUNCATED_REPO_READ_PATHS,
+)
+from ouroboros.tool_capabilities import (
+    UNTRUNCATED_TOOL_RESULTS as _UNTRUNCATED_TOOL_RESULTS,
+)
+from ouroboros.tool_capabilities import (
     tool_result_limit as _tool_result_limit,
 )
 from ouroboros.tools.registry import ToolRegistry
@@ -172,12 +177,18 @@ def _attach_late_tool_settlement(
     task_id: str,
     tool_call_id: str,
     correlation: Dict[str, Any],
+    on_settled: Optional[Callable[[], None]] = None,
 ) -> None:
     """Close the cognitive lease when a timed-out worker finally settles."""
     tool_ctx = getattr(tools, "_ctx", None)
     event_queue = getattr(tool_ctx, "event_queue", None)
 
     def _settled(_future: Any) -> None:
+        if on_settled is not None:
+            try:
+                on_settled()
+            except Exception:
+                log.debug("Late tool cleanup failed", exc_info=True)
         emit_cognitive_operation_event(
             event_queue,
             task_id=task_id,
@@ -876,6 +887,7 @@ def _execute_with_timeout(
     use_stateful = stateful_executor and fn_name in STATEFUL_BROWSER_TOOLS
     started_at = time.perf_counter()
     correlation = _tool_correlation(tools)
+    tool_ctx = getattr(tools, "_ctx", None)
     args_for_log = {}
     try:
         args = json.loads(tc["function"]["arguments"] or "{}")
@@ -893,6 +905,7 @@ def _execute_with_timeout(
     }, correlation, tool_call_id=tool_call_id))
 
     if use_stateful:
+        assert stateful_executor is not None
         future = stateful_executor.submit(_execute_single_tool, tools, tc, drive_logs, task_id)
         try:
             result = future.result(timeout=timeout_sec)
@@ -913,9 +926,24 @@ def _execute_with_timeout(
             }, correlation, tool_call_id=tool_call_id))
             return result
         except (TimeoutError, concurrent.futures.TimeoutError):
+            detached_browser_handles = None
+            on_settled: Optional[Callable[[], None]] = None
+            if use_stateful and tool_ctx is not None:
+                from ouroboros.tools.browser import (
+                    _detach_browser,
+                    cleanup_browser_handles,
+                )
+
+                detached_browser_handles = _detach_browser(tool_ctx)
+                def _cleanup_detached_browser() -> None:
+                    if detached_browser_handles is not None:
+                        cleanup_browser_handles(detached_browser_handles)
+
+                on_settled = _cleanup_detached_browser
             _attach_late_tool_settlement(
                 tools, future, task_id=task_id, tool_call_id=tool_call_id,
                 correlation={**correlation, "tool": fn_name},
+                on_settled=on_settled,
             )
             stateful_executor.reset()
             reset_msg = "Browser state has been reset. "

--- a/ouroboros/tools/browser.py
+++ b/ouroboros/tools/browser.py
@@ -46,7 +46,7 @@ def _normalize_browser_engine(engine: str = "") -> str:
 # Subagent browse restrictions (no loopback/private/non-HTTP) apply to ALL
 # delegated subagents — read-only, acting, and fail-closed missing-constraint.
 # Same fail-closed predicate as secret/control READ denials (SSOT in tools.core).
-from ouroboros.tools.core import is_restricted_subagent_profile as _readonly_subagent
+from ouroboros.tools.core import is_restricted_subagent_profile as _readonly_subagent  # noqa: E402
 
 
 def _is_subagent_blocked_browser_url(url: str, ctx: Any = None) -> bool:
@@ -506,9 +506,9 @@ def _ensure_browser(ctx: ToolContext, *, engine: str = "chromium", device: str =
     stored_device = getattr(bs, "_browser_device", "")
 
     if stored_thread_id is not None and stored_thread_id != current_thread_id:
-        log.info("Thread switch detected (old=%s, new=%s). Tearing down browser for this context.",
+        log.info("Thread switch detected (old=%s, new=%s). Detaching browser for this context.",
                  stored_thread_id, current_thread_id)
-        cleanup_browser(ctx)
+        _detach_browser(ctx)
     elif bs.browser is not None and (
         stored_engine != engine
         or stored_device.lower() != requested_device.lower()
@@ -586,30 +586,15 @@ def _ensure_browser(ctx: ToolContext, *, engine: str = "chromium", device: str =
     return bs.page
 
 
-def cleanup_browser(ctx: ToolContext) -> None:
-    """Close page/browser and stop the Playwright instance."""
+def _detach_browser(ctx: ToolContext) -> tuple[Any, Any, Any, Any]:
+    """Remove browser handles from shared state without touching Playwright."""
     bs = ctx.browser_state
-    try:
-        if bs.page is not None:
-            bs.page.close()
-    except Exception:
-        log.debug("Failed to close browser page during cleanup", exc_info=True)
-    try:
-        browser_context = getattr(bs, "_browser_context", None)
-        if browser_context is not None:
-            browser_context.close()
-    except Exception:
-        log.debug("Failed to close browser context during cleanup", exc_info=True)
-    try:
-        if bs.browser is not None:
-            bs.browser.close()
-    except Exception:
-        log.debug("Failed to close browser during cleanup", exc_info=True)
-    try:
-        if bs.pw_instance is not None:
-            bs.pw_instance.stop()
-    except Exception:
-        log.debug("Failed to stop Playwright instance during cleanup", exc_info=True)
+    handles = (
+        bs.page,
+        getattr(bs, "_browser_context", None),
+        bs.browser,
+        bs.pw_instance,
+    )
     bs.page = None
     bs.browser = None
     bs.pw_instance = None
@@ -617,6 +602,37 @@ def cleanup_browser(ctx: ToolContext) -> None:
     setattr(bs, "_browser_context", None)
     setattr(bs, "_browser_engine", "")
     setattr(bs, "_browser_device", "")
+    return handles
+
+
+def cleanup_browser_handles(handles: tuple[Any, Any, Any, Any]) -> None:
+    """Close detached Playwright handles on the thread that owns them."""
+    page, browser_context, browser, pw_instance = handles
+    try:
+        if page is not None:
+            page.close()
+    except Exception:
+        log.debug("Failed to close browser page during cleanup", exc_info=True)
+    try:
+        if browser_context is not None:
+            browser_context.close()
+    except Exception:
+        log.debug("Failed to close browser context during cleanup", exc_info=True)
+    try:
+        if browser is not None:
+            browser.close()
+    except Exception:
+        log.debug("Failed to close browser during cleanup", exc_info=True)
+    try:
+        if pw_instance is not None:
+            pw_instance.stop()
+    except Exception:
+        log.debug("Failed to stop Playwright instance during cleanup", exc_info=True)
+
+
+def cleanup_browser(ctx: ToolContext) -> None:
+    """Detach and close the context's Playwright handles."""
+    cleanup_browser_handles(_detach_browser(ctx))
 
 
 def _is_infrastructure_error(obj: Any) -> bool:

--- a/tests/test_browser_isolation.py
+++ b/tests/test_browser_isolation.py
@@ -6,9 +6,13 @@ import types
 
 import pytest
 
-from ouroboros.contracts.task_constraint import TaskConstraint
 import ouroboros.tools.browser as browser_mod
-from ouroboros.tools.browser import _is_infrastructure_error, cleanup_browser
+from ouroboros.contracts.task_constraint import TaskConstraint
+from ouroboros.tools.browser import (
+    _is_infrastructure_error,
+    cleanup_browser,
+    cleanup_browser_handles,
+)
 
 
 class TestInfrastructureErrorDetection:
@@ -424,6 +428,7 @@ class TestSetPlaywrightBrowsersPathIfBundled:
 
     def test_browser_install_uses_data_cache_when_zero_has_no_browser(self, monkeypatch, tmp_path):
         import os
+
         import ouroboros.tools.browser as bmod
 
         monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", "0")
@@ -456,6 +461,7 @@ class TestSetPlaywrightBrowsersPathIfBundled:
 
     def test_webkit_install_uses_data_cache_when_zero_has_no_bundled_webkit(self, monkeypatch, tmp_path):
         import os
+
         import ouroboros.tools.browser as bmod
 
         monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", "0")
@@ -488,6 +494,7 @@ class TestSetPlaywrightBrowsersPathIfBundled:
 
     def test_webkit_cache_fallback_does_not_strand_bundled_chromium(self, monkeypatch, tmp_path):
         import os
+
         import ouroboros.tools.browser as bmod
 
         monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", "0")
@@ -534,6 +541,7 @@ class TestSetPlaywrightBrowsersPathIfBundled:
 
     def test_frozen_missing_bundled_engine_installs_with_embedded_python(self, monkeypatch, tmp_path):
         import os
+
         import ouroboros.tools.browser as bmod
 
         embedded_python_posix = tmp_path / "python-standalone" / "bin" / "python3"
@@ -576,6 +584,7 @@ class TestSetPlaywrightBrowsersPathIfBundled:
 
     def test_readonly_missing_bundled_engine_does_not_create_cache(self, monkeypatch, tmp_path):
         import os
+
         import ouroboros.tools.browser as bmod
 
         monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", "0")
@@ -611,6 +620,7 @@ class TestSetPlaywrightBrowsersPathIfBundled:
 
     def test_readonly_existing_webkit_cache_is_reused_without_install(self, monkeypatch, tmp_path):
         import os
+
         import ouroboros.tools.browser as bmod
 
         cache = tmp_path / "data" / "playwright-browsers"
@@ -663,3 +673,14 @@ class TestCleanupBrowser:
         assert ctx.browser_state.page is None
         assert ctx.browser_state.browser is None
         assert ctx.browser_state.pw_instance is None
+
+    def test_cleanup_detached_handles_runs_on_owner_thread(self):
+        calls = []
+        handles = (
+            types.SimpleNamespace(close=lambda: calls.append("page")),
+            types.SimpleNamespace(close=lambda: calls.append("context")),
+            types.SimpleNamespace(close=lambda: calls.append("browser")),
+            types.SimpleNamespace(stop=lambda: calls.append("playwright")),
+        )
+        cleanup_browser_handles(handles)
+        assert calls == ["page", "context", "browser", "playwright"]

--- a/tests/test_tool_execution_classification.py
+++ b/tests/test_tool_execution_classification.py
@@ -1,6 +1,31 @@
 from ouroboros.loop_tool_execution import _extract_result_metadata, _is_tool_execution_failure
 
 
+def test_late_tool_settlement_runs_owner_cleanup_before_lease_close(monkeypatch):
+    from types import SimpleNamespace
+
+    import ouroboros.loop_tool_execution as lte
+
+    class ImmediateFuture:
+        def add_done_callback(self, callback):
+            callback(self)
+
+    calls = []
+    monkeypatch.setattr(lte, "emit_cognitive_operation_event", lambda *args, **kwargs: None)
+    tools = SimpleNamespace(_ctx=SimpleNamespace(event_queue=None, task_attempt=None))
+
+    lte._attach_late_tool_settlement(
+        tools,
+        ImmediateFuture(),
+        task_id="task",
+        tool_call_id="call",
+        correlation={},
+        on_settled=lambda: calls.append("cleanup"),
+    )
+
+    assert calls == ["cleanup"]
+
+
 def test_get_tool_timeout_honors_per_call_override(monkeypatch):
     """T3 (v6.35.0): the OUTER tool-execution timeout must rise for a per-call
     run_command/run_script timeout_sec, else the static 360s entry cap would cut
@@ -226,6 +251,7 @@ def test_live_tool_log_payload_includes_structured_result_metadata(tmp_path, mon
     import pathlib
     import time
     from types import SimpleNamespace
+
     import ouroboros.loop_tool_execution as loop_tool_execution
     from ouroboros.loop_tool_execution import _execute_with_timeout
 


### PR DESCRIPTION
Fixes #409.\n\nA timed-out stateful browser tool can leave Playwright handles owned by the abandoned worker thread while the next browser call reuses the shared context from a different thread. The next call now detaches the old handles without closing them cross-thread, and the late settlement callback closes those handles on the original worker thread before releasing the cognitive lease. Normal cleanup continues to detach and close handles synchronously.\n\nTests:\n- python -m pytest tests/test_browser_isolation.py tests/test_tool_execution_classification.py tests/test_openai_chat_dispatch.py -q --tb=short (75 passed)\n- python -m ruff check ouroboros/tools/browser.py ouroboros/loop_tool_execution.py tests/test_browser_isolation.py tests/test_tool_execution_classification.py (passed)\n- git diff --check (passed)\n- The full suite was run on the candidate branch; three unrelated Claudexor installer receipt tests fail identically on a clean upstream baseline commit e9dfb35.