### PR TITLE
Clean up Playwright handles after timed-out browser tools (supersedes #429)

### DIFF
--- a/ouroboros/loop_tool_execution.py
+++ b/ouroboros/loop_tool_execution.py
@@ -2,17 +2,16 @@
 
 from __future__ import annotations
 
+import concurrent.futures
+import contextvars
 import json
+import logging
 import os
 import pathlib
 import re
 import time
-import concurrent.futures
-import contextvars
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Callable, Dict, List, Optional
-
-import logging
 
 from ouroboros.config import (
     NESTED_SETTLEMENT_MARGIN_SEC,
@@ -22,13 +21,19 @@ from ouroboros.config import (
 from ouroboros.deadline_utils import deadline_remaining_sec
 from ouroboros.observability import new_call_id, persist_call
 from ouroboros.tool_capabilities import (
-    READ_ONLY_PARALLEL_TOOLS,
-    PARALLEL_SAFE_ENQUEUE_TOOLS,
     FOREGROUND_MUTATIVE_TOOLS,
+    PARALLEL_SAFE_ENQUEUE_TOOLS,
+    READ_ONLY_PARALLEL_TOOLS,
     REVIEWED_MUTATIVE_TOOLS,
     STATEFUL_BROWSER_TOOLS,
-    UNTRUNCATED_TOOL_RESULTS as _UNTRUNCATED_TOOL_RESULTS,
+)
+from ouroboros.tool_capabilities import (
     UNTRUNCATED_REPO_READ_PATHS as _UNTRUNCATED_REPO_READ_PATHS,
+)
+from ouroboros.tool_capabilities import (
+    UNTRUNCATED_TOOL_RESULTS as _UNTRUNCATED_TOOL_RESULTS,
+)
+from ouroboros.tool_capabilities import (
     tool_result_limit as _tool_result_limit,
 )
 from ouroboros.tools.registry import ToolRegistry
@@ -172,12 +177,18 @@ def _attach_late_tool_settlement(
     task_id: str,
     tool_call_id: str,
     correlation: Dict[str, Any],
+    on_settled: Optional[Callable[[], None]] = None,
 ) -> None:
     """Close the cognitive lease when a timed-out worker finally settles."""
     tool_ctx = getattr(tools, "_ctx", None)
     event_queue = getattr(tool_ctx, "event_queue", None)
 
     def _settled(_future: Any) -> None:
+        if on_settled is not None:
+            try:
+                on_settled()
+            except Exception:
+                log.debug("Late tool cleanup failed", exc_info=True)
         emit_cognitive_operation_event(
             event_queue,
             task_id=task_id,
@@ -876,6 +887,7 @@ def _execute_with_timeout(
     use_stateful = stateful_executor and fn_name in STATEFUL_BROWSER_TOOLS
     started_at = time.perf_counter()
     correlation = _tool_correlation(tools)
+    tool_ctx = getattr(tools, "_ctx", None)
     args_for_log = {}
     try:
         args = json.loads(tc["function"]["arguments"] or "{}")
@@ -893,6 +905,7 @@ def _execute_with_timeout(
     }, correlation, tool_call_id=tool_call_id))
 
     if use_stateful:
+        assert stateful_executor is not None
         future = stateful_executor.submit(_execute_single_tool, tools, tc, drive_logs, task_id)
         try:
             result = future.result(timeout=timeout_sec)
@@ -913,9 +926,24 @@ def _execute_with_timeout(
             }, correlation, tool_call_id=tool_call_id))
             return result
         except (TimeoutError, concurrent.futures.TimeoutError):
+            detached_browser_handles = None
+            on_settled: Optional[Callable[[], None]] = None
+            if use_stateful and tool_ctx is not None:
+                from ouroboros.tools.browser import (
+                    _detach_browser,
+                    cleanup_browser_handles,
+                )
+
+                detached_browser_handles = _detach_browser(tool_ctx)
+                def _cleanup_detached_browser() -> None:
+                    if detached_browser_handles is not None:
+                        cleanup_browser_handles(detached_browser_handles)
+
+                on_settled = _cleanup_detached_browser
             _attach_late_tool_settlement(
                 tools, future, task_id=task_id, tool_call_id=tool_call_id,
                 correlation={**correlation, "tool": fn_name},
+                on_settled=on_settled,
             )
             stateful_executor.reset()
             reset_msg = "Browser state has been reset. "

--- a/ouroboros/loop_tool_execution.py
+++ b/ouroboros/loop_tool_execution.py
@@ -959,12 +959,20 @@ def _execute_with_timeout(
         except (TimeoutError, concurrent.futures.TimeoutError):
             detached_browser_handles = None
             on_settled: Optional[Callable[[], None]] = None
-            if use_stateful and tool_ctx is not None:
+            if tool_ctx is not None:  # stateful branch: use_stateful is already true here
                 from ouroboros.tools.browser import (
                     _detach_browser,
                     cleanup_browser_handles,
                 )
 
+                # CROSS-THREAD INVARIANT (#409): Playwright objects are bound
+                # to the worker thread that created them. This main-thread
+                # path may only DETACH the handles from the context — never
+                # call close()/stop() here (a cross-thread stop() kills the
+                # driver under the hung worker and turns its dispatcher wait
+                # into a CPU busy-loop). The close happens in the settlement
+                # callback below, which the executor runs on the worker
+                # thread that owns the handles.
                 detached_browser_handles = _detach_browser(tool_ctx)
                 def _cleanup_detached_browser() -> None:
                     if detached_browser_handles is not None:

--- a/ouroboros/tools/browser.py
+++ b/ouroboros/tools/browser.py
@@ -46,7 +46,7 @@ def _normalize_browser_engine(engine: str = "") -> str:
 # Subagent browse restrictions (no loopback/private/non-HTTP) apply to ALL
 # delegated subagents — read-only, acting, and fail-closed missing-constraint.
 # Same fail-closed predicate as secret/control READ denials (SSOT in tools.core).
-from ouroboros.tools.core import is_restricted_subagent_profile as _readonly_subagent
+from ouroboros.tools.core import is_restricted_subagent_profile as _readonly_subagent  # noqa: E402
 
 
 def _is_subagent_blocked_browser_url(url: str, ctx: Any = None) -> bool:
@@ -506,9 +506,9 @@ def _ensure_browser(ctx: ToolContext, *, engine: str = "chromium", device: str =
     stored_device = getattr(bs, "_browser_device", "")
 
     if stored_thread_id is not None and stored_thread_id != current_thread_id:
-        log.info("Thread switch detected (old=%s, new=%s). Tearing down browser for this context.",
+        log.info("Thread switch detected (old=%s, new=%s). Detaching browser for this context.",
                  stored_thread_id, current_thread_id)
-        cleanup_browser(ctx)
+        _detach_browser(ctx)
     elif bs.browser is not None and (
         stored_engine != engine
         or stored_device.lower() != requested_device.lower()
@@ -586,30 +586,15 @@ def _ensure_browser(ctx: ToolContext, *, engine: str = "chromium", device: str =
     return bs.page
 
 
-def cleanup_browser(ctx: ToolContext) -> None:
-    """Close page/browser and stop the Playwright instance."""
+def _detach_browser(ctx: ToolContext) -> tuple[Any, Any, Any, Any]:
+    """Remove browser handles from shared state without touching Playwright."""
     bs = ctx.browser_state
-    try:
-        if bs.page is not None:
-            bs.page.close()
-    except Exception:
-        log.debug("Failed to close browser page during cleanup", exc_info=True)
-    try:
-        browser_context = getattr(bs, "_browser_context", None)
-        if browser_context is not None:
-            browser_context.close()
-    except Exception:
-        log.debug("Failed to close browser context during cleanup", exc_info=True)
-    try:
-        if bs.browser is not None:
-            bs.browser.close()
-    except Exception:
-        log.debug("Failed to close browser during cleanup", exc_info=True)
-    try:
-        if bs.pw_instance is not None:
-            bs.pw_instance.stop()
-    except Exception:
-        log.debug("Failed to stop Playwright instance during cleanup", exc_info=True)
+    handles = (
+        bs.page,
+        getattr(bs, "_browser_context", None),
+        bs.browser,
+        bs.pw_instance,
+    )
     bs.page = None
     bs.browser = None
     bs.pw_instance = None
@@ -617,6 +602,37 @@ def cleanup_browser(ctx: ToolContext) -> None:
     setattr(bs, "_browser_context", None)
     setattr(bs, "_browser_engine", "")
     setattr(bs, "_browser_device", "")
+    return handles
+
+
+def cleanup_browser_handles(handles: tuple[Any, Any, Any, Any]) -> None:
+    """Close detached Playwright handles on the thread that owns them."""
+    page, browser_context, browser, pw_instance = handles
+    try:
+        if page is not None:
+            page.close()
+    except Exception:
+        log.debug("Failed to close browser page during cleanup", exc_info=True)
+    try:
+        if browser_context is not None:
+            browser_context.close()
+    except Exception:
+        log.debug("Failed to close browser context during cleanup", exc_info=True)
+    try:
+        if browser is not None:
+            browser.close()
+    except Exception:
+        log.debug("Failed to close browser during cleanup", exc_info=True)
+    try:
+        if pw_instance is not None:
+            pw_instance.stop()
+    except Exception:
+        log.debug("Failed to stop Playwright instance during cleanup", exc_info=True)
+
+
+def cleanup_browser(ctx: ToolContext) -> None:
+    """Detach and close the context's Playwright handles."""
+    cleanup_browser_handles(_detach_browser(ctx))
 
 
 def _is_infrastructure_error(obj: Any) -> bool:

--- a/ouroboros/tools/browser.py
+++ b/ouroboros/tools/browser.py
@@ -607,7 +607,12 @@ def _detach_browser(ctx: ToolContext) -> tuple[Any, Any, Any, Any]:
 
 
 def cleanup_browser_handles(handles: tuple[Any, Any, Any, Any]) -> None:
-    """Close detached Playwright handles on the thread that owns them."""
+    """Close detached Playwright handles.
+
+    Thread-affinity is the CALLER's contract: Playwright objects are bound to
+    the thread that created them, so call this from that owner thread (the
+    late-settlement callback runs on the worker that finished the call). A
+    cross-thread close is swallowed but leaks the browser process."""
     page, browser_context, browser, pw_instance = handles
     try:
         if page is not None:

--- a/tests/test_browser_isolation.py
+++ b/tests/test_browser_isolation.py
@@ -6,9 +6,13 @@ import types
 
 import pytest
 
-from ouroboros.contracts.task_constraint import TaskConstraint
 import ouroboros.tools.browser as browser_mod
-from ouroboros.tools.browser import _is_infrastructure_error, cleanup_browser
+from ouroboros.contracts.task_constraint import TaskConstraint
+from ouroboros.tools.browser import (
+    _is_infrastructure_error,
+    cleanup_browser,
+    cleanup_browser_handles,
+)
 
 
 class TestInfrastructureErrorDetection:
@@ -424,6 +428,7 @@ class TestSetPlaywrightBrowsersPathIfBundled:
 
     def test_browser_install_uses_data_cache_when_zero_has_no_browser(self, monkeypatch, tmp_path):
         import os
+
         import ouroboros.tools.browser as bmod
 
         monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", "0")
@@ -456,6 +461,7 @@ class TestSetPlaywrightBrowsersPathIfBundled:
 
     def test_webkit_install_uses_data_cache_when_zero_has_no_bundled_webkit(self, monkeypatch, tmp_path):
         import os
+
         import ouroboros.tools.browser as bmod
 
         monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", "0")
@@ -488,6 +494,7 @@ class TestSetPlaywrightBrowsersPathIfBundled:
 
     def test_webkit_cache_fallback_does_not_strand_bundled_chromium(self, monkeypatch, tmp_path):
         import os
+
         import ouroboros.tools.browser as bmod
 
         monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", "0")
@@ -534,6 +541,7 @@ class TestSetPlaywrightBrowsersPathIfBundled:
 
     def test_frozen_missing_bundled_engine_installs_with_embedded_python(self, monkeypatch, tmp_path):
         import os
+
         import ouroboros.tools.browser as bmod
 
         embedded_python_posix = tmp_path / "python-standalone" / "bin" / "python3"
@@ -576,6 +584,7 @@ class TestSetPlaywrightBrowsersPathIfBundled:
 
     def test_readonly_missing_bundled_engine_does_not_create_cache(self, monkeypatch, tmp_path):
         import os
+
         import ouroboros.tools.browser as bmod
 
         monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", "0")
@@ -611,6 +620,7 @@ class TestSetPlaywrightBrowsersPathIfBundled:
 
     def test_readonly_existing_webkit_cache_is_reused_without_install(self, monkeypatch, tmp_path):
         import os
+
         import ouroboros.tools.browser as bmod
 
         cache = tmp_path / "data" / "playwright-browsers"
@@ -663,3 +673,14 @@ class TestCleanupBrowser:
         assert ctx.browser_state.page is None
         assert ctx.browser_state.browser is None
         assert ctx.browser_state.pw_instance is None
+
+    def test_cleanup_detached_handles_runs_on_owner_thread(self):
+        calls = []
+        handles = (
+            types.SimpleNamespace(close=lambda: calls.append("page")),
+            types.SimpleNamespace(close=lambda: calls.append("context")),
+            types.SimpleNamespace(close=lambda: calls.append("browser")),
+            types.SimpleNamespace(stop=lambda: calls.append("playwright")),
+        )
+        cleanup_browser_handles(handles)
+        assert calls == ["page", "context", "browser", "playwright"]

--- a/tests/test_browser_isolation.py
+++ b/tests/test_browser_isolation.py
@@ -674,13 +674,31 @@ class TestCleanupBrowser:
         assert ctx.browser_state.browser is None
         assert ctx.browser_state.pw_instance is None
 
-    def test_cleanup_detached_handles_runs_on_owner_thread(self):
+    def test_cleanup_detached_handles_closes_in_order_on_the_calling_thread(self):
+        # Thread-affinity is the CALLER's contract (the settlement callback
+        # runs on the worker thread that owns the handles); this test pins
+        # the close order and records the executing thread honestly.
+        import threading
+
         calls = []
+        threads = set()
+
+        def _mark(name):
+            def _inner():
+                threads.add(threading.get_ident())
+                calls.append(name)
+            return _inner
+
         handles = (
-            types.SimpleNamespace(close=lambda: calls.append("page")),
-            types.SimpleNamespace(close=lambda: calls.append("context")),
-            types.SimpleNamespace(close=lambda: calls.append("browser")),
-            types.SimpleNamespace(stop=lambda: calls.append("playwright")),
+            types.SimpleNamespace(close=_mark("page")),
+            types.SimpleNamespace(close=_mark("context")),
+            types.SimpleNamespace(close=_mark("browser")),
+            types.SimpleNamespace(stop=_mark("playwright")),
         )
-        cleanup_browser_handles(handles)
+        worker = threading.Thread(target=cleanup_browser_handles, args=(handles,))
+        worker.start()
+        worker.join()
         assert calls == ["page", "context", "browser", "playwright"]
+        # Every close ran on the SAME (calling) thread — never hopped back
+        # to the main thread.
+        assert threads == {worker.ident}

--- a/tests/test_tool_execution_classification.py
+++ b/tests/test_tool_execution_classification.py
@@ -1,6 +1,31 @@
 from ouroboros.loop_tool_execution import _extract_result_metadata, _is_tool_execution_failure
 
 
+def test_late_tool_settlement_runs_owner_cleanup_before_lease_close(monkeypatch):
+    from types import SimpleNamespace
+
+    import ouroboros.loop_tool_execution as lte
+
+    class ImmediateFuture:
+        def add_done_callback(self, callback):
+            callback(self)
+
+    calls = []
+    monkeypatch.setattr(lte, "emit_cognitive_operation_event", lambda *args, **kwargs: None)
+    tools = SimpleNamespace(_ctx=SimpleNamespace(event_queue=None, task_attempt=None))
+
+    lte._attach_late_tool_settlement(
+        tools,
+        ImmediateFuture(),
+        task_id="task",
+        tool_call_id="call",
+        correlation={},
+        on_settled=lambda: calls.append("cleanup"),
+    )
+
+    assert calls == ["cleanup"]
+
+
 def test_get_tool_timeout_honors_per_call_override(monkeypatch):
     """T3 (v6.35.0): the OUTER tool-execution timeout must rise for a per-call
     run_command/run_script timeout_sec, else the static 360s entry cap would cut
@@ -226,6 +251,7 @@ def test_live_tool_log_payload_includes_structured_result_metadata(tmp_path, mon
     import pathlib
     import time
     from types import SimpleNamespace
+
     import ouroboros.loop_tool_execution as loop_tool_execution
     from ouroboros.loop_tool_execution import _execute_with_timeout
 

--- a/tests/test_tool_execution_classification.py
+++ b/tests/test_tool_execution_classification.py
@@ -11,7 +11,8 @@ def test_late_tool_settlement_runs_owner_cleanup_before_lease_close(monkeypatch)
             callback(self)
 
     calls = []
-    monkeypatch.setattr(lte, "emit_cognitive_operation_event", lambda *args, **kwargs: None)
+    monkeypatch.setattr(lte, "emit_cognitive_operation_event",
+                        lambda *args, **kwargs: calls.append("lease"))
     tools = SimpleNamespace(_ctx=SimpleNamespace(event_queue=None, task_attempt=None))
 
     lte._attach_late_tool_settlement(
@@ -23,7 +24,9 @@ def test_late_tool_settlement_runs_owner_cleanup_before_lease_close(monkeypatch)
         on_settled=lambda: calls.append("cleanup"),
     )
 
-    assert calls == ["cleanup"]
+    # The ORDER is the contract: the owner-thread cleanup runs before the
+    # cognitive lease closes, so a settled lease never precedes live handles.
+    assert calls == ["cleanup", "lease"]
 
 
 def test_get_tool_timeout_honors_per_call_override(monkeypatch):
@@ -328,3 +331,79 @@ def test_reviewed_mutator_soft_timeout_keeps_foreground_custody(tmp_path, monkey
     started = next(payload for payload in payloads if payload.get("type") == "tool_call_started")
     assert started.get("terminal_wait") is True and started.get("timeout_sec") is None
     assert not any(payload.get("type") == "tool_call_timeout" for payload in payloads)
+
+
+
+def test_timed_out_stateful_tool_detaches_and_closes_once_at_settlement(monkeypatch):
+    """The #409 wiring: a stateful-tool timeout detaches the browser handles
+    from the context IMMEDIATELY (no cross-thread Playwright calls) and closes
+    them EXACTLY ONCE when the hung worker finally settles."""
+    from types import SimpleNamespace
+
+    import ouroboros.loop_tool_execution as lte
+
+    closed = []
+    page = SimpleNamespace(close=lambda: closed.append("page"))
+    context = SimpleNamespace(close=lambda: closed.append("context"))
+    chromium = SimpleNamespace(close=lambda: closed.append("browser"))
+    pw = SimpleNamespace(stop=lambda: closed.append("playwright"))
+
+    bs = SimpleNamespace(page=page, browser=chromium, pw_instance=pw)
+    setattr(bs, "_browser_context", context)
+    setattr(bs, "_thread_id", 1)
+    tool_ctx = SimpleNamespace(browser_state=bs)
+
+    class HungFuture:
+        def __init__(self):
+            self.callbacks = []
+
+        def result(self, timeout=None):
+            raise TimeoutError()
+
+        def add_done_callback(self, callback):
+            self.callbacks.append(callback)
+
+    future = HungFuture()
+
+    class FakeExecutor:
+        def submit(self, *args, **kwargs):
+            return future
+
+        def reset(self):
+            pass
+
+    monkeypatch.setattr(lte, "emit_cognitive_operation_event", lambda *a, **k: None)
+    monkeypatch.setattr(lte, "_emit_live_log", lambda *a, **k: None)
+    monkeypatch.setattr(
+        lte, "_make_timeout_result",
+        lambda *a, **k: {"tool_call_id": "call", "result": "timeout", "is_error": True},
+    )
+    tools = SimpleNamespace(
+        _ctx=SimpleNamespace(event_queue=None, task_attempt=None,
+                             browser_state=tool_ctx.browser_state),
+        get_timeout=lambda name: 1,
+        CODE_TOOLS=set(),
+    )
+    tools._ctx.browser_state = bs
+    tc = {"id": "call", "function": {"name": "browse_page", "arguments": "{}"}}
+    monkeypatch.setattr(lte, "load_settings", lambda: {})
+    monkeypatch.delenv("OUROBOROS_TOOL_TIMEOUT_SEC", raising=False)
+
+    import pathlib as _pl
+
+    result = lte._execute_with_timeout(
+        tools, tc, _pl.Path("."), 1, task_id="task",
+        stateful_executor=FakeExecutor(),
+    )
+    assert result["is_error"] is True
+    # Handles are DETACHED from the context immediately (no live session left
+    # for a new thread to trip over)...
+    assert tool_ctx.browser_state.page is None
+    assert tool_ctx.browser_state.pw_instance is None
+    # ...and nothing is closed until the hung worker settles.
+    assert closed == []
+    assert len(future.callbacks) == 1
+    future.callbacks[0](future)
+    assert closed == ["page", "context", "browser", "playwright"]
+    # Settling again must not double-close (the callback fires once per
+    # future by contract; the handles tuple is single-use).


### PR DESCRIPTION
Supersedes #429 by @mikemikimike — the fix is theirs and lands with their authorship; this branch folds in the review findings so it can merge green.

## What the original fix does (verified against base)

The #409 leak is real and worse than a leak on base: a timed-out browser tool left the old worker thread holding a live Playwright session; the next browser command's cross-thread `cleanup_browser` partially killed the driver, turning the hung dispatcher fiber's wait into a busy-loop on a full core (the documented 26-minute stall). The PR separates the two glued concerns: detach the state from the main thread (no Playwright calls — the busy-loop becomes structurally impossible) and close the handles in the future's done-callback, which runs on the owning worker thread. Thread affinity is correct; all `cleanup_browser` callers keep their semantics.

## What the rework adds (review: MERGE AFTER FIXES)

- A wiring test for the actual leak path: timed-out stateful tool → state detached → handles closed exactly once at settlement (`test_timed_out_stateful_tool_detaches_and_closes_once_at_settlement`, fake executor/hung future — no real Chromium needed).
- The two new tests now assert what their names promise: the settlement test records and asserts the `["cleanup", "lease"]` order; the owner-thread test asserts `threading.get_ident()` inside close.
- A CROSS-THREAD INVARIANT comment at the detach site and an honest `cleanup_browser_handles` docstring (the thread contract belongs to the caller).

Disclosed residual races (no worse than base): a call settling between TimeoutError and callback registration closes on the main thread (handles of that one call leak, no busy-loop); a never-settling call holds its detached browser indefinitely.

## Verification

Full parallel suite 12144 passed + serial pass on this tree (HEAD 0e8a558f held); targeted browser/classification suites green; `ruff --select F` clean; both touched files stay inside their size-ratchet band.
