### PR TITLE
Contributor review: agentic checklist path, honest script-lane budget shape (#395)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -45,9 +45,10 @@ Evidence:
 
 ## Governance and documentation
 
-- [ ] I read `CONTRIBUTING.md`; for a substantive change I also read
-      `BIBLE.md`, `docs/ARCHITECTURE.md`, `docs/DEVELOPMENT.md`, and
-      `docs/CHECKLISTS.md` in full.
+- [ ] I read `CONTRIBUTING.md` and `docs/CHECKLISTS.md` in full; for a
+      substantive change I mapped `BIBLE.md`, `docs/ARCHITECTURE.md`,
+      `docs/DEVELOPMENT.md`, and `docs/DESIGN.md` by their headings and read
+      every section relevant to this change in full.
 - [ ] I updated tests and documentation where behavior or architecture changed.
 - [ ] I did not include secrets, local settings, runtime state, logs, caches, or
       generated build/review artifacts in the commit.
@@ -74,6 +75,29 @@ available, use NOT_RUN and say why.
 - Checks performed and coverage limitations:
 - Full review output or artifact link:
 - If not run, reason:
+
+Scope checklist coverage (from the reviewer's JSON; one row per item, extra
+rows for additional FAIL findings on the same item):
+
+| Item | Verdict | Evidence |
+| --- | --- | --- |
+| intent_alignment | | |
+| forgotten_touchpoints | | |
+| cross_surface_consistency | | |
+| regression_surface | | |
+| prompt_doc_sync | | |
+| architecture_fit | | |
+| cross_module_bugs | | |
+| implicit_contracts | | |
+
+<details>
+<summary>Reviewer checklist JSON (validate with scripts/validate_scope_receipt.py)</summary>
+
+```json
+
+```
+
+</details>
 
 ## Final checklist
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,12 @@ this flow.
 
 ## 1. Read the Project Before Editing
 
-For a substantive change, read these files **in full** before designing or
-editing:
+For a substantive change, ground yourself in the project documents before
+designing or editing. Read [`docs/CHECKLISTS.md`](docs/CHECKLISTS.md) — the
+review checklist single source of truth — **in full**: your change will be
+judged against it. For the other four, build a navigation map from their
+headings first, then read every section relevant to your change **in full**
+(skimming a relevant section does not count):
 
 - [`BIBLE.md`](BIBLE.md) — constitutional principles and design priorities.
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — structure, data flows, and
@@ -28,16 +32,18 @@ editing:
 - [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) — engineering, testing, and
   review conventions.
 - [`docs/DESIGN.md`](docs/DESIGN.md) — visual and interaction semantics.
-- [`docs/CHECKLISTS.md`](docs/CHECKLISTS.md) — the review checklist single
-  source of truth.
+
+When in doubt whether a section is relevant, read it. Reading everything in
+full remains the strongest preparation for a large or cross-cutting change.
 
 Reuse the modules, contracts, and authorities those documents name. Do not
 invent a parallel mechanism when the repository already has one. A useful
 first instruction for a coding agent is:
 
-> Read CONTRIBUTING.md, BIBLE.md, docs/ARCHITECTURE.md,
-> docs/DEVELOPMENT.md, docs/DESIGN.md, and docs/CHECKLISTS.md in full before
-> editing. Follow their current architecture and keep the requested change focused.
+> Read CONTRIBUTING.md and docs/CHECKLISTS.md in full. Map BIBLE.md,
+> docs/ARCHITECTURE.md, docs/DEVELOPMENT.md, and docs/DESIGN.md by their
+> headings and read every section relevant to the requested change in full.
+> Follow their current architecture and keep the requested change focused.
 
 These documents may themselves be improved, but constitutional changes must
 follow the semantic change process in `BIBLE.md`, and behavior, tests, and
@@ -124,6 +130,16 @@ Before opening a substantive PR, the authoring agent must hand the final
 committed diff to a **separate agent context**. Use a subagent, new task, or
 fresh agent session. Reviewing in the authoring conversation does not count.
 
+The main review path is an **agentic checklist review**: the reviewer reads
+the repository with its own tools and covers the "Intent / Scope Review
+Checklist" from [`docs/CHECKLISTS.md`](docs/CHECKLISTS.md) — every one of its
+eight items (`intent_alignment`, `forgotten_touchpoints`,
+`cross_surface_consistency`, `regression_surface`, `prompt_doc_sync`,
+`architecture_fit`, `cross_module_bugs`, `implicit_contracts`) — following
+that checklist's output contract: one JSON array covering all eight items,
+PASS rows mandatory and justified with a concrete artifact, FAIL rows with
+severity (a critical FAIL names an exact file/symbol).
+
 Give the reviewer the issue or goal, non-goals, exact base and head SHAs, and
 repository access. The reviewer must not edit the candidate. Use this compact
 instruction:
@@ -131,14 +147,31 @@ instruction:
 ```text
 Review the final pull request diff from <base SHA> to <head SHA>. Do not edit.
 
-Read CONTRIBUTING.md. For a substantive change, read BIBLE.md,
-docs/ARCHITECTURE.md, docs/DEVELOPMENT.md, docs/DESIGN.md, and
-docs/CHECKLISTS.md in full.
+Read CONTRIBUTING.md and docs/CHECKLISTS.md in full. Map BIBLE.md,
+docs/ARCHITECTURE.md, docs/DEVELOPMENT.md, and docs/DESIGN.md by their
+headings and read every section relevant to this change in full.
 Inspect the complete diff, touched files, relevant callers, tests, and docs.
 
-Return findings first with severity and exact file/line references, then checks
+Cover the Intent / Scope Review Checklist from docs/CHECKLISTS.md exactly:
+output a JSON array of objects with the keys "item", "verdict" (PASS/FAIL),
+"severity" (critical/advisory), and "reason", covering all eight checklist
+items per its output contract — PASS rows are mandatory and justified with a
+concrete artifact; a critical FAIL names an exact file/symbol. Then report
+any further findings with severity and file/line references, checks
 performed, coverage limitations, and one verdict: PASS, NEEDS_CHANGES, or
 INCOMPLETE. Do not report PASS when required material was unavailable.
+```
+
+Paste the reviewer's checklist JSON into the PR's review-evidence block and
+fill the checklist table from it. Validate the JSON locally before opening
+the PR — the schema validator reuses the runtime contract and accepts the
+array bare, inside a fenced `json` code block, or embedded in the
+reviewer's prose. It
+validates SHAPE, not truth: a passing receipt is well-formed coverage, not a
+review verdict.
+
+```bash
+python scripts/validate_scope_receipt.py path/to/receipt.json
 ```
 
 Reproduce material findings when possible. Fix confirmed problems, and briefly
@@ -150,11 +183,25 @@ loop.
 If no separate agent context is available, do not substitute same-context
 self-review. Mark the review `NOT_RUN` and explain why in the PR.
 
-### Optional project-native review command
+### Maintainer-grade project-native review command
 
-Ouroboros can produce the same evidence in a structured SHA-bound packet. Its
+Ouroboros can produce review evidence in a structured SHA-bound packet. Its
 contributor mode uses the reviewer slots actually configured on the machine:
 `api_chat`, `agent_session`, or a mixture.
+
+Treat this command as **maintainer / large-window tooling**, not the default
+contributor path. The scope reviewer's required-artifact pack (protected
+runtime paths, prompts, contracts, canonical docs, the review stack) is
+required regardless of how small the diff is, and on a default install it
+can exceed the configured scope slot's context window even after every
+degradation step — the run then fails closed with `SCOPE_REVIEW_BLOCKED`
+and still preserves the evidence packet (marked incomplete). The documented
+routes past that pack budget are: configure the scope row as an
+`agent_session` reviewer (a different delivery class — it reads the
+repository with its own tools instead of being handed one assembled pack,
+and needs its own confirmed 200K+ window), or configure an API scope slot
+whose confirmed context window fits the pack. The agentic checklist review
+above needs neither.
 
 Configured API slots need their provider credentials and a positive finite
 `TOTAL_BUDGET`. Agent-session slots need their configured agent route and
