### PR TITLE
Fix delayed Claudexor startup reconciliation

### DIFF
--- a/ouroboros/claudexor_daemon.py
+++ b/ouroboros/claudexor_daemon.py
@@ -263,7 +263,7 @@ class OwnedClaudexorDaemon:
 
     # -- state ------------------------------------------------------------
 
-    def _classify_liveness(self) -> tuple:
+    def _classify_liveness(self, *, timeout_sec: Optional[float] = None) -> tuple:
         """(endpoint_or_None, state, detail) — the ONE liveness probe.
 
         The bearer token in OUR descriptor is the identity proof: each home's
@@ -290,7 +290,11 @@ class OwnedClaudexorDaemon:
             return None, "stale", f"{exc.code}: {exc}"
         try:
             with ClaudexorGateway(endpoint) as gateway:
-                handshake = gateway.handshake()
+                handshake = (
+                    gateway.handshake()
+                    if timeout_sec is None
+                    else gateway.handshake(timeout_sec=timeout_sec)
+                )
                 self._engine_version = gateway.engine_version
                 engine = handshake.get("engine") if isinstance(handshake.get("engine"), dict) else {}
                 self._engine_build_sha = str(engine.get("sha") or "")
@@ -311,9 +315,9 @@ class OwnedClaudexorDaemon:
                 )
             return None, "stale", f"{exc.code}: {exc}"
 
-    def _alive_endpoint(self) -> Optional[Any]:
+    def _alive_endpoint(self, *, timeout_sec: Optional[float] = None) -> Optional[Any]:
         """Endpoint of a LIVE daemon on our home, or None. Never spawns."""
-        endpoint, state, detail = self._classify_liveness()
+        endpoint, state, detail = self._classify_liveness(timeout_sec=timeout_sec)
         if detail:
             self._last_error = detail
         return endpoint
@@ -365,7 +369,10 @@ class OwnedClaudexorDaemon:
         home is not ours, or the spawned daemon never published a live
         descriptor.
         """
-        from ouroboros.gateways.claudexor import ClaudexorUnavailable
+        from ouroboros.gateways.claudexor import (
+            SHORT_POLL_TIMEOUT_SEC,
+            ClaudexorUnavailable,
+        )
 
         with self._lock:
             endpoint, state, detail = self._classify_liveness()
@@ -458,29 +465,29 @@ class OwnedClaudexorDaemon:
                 )
             _write_ownership_marker()
             deadline = time.monotonic() + _SPAWN_WAIT_SEC
-            while time.monotonic() < deadline:
-                if self._proc.poll() is not None:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
                     break
+                # An exited child may only have lost the writer lease to another
+                # worker. Child state is not completion authority: the shared,
+                # authenticated endpoint or this deadline is.
                 # RECONCILE: fresh discovery + AUTHENTICATED handshake against
                 # the descriptor the new daemon just wrote — the same identity
                 # proof attach uses, so a restart never claims a port it does
                 # not hold.
-                endpoint = self._alive_endpoint()
+                endpoint = self._alive_endpoint(
+                    timeout_sec=min(remaining, SHORT_POLL_TIMEOUT_SEC),
+                )
                 if endpoint is not None:
+                    if self._proc is not None and self._proc.poll() is not None:
+                        self._proc = None
                     self._last_error = ""
                     return endpoint
-                time.sleep(_SPAWN_POLL_SEC)
-            # Two Ouroboros processes can race only on first provisioning: the
-            # winner publishes the owned endpoint and the losing Claudexor
-            # child exits after observing the same writer lease. Reconcile one
-            # final time after child exit before reporting a false spawn
-            # failure. An exited loser is not a process this manager owns.
-            endpoint = self._alive_endpoint()
-            if endpoint is not None:
-                if self._proc.poll() is not None:
-                    self._proc = None
-                self._last_error = ""
-                return endpoint
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                time.sleep(min(_SPAWN_POLL_SEC, remaining))
             tail = ""
             try:
                 tail = log_path.read_bytes()[-500:].decode("utf-8", errors="replace")
@@ -673,9 +680,9 @@ def ensure_owned_gateway(*, admission_wait_sec: Optional[float] = None) -> Any:
     the zero-wait variant for callers that must not stall on ADMISSION: a
     recovering daemon is an immediate typed refusal there, and the initial
     handshake below is read-bounded by the same small window. The wait bounds
