### PR TITLE
Fix stale delivery control after acceptance revisions

### DIFF
--- a/ouroboros/loop.py
+++ b/ouroboros/loop.py
@@ -3479,6 +3479,11 @@ def _arm_delivery_control(
     evidence_revision, evidence_fingerprint = _delivery_evidence_state(tools, ctx, llm_trace)
     candidate.finalization_control = control
     candidate.repair_attempted = False
+    # Keep the causal fact after the transient latch is cleared. Acceptance
+    # improvement rounds are intentionally free-form, but an exact protocol
+    # object emitted while an earlier host control episode is still in the
+    # transcript must not become owner-facing prose.
+    tools._ctx._delivery_control_episode_seen = True
     tools._ctx._delivery_control_required = True
     _append_or_merge_user_message(
         ctx.messages,
@@ -3533,6 +3538,17 @@ def _resolve_delivery_control(
     is_control_intent = duplicate_protocol_key or (
         isinstance(parsed, dict) and "delivery_control" in parsed
     )
+    if not required and bool(
+        getattr(tools._ctx, "_delivery_control_acceptance_revision_pending", False)
+    ):
+        # Acceptance improvement deliberately clears the one-round latch, but
+        # the prior host prompt remains in the transcript. Consume this
+        # one-round compatibility marker: a normal prose answer is free-form,
+        # while a protocol-shaped response still belongs to the stale prompt.
+        tools._ctx._delivery_control_acceptance_revision_pending = False
+        if is_control_intent:
+            required = True
+            tools._ctx._delivery_control_required = True
     if not required:
         if _delivery_replace_required(candidate):
             # A writer/skill action cannot silently turn a short acknowledgement
@@ -4130,6 +4146,8 @@ def _no_tool_final_answer(
         # froze the model into resubmitting the same answer. The next
         # free-form answer re-enters the acceptance panel (blocking not
         # weakened); other lanes still arm where JSON keep/replace is needed.
+        if bool(getattr(tools._ctx, "_delivery_control_episode_seen", False)):
+            tools._ctx._delivery_control_acceptance_revision_pending = True
         return None
     candidate = getattr(tools._ctx, "_delivery_candidate", None)
     if isinstance(candidate, DeliveryCandidate):
@@ -4622,12 +4640,17 @@ def _resolve_forced_delivery_control(
         return extracted, ""
     candidate = getattr(tools_ctx, "_delivery_candidate", None)
     candidate = candidate if isinstance(candidate, DeliveryCandidate) else None
+    acceptance_revision_pending = bool(
+        getattr(tools_ctx, "_delivery_control_acceptance_revision_pending", False)
+    )
     armed = bool(getattr(tools_ctx, "_delivery_control_required", False)) or (
         candidate is not None and _delivery_replace_required(candidate)
-    )
+    ) or acceptance_revision_pending
     if not armed:
         return extracted, ""
     tools_ctx._delivery_control_required = False
+    if acceptance_revision_pending:
+        tools_ctx._delivery_control_acceptance_revision_pending = False
     parsed, duplicate_protocol_key, embedded_protocol = _parse_delivery_control_body(extracted)
     # Protocol intent: any parsed object with the protocol key (unknown verb =
     # broken control; a trailing prose-embedded object counts), or JSON-looking
@@ -6113,6 +6136,8 @@ def run_llm_loop(
     ctx = tools._ctx
     ctx._delivery_candidate, ctx._delivery_candidate_revision = None, 0
     ctx._delivery_control_required = False
+    ctx._delivery_control_episode_seen = False
+    ctx._delivery_control_acceptance_revision_pending = False
     ctx._delivery_evidence_revision, ctx._delivery_evidence_fingerprint = 0, ""
     _initialize_owner_directives(ctx, messages)
     task_model_override = str(getattr(ctx, "task_model_override", "") or "").strip()

--- a/tests/test_delivery_forced_finalization.py
+++ b/tests/test_delivery_forced_finalization.py
@@ -1532,6 +1532,38 @@ def test_forced_finalization_passes_json_through_when_latch_not_armed(tmp_path, 
     assert text.startswith(legitimate)
 
 
+def test_forced_resolver_passes_json_through_without_a_control_episode(tmp_path):
+    """The forced resolver preserves protocol-shaped JSON without history."""
+    loop, registry, limit_ctx, trace = _forced_test_context(tmp_path)
+    loop._replace_delivery_candidate(
+        registry, limit_ctx, trace, "Retained complete answer.", control="candidate",
+    )
+    content = '{"delivery_control":"replace","full_answer":"user data"}'
+
+    text, degraded_reason = loop._resolve_forced_delivery_control(
+        registry._ctx, content,
+    )
+
+    assert text == content
+    assert degraded_reason == ""
+
+
+def test_forced_resolver_decodes_stale_control_after_acceptance_revision(tmp_path, monkeypatch):
+    """A forced rail must also contain a stale host control envelope."""
+    loop, registry, limit_ctx, trace = _forced_test_context(tmp_path)
+    _prepare_acceptance_revision_after_delivery_control(
+        loop, registry, limit_ctx, trace, monkeypatch,
+    )
+    content = '{"delivery_control":"replace","full_answer":"answer\\nwith **markdown**"}'
+
+    text, degraded_reason = loop._resolve_forced_delivery_control(
+        registry._ctx, content,
+    )
+
+    assert text == "answer\nwith **markdown**"
+    assert degraded_reason == ""
+
+
 def test_forced_finalization_degrades_unknown_verb_control_to_retained_candidate(
     tmp_path, monkeypatch,
 ):
@@ -1931,6 +1963,81 @@ def test_nonforced_resolver_passes_mixed_prose_json_when_latch_not_armed(tmp_pat
 
     assert status == "fresh"
     assert text == mixed
+
+
+def _prepare_acceptance_revision_after_delivery_control(
+    loop, registry, limit_ctx, trace, monkeypatch,
+):
+    """Drive the real no-tool acceptance-improvement branch after control."""
+    loop._replace_delivery_candidate(
+        registry, limit_ctx, trace, "Retained complete answer.", control="candidate",
+    )
+    loop._arm_delivery_control(registry, limit_ctx, trace)
+    status, text = loop._resolve_delivery_control(
+        '{"delivery_control":"replace","full_answer":"first answer"}',
+        registry, limit_ctx, trace,
+    )
+    assert status == "resolved"
+    assert text == "first answer"
+
+    monkeypatch.setattr(loop, "_compute_subagent_handoff", lambda *_a, **_k: None)
+    monkeypatch.setattr(loop, "_maybe_inject_finalization_nudges", lambda *_a, **_k: False)
+    monkeypatch.setattr(loop, "_run_task_acceptance_review_once", lambda **_k: True)
+    assert loop._no_tool_final_answer(
+        "Revised answer draft.",
+        limit_ctx,
+        trace,
+        registry,
+        queue.Queue(),
+        set(),
+        lambda _text: None,
+    ) is None
+    assert registry._ctx._delivery_control_acceptance_revision_pending is True
+
+
+def test_stale_control_envelope_is_decoded_after_acceptance_revision(tmp_path, monkeypatch):
+    """A cleared latch must not leak a prior host control envelope."""
+    loop, registry, limit_ctx, trace = _forced_test_context(tmp_path)
+    _prepare_acceptance_revision_after_delivery_control(
+        loop, registry, limit_ctx, trace, monkeypatch,
+    )
+    content = '{"delivery_control":"replace","full_answer":"answer\\nwith **markdown**"}'
+
+    status, text = loop._resolve_delivery_control(content, registry, limit_ctx, trace)
+
+    assert status == "resolved"
+    assert text == "answer\nwith **markdown**"
+    assert registry._ctx._delivery_control_required is False
+
+
+def test_acceptance_revision_marker_is_consumed_by_ordinary_prose(tmp_path, monkeypatch):
+    """An ordinary revision consumes the stale-control compatibility window."""
+    loop, registry, limit_ctx, trace = _forced_test_context(tmp_path)
+    _prepare_acceptance_revision_after_delivery_control(
+        loop, registry, limit_ctx, trace, monkeypatch,
+    )
+
+    status, text = loop._resolve_delivery_control(
+        "Ordinary revised answer.", registry, limit_ctx, trace,
+    )
+
+    assert status == "fresh"
+    assert text == "Ordinary revised answer."
+    assert registry._ctx._delivery_control_acceptance_revision_pending is False
+
+
+def test_unrelated_json_remains_fresh_without_a_control_episode(tmp_path):
+    """JSON stays user-facing when no host control episode occurred."""
+    loop, registry, limit_ctx, trace = _forced_test_context(tmp_path)
+    loop._replace_delivery_candidate(
+        registry, limit_ctx, trace, "Retained complete answer.", control="candidate",
+    )
+    content = '{"delivery_control":"replace","full_answer":"user data"}'
+
+    status, text = loop._resolve_delivery_control(content, registry, limit_ctx, trace)
+
+    assert status == "fresh"
+    assert text == content
 
 
 def test_forced_rail_truncated_trailing_fragment_is_a_disclosed_residual(

--- a/tests/test_v671_acceptance_convergence.py
+++ b/tests/test_v671_acceptance_convergence.py
@@ -326,3 +326,4 @@ def test_acceptance_revision_round_does_not_arm_delivery_control(tmp_path, monke
     # conflicted with OPEN OBLIGATIONS prose + the periodic self-check and froze
     # the model into identical no-tool resubmits).
     assert not bool(getattr(registry._ctx, "_delivery_control_required", False))
+    assert not bool(getattr(registry._ctx, "_delivery_control_acceptance_revision_pending", False))


### PR DESCRIPTION
## Summary

Fixes #449, where a stale `DELIVERY_FINALIZATION_CONTROL` envelope could become the owner-facing answer after an acceptance-improvement round cleared the transient latch.

The loop now records that a host control episode occurred, arms a one-round pending marker only when the real acceptance-improvement branch is entered, and consumes that marker in both normal and forced delivery resolvers. Ordinary prose clears the marker, and protocol-shaped JSON remains unchanged when no control episode exists.

## Verification

- `uv run --locked python -m pytest tests/test_delivery_forced_finalization.py tests/test_delivery_candidate.py tests/test_v671_acceptance_convergence.py -q` — passed
- `uv run --locked ruff check . --select F` — passed
- `uv run --locked ruff check ouroboros/loop.py tests/test_delivery_forced_finalization.py tests/test_v671_acceptance_convergence.py --select E,F,W --ignore E501,E402` — passed
- `git diff --check` — passed
- Separate read-only review — PASS

The full default suite was also attempted under `PYTHONUTF8=1`; it stopped at the unrelated baseline failure `tests/test_claudexor_owned_daemon.py::test_install_success_receipt_is_strict_and_provenance_is_a_pair`.