@@ -197,6 +244,7 @@ Complete the PR template with:
 - reviewed base SHA and head SHA;
 - verdict, findings, and their disposition;
 - checks, coverage limitations, and full output or artifact link;
+- the scope-checklist coverage table and the reviewer's checklist JSON;
 - `NOT_RUN` plus a reason for unavailable verification or review.
 
 Review output is public evidence. Inspect attachments for credentials, private
@@ -210,7 +258,8 @@ commit, push, merge, release, or publication.
 
 - [ ] The PR targets `ouroboros` and is current with its recorded base.
 - [ ] The PR has one coherent purpose and explicit non-goals.
-- [ ] The required project documents were read in full.
+- [ ] `docs/CHECKLISTS.md` was read in full and every relevant section of the
+      other project documents was read in full.
 - [ ] Relevant tests and UI evidence are recorded honestly.
 - [ ] No release-version carrier was changed.
 - [ ] No secret, runtime state, generated run, or build artifact is in the diff.

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ ouroboros run --start \
 
 Use `--jsonl` for a machine-readable event stream and `--detach` when the caller will follow the task with `ouroboros tasks watch <task_id>` or inspect it with `ouroboros tasks show <task_id>`. External workspace runs keep Ouroboros's own repository and governance context separate, then export changes as reviewable patch artifacts.
 
