### PR TITLE
test: close the CRLF source-pin class in web tests; band entry for test_services_tool_v2

### DIFF
--- a/ouroboros/size_ratchet_manifest.py
+++ b/ouroboros/size_ratchet_manifest.py
@@ -200,6 +200,7 @@ BAND_PATHS = {
     "tests/test_review_verification_v6544.py": None,
     "tests/test_reviewer_slot_config.py": "Existing suite grew by successor pins for the shared actor-row vocabulary (subagent_id round-trip, api_chat spelling); splitting the module would separate the contract from its historical pins.",
     "tests/test_safety_policy.py": None,
+    "tests/test_services_tool_v2.py": "race-free waits for observable service-log state (CI serial-lane flake fix, PR #482) pushed the suite past 1000 lines; the three affected tests keep their assertions and gain explicit waits",
     "tests/test_skill_review_runner.py": "Skill lifecycle/review terminal-state regression coverage stays one focused suite below the 1500-line band cap.",
     "tests/test_swe_pro_e1v2.py": None,
     "tests/test_telegram_miniapp_lifecycle.py": None,

--- a/web/tests/chat_plain_system_rows.test.js
+++ b/web/tests/chat_plain_system_rows.test.js
@@ -10,8 +10,12 @@ import { readFileSync } from 'node:fs';
 
 import { createChatInstance } from '../modules/chat.js';
 
-const chatSource = readFileSync(new URL('../modules/chat.js', import.meta.url), 'utf8');
-const styleSource = readFileSync(new URL('../style.css', import.meta.url), 'utf8');
+// Source pins below match across line breaks; normalize CRLF so a Windows
+// checkout (core.autocrlf) reads the same bytes the regexes were written for.
+const chatSource = readFileSync(new URL('../modules/chat.js', import.meta.url), 'utf8')
+    .replace(/\r\n?/g, '\n');
+const styleSource = readFileSync(new URL('../style.css', import.meta.url), 'utf8')
+    .replace(/\r\n?/g, '\n');
 
 // --- DOM harness (same stub family as chat_instance_dom.test.js) ---
 

--- a/web/tests/wire_contract.test.js
+++ b/web/tests/wire_contract.test.js
@@ -23,18 +23,24 @@ import { accountRows } from '../modules/harness_accounts.js';
 import { nextUpAccount } from '../modules/claudexor_status_store.js';
 import { indexProfilesByHarness } from '../modules/reviewer_slots.js';
 
+// Source pins below delimit across line breaks; normalize CRLF so a Windows
+// checkout (core.autocrlf) reads the same bytes the delimiters were written for.
 const repoFile = (rel) => readFileSync(
     fileURLToPath(new URL(`../../${rel}`, import.meta.url)), 'utf-8',
-);
+).replace(/\r\n?/g, '\n');
 const moduleFile = (rel) => readFileSync(
     fileURLToPath(new URL(`../modules/${rel}`, import.meta.url)), 'utf-8',
-);
+).replace(/\r\n?/g, '\n');
 
 /** Names inside a Python tuple literal assigned to `name = (...)`. */
 function pythonTupleNames(source, name) {
     const start = source.indexOf(`${name} = (`);
     assert.notEqual(start, -1, `${name} not found — the wire contract moved, update this test`);
-    const body = source.slice(start, source.indexOf('\n)\n', start));
+    const end = source.indexOf('\n)\n', start);
+    // A missing closer must fail loudly: a slice to EOF over-fills the name set
+    // and lets the subset assertions below pass vacuously.
+    assert.notEqual(end, -1, `${name} tuple closer not found — update this test`);
+    const body = source.slice(start, end);
     return new Set([...body.matchAll(/"([a-z_]+)"/g)].map((m) => m[1]));
 }
 


### PR DESCRIPTION
Three CI-only reds on the current `ouroboros` tip, root-caused and fixed without touching product code or weakening any assertion:

1. **Windows full-test, node lane** — `web/tests/chat_plain_system_rows.test.js` pins `chat.js`/`style.css` text with regexes spanning line breaks; a `core.autocrlf` checkout delivers CRLF, so the pins fail on the Windows leg only. Normalized with the same idiom the other source-pinning web tests use.
2. **Same class, silent instance** (found in review): `web/tests/wire_contract.test.js` delimited a Python tuple with an LF-only `'\n)\n'`; on CRLF `indexOf` returned -1, the slice ran to EOF and the subset assertions passed vacuously on Windows — a silently weakened wire contract. Normalized, and the closer is now asserted so a missing delimiter fails loudly.
3. **size-ratchet lane (quick-test + full-test)** — PR #482 grew `tests/test_services_tool_v2.py` to 1007 lines without the 1001-1500 band entry. Adds the `BAND_PATHS` rationale; nothing else in the manifest moves.

Verification: full `node --test` web suite green; size-ratchet lane green with explicit base = tip (the local degraded parent-base mode is red only because the parent tree itself carries the manifest defect this PR fixes); ruff F clean. Reviewed by two autonomous read-only agent lanes (gpt-5.6-sol, claude-fable-5); their one finding (item 2) is included.