-    admission only — ``ensure_running``'s own liveness/spawn probes keep their
-    pre-existing finite transport ceilings (connect 5s; they are one identity
-    handshake, not a poll loop), unchanged for every caller of this seam.
+    admission only. ``ensure_running`` keeps ordinary attach probes on their
+    default transport ceiling, while a spawned daemon is reconciled through
+    bounded authenticated handshakes inside its existing startup window.
     An expired/failed admission also skips the reconcile: the recovering
     daemon 503s settings reads anyway, and the next ensure retries it.
     """

--- a/ouroboros/gateways/claudexor.py
+++ b/ouroboros/gateways/claudexor.py
@@ -42,7 +42,8 @@ _CONNECT_TIMEOUT_SEC = 5.0
 # purpose: most calls here would rather wait than fail, and a run start can take a while
 # to answer.
 _READ_TIMEOUT_SEC = 60.0
-# The FLOOR under such a caller's ask, not a bound anything asks for by name. Every
+# The FLOOR under non-strict bounded wait/admission asks. Owned-daemon startup also
+# imports it as the CEILING for each fast loopback liveness probe. Every ordinary
 # `delegate_wait` poll asks for what its window has left; this is where that narrowing
 # stops, because a nearly spent window asking for its own 0.2s turns a healthy daemon
 # into a timeout, while the 60s default would outrun the very deadline the wait clamps

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,12 +127,15 @@ def _bind_pytest_runtime_roots() -> None:
         return
     root = _PYTEST_DATA_DIR.resolve(strict=False)
     import ouroboros.config as config
-    from supervisor import queue, state, workers
+    from supervisor import git_ops, queue, state, workers
 
     config.DATA_DIR = root
     config.SETTINGS_PATH = root / "settings.json"
     state.init(root, state.TOTAL_BUDGET_LIMIT)
     queue.init(root, queue.SOFT_TIMEOUT_SEC, queue.HARD_TIMEOUT_SEC)
+    # git_ops has no env fallback: keep every rescue/log writer on the disposable
+    # data root without init(), which would also overwrite branch/remote authority.
+    git_ops.DRIVE_ROOT = root
     workers.DRIVE_ROOT = root
     # spawn_workers hands str(workers.REPO_DIR) to every child, and the child binds git_ops to
     # it — so leaving this at the live default would send workers started BY A TEST back at the

--- a/tests/test_claudexor_owned_daemon.py
+++ b/tests/test_claudexor_owned_daemon.py
@@ -2529,9 +2529,12 @@ def test_a_spawn_that_never_publishes_a_descriptor_does_not_leave_the_child_runn
 
 
 def test_first_spawn_loser_attaches_to_the_winners_endpoint(monkeypatch, tmp_path):
-    """A concurrent first-use winner is success, not a false spawn failure."""
+    """A delayed concurrent winner is success, not a false spawn failure."""
     from ouroboros import claudexor_runtime as runtime
-    from ouroboros.gateways.claudexor import DaemonEndpoint
+    from ouroboros.gateways.claudexor import (
+        SHORT_POLL_TIMEOUT_SEC,
+        DaemonEndpoint,
+    )
 
     data_dir = tmp_path / "data"
     config_dir = data_dir / "claudexor"
@@ -2563,11 +2566,123 @@ def test_first_spawn_loser_attaches_to_the_winners_endpoint(monkeypatch, tmp_pat
     endpoint = DaemonEndpoint(host="127.0.0.1", port=45681, token="winner-token")
     manager = owned.OwnedClaudexorDaemon()
     monkeypatch.setattr(manager, "_classify_liveness", lambda: (None, "not_provisioned", ""))
-    monkeypatch.setattr(manager, "_alive_endpoint", lambda: endpoint)
+    monkeypatch.setattr(owned, "_SPAWN_POLL_SEC", 0.0)
+    probe_bounds = []
+
+    def delayed_winner(*, timeout_sec=None):
+        probe_bounds.append(timeout_sec)
+        return endpoint if len(probe_bounds) == 3 else None
+
+    monkeypatch.setattr(manager, "_alive_endpoint", delayed_winner)
 
     assert manager.ensure_running() is endpoint
+    assert len(probe_bounds) == 3
+    assert all(0 < bound <= SHORT_POLL_TIMEOUT_SEC for bound in probe_bounds)
     assert manager._proc is None
     assert manager.stop() is False
+
+
+def test_exited_spawn_times_out_cleanly_with_bounded_liveness_probes(
+        monkeypatch, tmp_path):
+    """An exited child is forgotten only after the shared startup window."""
+    from ouroboros import claudexor_runtime as runtime
+    from ouroboros.gateways import claudexor as gateway_mod
+    from ouroboros.gateways.claudexor import (
+        SHORT_POLL_TIMEOUT_SEC,
+        ClaudexorUnavailable,
+        DaemonEndpoint,
+    )
+
+    data_dir = tmp_path / "data"
+    config_dir = data_dir / "claudexor"
+    _point_owned_home(monkeypatch, config_dir, data_dir)
+    monkeypatch.setattr(owned, "verify_owned_home", lambda: "")
+    monkeypatch.setattr(owned, "_SPAWN_WAIT_SEC", 0.03)
+    monkeypatch.setattr(owned, "_SPAWN_POLL_SEC", 0.01)
+
+    class Clock:
+        now = 0.0
+
+        def monotonic(self):
+            return self.now
+
+        def sleep(self, seconds):
+            self.now += seconds
+
+    clock = Clock()
+    monkeypatch.setattr(owned, "time", clock)
+
+    class ReadyRuntime:
+        def ensure(self):
+            return ["/fixture/node", "/fixture/claudexord.bundle.cjs"]
+
+        def status(self):
+            return {"source": "download"}
+
+    monkeypatch.setattr(runtime, "get_runtime_manager", lambda: ReadyRuntime())
+
+    provisioned = {"value": False}
+    monkeypatch.setattr(owned, "owned_daemon_provisioned",
+                        lambda: provisioned["value"])
+    endpoint = DaemonEndpoint(host="127.0.0.1", port=45682, token="winner-token")
+    monkeypatch.setattr(gateway_mod, "discover_daemon_at", lambda _home: endpoint)
+    handshake_bounds = []
+
+    class UnreachableGateway:
+        def __init__(self, _endpoint):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            pass
+
+        def handshake(self, *, timeout_sec=None):
+            handshake_bounds.append((clock.monotonic(), timeout_sec))
+            raise ClaudexorUnavailable("daemon_unreachable", "not ready")
+
+    monkeypatch.setattr(gateway_mod, "ClaudexorGateway", UnreachableGateway)
+
+    class ExitedChild:
+        pid = 424244
+        terminated = 0
+
+        def poll(self):
+            return 1
+
+        def terminate(self):
+            self.terminated += 1
+
+    child = ExitedChild()
+    import ouroboros.process_custody as custody_mod
+
+    def spawn(*_args, **kwargs):
+        provisioned["value"] = True
+        kwargs["stdout"].write(b"writer lease lost\n")
+        kwargs["stdout"].flush()
+        return child
+
+    monkeypatch.setattr(custody_mod, "spawn_supervised", spawn)
+
+    manager = owned.OwnedClaudexorDaemon()
+    with pytest.raises(ClaudexorUnavailable) as err:
+        manager.ensure_running()
+
+    assert err.value.code == "daemon_spawn_failed"
+    assert "writer lease lost" in str(err.value)
+    assert handshake_bounds
+    assert clock.now == pytest.approx(owned._SPAWN_WAIT_SEC)
+    assert all(started < owned._SPAWN_WAIT_SEC for started, _bound in handshake_bounds)
+    assert all(
+        0 < bound <= min(owned._SPAWN_WAIT_SEC - started, SHORT_POLL_TIMEOUT_SEC)
+        for started, bound in handshake_bounds
+    )
+    assert child.terminated == 0
+    assert manager._proc is None
+
+    manager._classify_liveness()
+    assert handshake_bounds[-1] == (clock.now, None)
 
 
 def test_dead_owned_daemon_is_restarted_and_reconciled(monkeypatch, tmp_path):
@@ -2854,7 +2969,7 @@ def test_staged_update_activates_only_at_the_next_natural_start(monkeypatch, tmp
         "spawn_supervised",
         lambda command, **_kwargs: spawns.append(list(command)) or _LiveChild(),
     )
-    monkeypatch.setattr(daemon, "_alive_endpoint", lambda: new_endpoint)
+    monkeypatch.setattr(daemon, "_alive_endpoint", lambda **_kwargs: new_endpoint)
 
     # Phase 1: the OLD endpoint keeps serving; the new target is only staged.
     assert daemon.ensure_running() is old_endpoint

--- a/tests/test_evolution_state_integrity_v3.py
+++ b/tests/test_evolution_state_integrity_v3.py
@@ -69,11 +69,12 @@ def _assignment_case(tmp_path, monkeypatch, task_id="assign-evo"):
 
 
 def test_pytest_process_globals_use_the_disposable_root():
-    from supervisor import queue, state, workers
+    from supervisor import git_ops, queue, state, workers
 
     expected = pathlib.Path(os.environ["OUROBOROS_DATA_DIR"]).resolve(strict=False)
     assert state.DRIVE_ROOT.resolve(strict=False) == expected
     assert queue.DRIVE_ROOT.resolve(strict=False) == expected
+    assert git_ops.DRIVE_ROOT.resolve(strict=False) == expected
     assert workers.DRIVE_ROOT.resolve(strict=False) == expected
     assert expected != (pathlib.Path.home() / "Ouroboros" / "data").resolve(strict=False)
 
@@ -109,16 +110,21 @@ def test_pytest_bootstrap_rebinds_preimported_modules_away_from_fake_home(tmp_pa
     ):
         env.pop(key, None)
     env["HOME"] = str(fake_home)
+    env["USERPROFILE"] = str(fake_home)
     env["PYTHONPATH"] = os.pathsep.join((str(repo), str(repo / "tests")))
     code = """
 import importlib.util, json, pathlib