-To change Ouroboros itself, follow [CONTRIBUTING.md](CONTRIBUTING.md) and read [BIBLE.md](BIBLE.md), [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md), [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md), and [docs/CHECKLISTS.md](docs/CHECKLISTS.md) in full before editing.
+To change Ouroboros itself, follow [CONTRIBUTING.md](CONTRIBUTING.md): read [docs/CHECKLISTS.md](docs/CHECKLISTS.md) in full, and map [BIBLE.md](BIBLE.md), [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md), [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md), and [docs/DESIGN.md](docs/DESIGN.md) by their headings, reading every section relevant to your change in full before editing.
 
 #### Configuration
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -412,6 +412,7 @@ CITATION.cff                  ← Machine-readable software citation plus the pr
 docs/benchmarks/evidence.json ← Release-bound non-GAIA projection of public benchmark claims and immutable evidence links; README remains the claim SSOT
 site/paper/index.html         ← Canonical technical-report landing page with author/citation metadata, `ScholarlyArticle` JSON-LD, paper links, and evidence navigation
 scripts/claudexor_platform_smoke.py ← the platform gate's smoke runner (daemon boot, one delegated no-edit/edit task, containment report)
+scripts/validate_scope_receipt.py   ← contributor-facing shape validator for the CONTRIBUTING scope-checklist receipt; a thin CLI over `scope_review_contract.normalize_scope_items` (accepts bare/fenced/embedded JSON via the runtime `extract_json_array`)
 scripts/fetch_claudexor_runtime.py  ← release-build fetcher for the pinned managed Claudexor runtime archive (claudexor_runtime_pin.json is the SSOT)
 build.sh                      ← macOS build (PyInstaller → .dmg)
 build_linux.sh                ← Linux build (portable-Python PyInstaller → .AppImage + .tar.gz)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1104,8 +1104,10 @@ may supply that independent context; same-conversation self-review does not.
 Unavailable review is recorded as `NOT_RUN`, never silently presented as clean.
 `CONTRIBUTING.md` owns the public procedure and evidence fields.
 
