### PR TITLE
ouroboros#452

### DIFF
--- a/ouroboros/loop.py
+++ b/ouroboros/loop.py
@@ -4094,6 +4094,11 @@ def _arm_delivery_control(
     evidence_revision, evidence_fingerprint = _delivery_evidence_state(tools, ctx, llm_trace)
     candidate.finalization_control = control
     candidate.repair_attempted = False
+    # Keep the causal fact after the transient latch is cleared. Acceptance
+    # improvement rounds are intentionally free-form, but an exact protocol
+    # object emitted while an earlier host control episode is still in the
+    # transcript must not become owner-facing prose.
+    tools._ctx._delivery_control_episode_seen = True
     tools._ctx._delivery_control_required = True
     _append_or_merge_user_message(
         ctx.messages,
@@ -4173,6 +4178,16 @@ def _resolve_delivery_control(
     is_control_intent = duplicate_protocol_key or (
         isinstance(parsed, dict) and "delivery_control" in parsed
     )
+    if (
+        not required
+        and is_control_intent
+        and bool(getattr(tools._ctx, "_delivery_control_episode_seen", False))
+    ):
+        # A prior host-issued control prompt makes this an outstanding
+        # protocol response even when an ordinary acceptance revision
+        # deliberately disabled the one-round latch.
+        required = True
+        tools._ctx._delivery_control_required = True
     if not required:
         if _delivery_replace_required(candidate):
             # A writer/skill action cannot silently turn a short acknowledgement
@@ -6713,6 +6728,7 @@ def run_llm_loop(
     ctx._delivery_candidate = None
     ctx._delivery_candidate_revision = 0
     ctx._delivery_control_required = False
+    ctx._delivery_control_episode_seen = False
     ctx._delivery_evidence_revision = 0
     ctx._delivery_evidence_fingerprint = ""
     _initialize_owner_directives(ctx, messages)

--- a/tests/test_delivery_forced_finalization.py
+++ b/tests/test_delivery_forced_finalization.py
@@ -1532,6 +1532,32 @@ def test_forced_finalization_passes_json_through_when_latch_not_armed(tmp_path, 
     assert text.startswith(legitimate)
 
 
+def test_stale_control_envelope_is_decoded_after_acceptance_revision(tmp_path):
+    """A cleared latch must not leak a prior host control envelope."""
+    loop, registry, limit_ctx, trace = _forced_test_context(tmp_path)
+    _arm_latch_with_candidate(loop, registry, limit_ctx, trace)
+    registry._ctx._delivery_control_episode_seen = True
+    registry._ctx._delivery_control_required = False
+    content = '{"delivery_control":"replace","full_answer":"answer\\nwith **markdown**"}'
+
+    status, text = loop._resolve_delivery_control(content, registry, limit_ctx, trace)
+
+    assert status == "resolved"
+    assert text == "answer\nwith **markdown**"
+    assert registry._ctx._delivery_control_required is False
+
+
+def test_unrelated_json_remains_fresh_without_a_control_episode(tmp_path):
+    """JSON stays user-facing when no host control episode occurred."""
+    loop, registry, limit_ctx, trace = _forced_test_context(tmp_path)
+    content = '{"delivery_control":"replace","full_answer":"user data"}'
+
+    status, text = loop._resolve_delivery_control(content, registry, limit_ctx, trace)
+
+    assert status == "fresh"
+    assert text == content
+
+
 def test_forced_finalization_degrades_unknown_verb_control_to_retained_candidate(
     tmp_path, monkeypatch,
 ):


### PR DESCRIPTION
## Summary

Fixes a delivery-boundary bug where a valid `DELIVERY_FINALIZATION_CONTROL` envelope could become the owner-facing answer after an acceptance-improvement round cleared the transient control latch.

The loop now retains the fact that a host control episode occurred during the current run. If a later exact control object is emitted while the latch is temporarily off, it is still parsed as protocol and only the decoded `full_answer` is retained. Runs with no host control episode continue to deliver user-facing JSON unchanged.

Closes #449.

## Scope

- Preserve the existing free-form acceptance-improvement path.
- Prevent stale host-issued delivery envelopes from entering the canonical answer.
- Add regression coverage for stale-envelope decoding and unrelated JSON passthrough.

## Verification

- `uv run --locked python -m pytest tests/test_delivery_forced_finalization.py tests/test_v671_acceptance_convergence.py -q` — passed (65 tests).
- `uv run --locked ruff check ouroboros/loop.py tests/test_delivery_forced_finalization.py --ignore I001,E402` — passed.
- `git diff --check` — passed.
- `uv run --locked python -m pytest tests/ -q --tb=short` — not clean on this checkout: unrelated existing failures were observed in `tests/test_claudexor_owned_daemon.py` and `tests/test_consciousness_observations.py`; no failure implicated the changed files.

## Base and head

- Base: `e9dfb359963789516eed4a3960c2cfaea95044b0`
- Head: `a51c3cdc99213a984c6fd5e35f47af6ee376bd09`