-from supervisor import queue, state, workers
+from supervisor import git_ops, queue, state, workers
 spec = importlib.util.spec_from_file_location('isolated_conftest', pathlib.Path('tests/conftest.py'))
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
 module._bind_pytest_runtime_roots()
 state.update_state(lambda live: live.update({'probe': 'isolated'}))
-print(json.dumps({'root': str(state.DRIVE_ROOT), 'state': state.load_state()}))
+print(json.dumps({
+    'root': str(state.DRIVE_ROOT),
+    'git_ops_root': str(git_ops.DRIVE_ROOT),
+    'state': state.load_state(),
+}))
 """
 
     proc = subprocess.run(
@@ -133,6 +139,7 @@ print(json.dumps({'root': str(state.DRIVE_ROOT), 'state': state.load_state()}))
     payload = json.loads(proc.stdout.strip().splitlines()[-1])
     assert sentinel_path.read_bytes() == sentinel
     assert pathlib.Path(payload["root"]) != sentinel_path.parents[1]
+    assert payload["git_ops_root"] == payload["root"]
     assert payload["state"]["probe"] == "isolated"
 
 

--- a/tests/test_update_apply_routing.py
+++ b/tests/test_update_apply_routing.py
@@ -730,9 +730,8 @@ def test_writer_fence_order(monkeypatch):
         lambda *_args, **_kwargs: calls.append("kill_services") or [],
     )
     # The custody sweep is the fence's fifth step and reads
-    # supervisor.git_ops.DRIVE_ROOT, which is bound at IMPORT time — an
-    # isolated OUROBOROS_DATA_DIR does not rebind it (docs/DEVELOPMENT.md
-    # hermetic-preflight rule). Unpatched, this unit test of ORDER reached the
+    # supervisor.git_ops.DRIVE_ROOT. The shared pytest bootstrap now rebinds it
+    # to a disposable root; before that binding, this order-only test reached the
     # operator's live process ledger: it reported live entries as blockers
     # (any machine running Ouroboros failed this test) and, worse, would have
     # killed a ledgered task/session service that happened to be running.


### PR DESCRIPTION
Fixes #446.

Keeps polling the authenticated shared endpoint after a losing Claudexor child exits, bounded by the existing startup deadline and short per-probe timeout. Concurrent first-use callers can attach to the winner instead of returning a premature spawn failure.

Also isolates git-operation data roots in pytest so import-time writers do not reach live state.

The frozen branch passed 154 focused tests, repository-wide Ruff F, changed-file compilation, and size-ratchet shape checks. The final canonical triad/scope run did not complete: two attempts failed before model execution because the isolated review home lacked the required Claude and Cursor profiles. No further checks or post-target-drift rerun were performed at the owner's direction.