-`scripts/run_external_review.py --contributor` is an optional structured
-producer for the same evidence. It preserves and freezes the machine's
+`scripts/run_external_review.py --contributor` is maintainer-grade
+large-window tooling that produces structured review evidence (its scope
+reviewer's required-artifact pack is independent of diff size and can exceed
+a default install's scope window — see CONTRIBUTING for the budget shape). It preserves and freezes the machine's
 configured `api_chat` and `agent_session` triad/scope rows, then binds each row
 to its dispatched prompt receipt and observed response receipt. The shareable
 packet records exact base/head/tree/diff hashes, route/model/profile facts,

--- a/scripts/validate_scope_receipt.py
+++ b/scripts/validate_scope_receipt.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Validate a contributor scope-checklist receipt against the runtime contract.
+
+CONTRIBUTING.md's main review path asks the separate review agent to output a
+JSON array covering all eight Intent/Scope checklist items. This validator is
+a thin CLI over the SAME contract the runtime scope review enforces
+(`ouroboros.tools.scope_review_contract.normalize_scope_items`) — coverage,
+duplicate/contradictory rows, severities, and justified PASS reasons — so a
+receipt that passes here matches what the project's own reviewers must
+produce. It validates SHAPE, not truth: the maintainer still reads the
+evidence.
+
+The array is accepted bare, inside a ```json fence, or embedded in the
+reviewer's surrounding prose — extraction reuses the runtime's own
+`extract_json_array`, so what the project's scope parser would read is what
+gets validated.
+
+Usage:
+    python scripts/validate_scope_receipt.py path/to/receipt.json
+    ... | python scripts/validate_scope_receipt.py -
+
+Exit code 0 when the receipt is valid; 1 with the contract errors otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) == 2 and argv[1] in {"-h", "--help"}:
+        print(__doc__.strip())
+        return 0
+    if len(argv) != 2:
+        print(__doc__.strip(), file=sys.stderr)
+        return 1
+    try:
+        raw = (sys.stdin.read() if argv[1] == "-"
+               else pathlib.Path(argv[1]).read_text(encoding="utf-8"))
+    except OSError as exc:
+        print(f"invalid: cannot read receipt ({exc})", file=sys.stderr)
+        return 1
+
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+    from ouroboros.tools.scope_review_contract import normalize_scope_items
+    from ouroboros.triad_review import extract_json_array
+
+    try:
+        items = json.loads(raw)
+    except json.JSONDecodeError:
+        items = extract_json_array(raw)
+        if items is None:
+            print("invalid: no JSON array found in the receipt "
+                  "(bare, fenced, or embedded)", file=sys.stderr)
+            return 1
+
+    normalized, error = normalize_scope_items(items)
+    if error:
+        print(f"invalid: {error}", file=sys.stderr)
+        return 1
+    fails = [item for item in normalized if item["verdict"] == "FAIL"]
+    print(
+        f"valid: {len(normalized)} rows cover all checklist items; "
+        f"{len(fails)} FAIL row(s)"
+        + (" — " + ", ".join(sorted({f['item'] for f in fails})) if fails else "")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_contributor_flow.py
+++ b/tests/test_contributor_flow.py
@@ -15,10 +15,40 @@ def test_public_contributor_flow_is_agent_first_and_route_neutral():
         "docs/CHECKLISTS.md",
     ):
         assert path in guide
-    assert "read these files **in full**" in guide
+    # 11=A: only the checklist SSOT is read cover-to-cover; the other project
+    # documents are mapped by headings with relevant sections read in full.
+    assert "[`docs/CHECKLISTS.md`](docs/CHECKLISTS.md)" in guide
+    assert "**in full**" in guide
+    assert "navigation map" in guide
+    assert "read every section relevant" in guide
+    # Negative pins: the retired blanket contract must not resurface anywhere
+    # in the two entry documents (README routes contributors here).
+    assert "read these files **in full**" not in guide
+    assert "The required project documents were read in full" not in guide
+    assert "in full before editing" not in readme.replace(
+        "reading every section relevant to your change in full before editing", "")
+    # 10=A: the agentic checklist review is the main path and must cover all
+    # eight Intent/Scope items with the runtime output contract.
+    assert "agentic checklist review" in guide
+    for item in (
+        "intent_alignment", "forgotten_touchpoints", "cross_surface_consistency",
+        "regression_surface", "prompt_doc_sync", "architecture_fit",
+        "cross_module_bugs", "implicit_contracts",
+    ):
+        assert item in guide
+    assert "scripts/validate_scope_receipt.py" in guide
     assert "separate agent context" in guide
     assert "Reviewing in the authoring conversation does not count" in guide
     assert "Mark the review `NOT_RUN`" in guide
+    # The script lane is honest about its budget shape instead of failing
+    # contributors by surprise (#395).
+    assert "maintainer / large-window tooling" in guide
+    assert "SCOPE_REVIEW_BLOCKED" in guide
+    # The honest budget-shape paragraph names the full required pack and the
+    # session route's own window requirement (sol round-1).
+    assert "prompts, contracts, canonical docs" in guide
+    assert "confirmed 200K+ window" in guide
+    assert "SHAPE, not truth" in guide
     assert "--contributor" in guide
     assert "--base-ref upstream/ouroboros" in guide
     assert "--head-ref HEAD" in guide
@@ -44,6 +74,17 @@ def test_pull_request_template_has_one_universal_agent_review_block():
     assert "coverage limitations" in template
     assert "PASS`, `NEEDS_CHANGES`, `INCOMPLETE`, or `NOT_RUN" in template
     assert "If not run, reason" in template
+    # 21=A: the checklist coverage travels as a markdown table plus the raw
+    # reviewer JSON, both inside the single review-evidence block — all eight
+    # rows, not just the endpoints.
+    for item in (
+        "intent_alignment", "forgotten_touchpoints", "cross_surface_consistency",
+        "regression_surface", "prompt_doc_sync", "architecture_fit",
+        "cross_module_bugs", "implicit_contracts",
+    ):
+        assert template.count(f"| {item} |") == 1
+    assert "Reviewer checklist JSON" in template
+    assert "scripts/validate_scope_receipt.py" in template
     assert "self-review in the\nauthoring conversation does not" in template
     assert "Agent assistance (optional)" not in template
     assert "Human verification" not in template
@@ -126,3 +167,76 @@ def test_repository_has_explicit_mit_license_holder():
     assert license_text.startswith("MIT License\n")
     assert "Copyright (c) 2026 Anton Razzhigaev" in license_text
     assert "Andrew Kaznacheev" not in license_text
+
+
+def test_scope_receipt_validator_reuses_the_runtime_contract(tmp_path, capsys):
+    """The contributor-facing validator is a thin CLI over
+    normalize_scope_items — a receipt it accepts matches what the project's
+    own scope reviewers must produce (10=A)."""
+    from ouroboros.tools.scope_review_contract import SCOPE_REQUIRED_ITEMS
+    from scripts.validate_scope_receipt import main
+
+    good = [
+        {"item": item, "verdict": "PASS", "severity": "advisory",
+         "reason": f"Checked {item} against the concrete diff artifacts involved."}
+        for item in sorted(SCOPE_REQUIRED_ITEMS)
+    ]
+    good_path = tmp_path / "good.json"
+    good_path.write_text(__import__("json").dumps(good), encoding="utf-8")
+    assert main(["validate", str(good_path)]) == 0
+    assert "valid:" in capsys.readouterr().out
+
+    missing = good[:-1]
+    bad_path = tmp_path / "missing.json"
+    bad_path.write_text(__import__("json").dumps(missing), encoding="utf-8")
+    assert main(["validate", str(bad_path)]) == 1
+    assert "missing required items" in capsys.readouterr().err
+
+    dup = good + [dict(good[0])]
+    dup_path = tmp_path / "dup.json"
+    dup_path.write_text(__import__("json").dumps(dup), encoding="utf-8")
+    assert main(["validate", str(dup_path)]) == 1
+    assert "duplicate PASS" in capsys.readouterr().err
+
+    not_json = tmp_path / "broken.json"
+    not_json.write_text("{nope", encoding="utf-8")
+    assert main(["validate", str(not_json)]) == 1
+    assert "no JSON array" in capsys.readouterr().err
+
+
+def test_scope_receipt_validator_accepts_fenced_and_embedded_arrays(tmp_path, capsys):
+    """CONTRIBUTING's compact instruction asks for the array plus surrounding
+    narrative — the validator must read what the runtime scope parser would
+    read (extract_json_array), not only a bare file."""
+    import json
+
+    from ouroboros.tools.scope_review_contract import SCOPE_REQUIRED_ITEMS
+    from scripts.validate_scope_receipt import main
+
+    rows = json.dumps([
+        {"item": item, "verdict": "PASS", "severity": "advisory",
+         "reason": f"Checked {item} against the concrete diff artifacts involved."}
+        for item in sorted(SCOPE_REQUIRED_ITEMS)
+    ])
+    fenced = tmp_path / "fenced.md"
+    fenced.write_text(
+        "Reviewer notes before the receipt.\n\n```json\n" + rows + "\n```\n\nVerdict: PASS\n",
+        encoding="utf-8",
+    )
+    assert main(["validate", str(fenced)]) == 0
+    assert "valid:" in capsys.readouterr().out
+
+    prose_only = tmp_path / "prose.md"
+    prose_only.write_text("No receipt here at all.", encoding="utf-8")
+    assert main(["validate", str(prose_only)]) == 1
+    assert "no JSON array" in capsys.readouterr().err
+
+
+def test_scope_receipt_validator_cli_edges(tmp_path, capsys):
+    from scripts.validate_scope_receipt import main
+
+    assert main(["validate", "--help"]) == 0
+    assert "Usage" in capsys.readouterr().out
+
+    assert main(["validate", str(tmp_path / "absent.json")]) == 1
+    assert "cannot read receipt" in capsys.readouterr().err


### PR DESCRIPTION
Closes #395.

## What this does

The contributor review lane structurally fail-closed: the scope reviewer's required-artifact pack (protected runtime paths, prompts, contracts, canonical docs, the review stack) is required regardless of diff size and exceeds a default install's scope window even after every degradation step, so `scripts/run_external_review.py --contributor` ended every seat `not_dispatched` with `SCOPE_REVIEW_BLOCKED`. The issue asked for either a budget ladder for the required set or a documented larger-window route. This PR answers with the documented routes plus an honest re-framing of the contributor path (owner decisions 10=A, 11=A, 21=A):

**The main path is now the agentic checklist review.** CONTRIBUTING §5 has the separate review agent read the repository with its own tools and cover all eight Intent/Scope checklist items from `docs/CHECKLISTS.md` under that checklist's own output contract — the compact instruction names the exact JSON keys (`item`/`verdict`/`severity`/`reason`) and the honest severity rule (a critical FAIL names an exact file/symbol). The receipt lands in the PR's review-evidence block: a coverage table (one row per item, extra rows for additional FAIL findings) plus the raw reviewer JSON. This path needs no assembled pack and no large window.

**A local shape validator over the runtime contract.** New `scripts/validate_scope_receipt.py` is a thin CLI over `ouroboros.tools.scope_review_contract.normalize_scope_items` — the same coverage/duplicate/severity/justified-PASS rules the project's own scope reviewers must satisfy — and reads the array the way the runtime parser would (bare, fenced, or embedded in prose, via the runtime `extract_json_array`). It validates SHAPE, not truth, and says so. No CI workflow changes; the repository's own tests pin the surfaces.

**The script lane is honestly labeled.** §5.1 becomes "Maintainer-grade project-native review command" and states the budget shape: the pack is diff-size-independent; on overflow the run fails closed with `SCOPE_REVIEW_BLOCKED` and still preserves the evidence packet (marked incomplete). The documented routes past the pack budget: an `agent_session` scope row (a different delivery class that reads the repository itself and needs its own confirmed 200K+ window) or an API scope slot whose confirmed window fits the pack. `docs/DEVELOPMENT.md` says the same.

**Proportional reading requirements (11=A).** `docs/CHECKLISTS.md` stays read-in-full; BIBLE/ARCHITECTURE/DEVELOPMENT/DESIGN are mapped by headings with every relevant section read in full — consistently across CONTRIBUTING §1, the agent instruction blockquote, the Final Checklist, the PR template governance line, and README's contributor pointer.

The witness-root premise from the issue batch was disproven by research: density witnesses read and write the same canonical DATA_DIR root (the historical divergence was fixed in c707a17b and is pinned by `test_round_fit_reads_density_from_canonical_store_not_child_drive`); this PR deliberately changes no witness code.

## Review

Round 1: codex gpt-5.6-sol (xhigh), claude-fable-5 (cursor thinking-xhigh lane), cursor grok-4.6 (xhigh) + agentic scope pass — 3× NEEDS WORK + scope 5 critical/3 advisory, all convergent (README and the Final Checklist still carried the retired read-in-full contract; the validator rejected the fenced/prose receipts the instruction itself requests; unnamed JSON keys; §5.1 honesty gaps; missing ARCHITECTURE module-map row). One batch closed everything. Round 2 delta (fable): **DELTA CLEAN** — the validator's acceptance is verified as a strict fail-closed subset of the runtime parser, negative pins verified non-over-constraining.

## Verification

Full parallel suite 12087 passed, serial 629 passed, `ruff --select F` clean. 9 behavioral tests in `tests/test_contributor_flow.py` exercise the validator against the real contract (coverage, duplicates, fenced/prose extraction, CLI edges) and pin the new copy in CONTRIBUTING, README, and the template — including negative pins on the retired phrasing. The fork-safety CI pins are untouched and `ci.yml` is byte-identical to base.
