### PR TITLE
chore: pin Claudexor 3.9.5

### DIFF
--- a/ouroboros/claudexor_runtime_pin.json
+++ b/ouroboros/claudexor_runtime_pin.json
@@ -1,12 +1,12 @@
 {
  "schema_version": 1,
  "release": {
-  "version": "3.9.4",
-  "build_sha": "7402e18cbbad61ca0b4211e3730a5090f3b3fd89",
+  "version": "3.9.5",
+  "build_sha": "519390b6172264d0d7a27a442c564a5aa88873eb",
   "protocol_major": 3,
-  "archive_url": "https://github.com/razzant/claudexor/releases/download/v3.9.4/claudexor-runtime-3.9.4.tar.gz",
-  "sha256": "1f89db6920679b5bd679eca4be4667910aa2c63ac8444c7c1578d2df088872cf",
-  "size_bytes": 21998999,
+  "archive_url": "https://github.com/razzant/claudexor/releases/download/v3.9.5/claudexor-runtime-3.9.5.tar.gz",
+  "sha256": "b2fb651aa6d3693abd4c0aea82683deeac964cb11e1441de7766c9783314c79c",
+  "size_bytes": 21998929,
   "node_version": "24.16.0",
   "node_artifacts": {
    "darwin-arm64": {

--- a/tests/test_claudexor_runtime_delivery.py
+++ b/tests/test_claudexor_runtime_delivery.py
@@ -154,7 +154,7 @@ def test_tracked_pin_names_a_cli_capable_release():
     of this proposal converged on while the pin was still pre-CLI 3.6.0)."""
     pin = runtime.load_runtime_pin()
     assert pin is not None
-    assert pin.version == "3.9.4"
+    assert pin.version == "3.9.5"
     assert pin.cli_entrypoint == "claudexor.bundle.cjs"
 
 
@@ -170,7 +170,7 @@ def test_managed_runtime_layout_stays_inside_legacy_windows_path_budget(
         runtime.managed_runtime_root()
     ) == pathlib.Path(pin.install_name)
 
-    # The current public closure's measured longest relative member is 170
+    # The current public closure's measured longest relative member is 172
     # characters.  A conservative default Windows profile still stays below
     # legacy MAX_PATH with the shared compact layout; no platform fork needed.
     windows_data_root = pathlib.PureWindowsPath(
@@ -178,10 +178,11 @@ def test_managed_runtime_layout_stays_inside_legacy_windows_path_budget(
     )
     longest_member = (
         "browser-mcp-runtime/node_modules/.pnpm/"
-        "playwright-core@1.62.0-alpha-1783623505000/node_modules/"
-        "playwright-core/lib/vite/traceViewer/assets/defaultSettingsView-CT5oRh4X.js"
+        "@claudexor+schema@file+packages+schema/node_modules/"
+        "@claudexor/schema/generated/"
+        "ControlCredentialProfilesSnapshotResponse.schema.json"
     )
-    assert len(longest_member) == 170
+    assert len(longest_member) == 172
     candidate = windows_data_root / "state" / "cx" / pin.install_name / longest_member
     assert len(str(candidate)) < 260
 


### PR DESCRIPTION
Updates the managed Claudexor runtime pin from 3.9.4 to the public 3.9.5 release. The signed runtime manifest identifies build `519390b6172264d0d7a27a442c564a5aa88873eb` and archive SHA-256 `b2fb651aa6d3693abd4c0aea82683deeac964cb11e1441de7766c9783314c79c`; the public archive is `21,998,929` bytes. The committed pin matches those public values.

Protocol 3, Node 24.16.0, all five Node artifacts, and both entrypoints are unchanged. The existing Windows path-budget fixture now tracks the public archive's actual 172-character longest member. This PR changes no Ouroboros version carrier and does not restart or hot-swap a running daemon; the new runtime is selected on the next natural managed-daemon start.

Verification: 32 focused pin tests passed. The public archive passed signed-manifest, checksum, independent-download, strict provenance, and `--verify-only` checks; a managed-runtime fixture served Claudexor 3.9.5 at the exact build, completed a mutating task, returned its primary artifact to EOF, and stopped gracefully. The full isolated suite had 12,875 passed, 5 skipped, and one pre-existing packaged-Node test-isolation failure reproduced unchanged on the parent. Exact-SHA Sol, Fable, Grok, and scope review converged without an actionable finding.

A non-published combined tree with #457 passed 254 focused tests, Ruff, the managed-runtime fixture, and a full isolated suite with 12,876 passed, 5 skipped, and the same parent-reproduced packaged-Node failure. The fixture uses a fake harness, so it verifies runtime delivery and transport rather than a live subscription/model route. Pinning the artifact does not prove live adoption until a later daemon start.
