### PR TITLE
loop: don't latch a terminal delivery candidate while the task's own edits are uncommitted

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1818,6 +1818,14 @@ Before every commit, verify the following:
   because it would contradict the required disposition tool call. Before the
   first reminder places the hold, no disposition instruction exists yet, so
   the ordinary evidence-change arm still applies there.
+- A host-bound (non-subagent) task must not turn a fresh prose turn into the
+  terminal delivery candidate while the tracked files its own coding-tool
+  effects touched are still uncommitted. Up to `_MAX_UNCOMMITTED_DELIVERY_NUDGES`
+  (4) bounded `[UNCOMMITTED_WORK]` reminders are allowed (call `commit_reviewed`,
+  or discard with `vcs_restore`); after that, finalization proceeds unchanged
+  and the run finalizes `work_uncommitted` → `STATUS_FAILED`. Read-only probe
+  (`git status --porcelain`), fail-open, and the attributed-path intersection
+  keeps a concurrent task's dirt on the shared tree from counting.
 
 #### Page Header Layout
 - Top-level page chrome (`renderPageHeader`, tab strips, primary actions) must sit outside the scrolling content region.

--- a/ouroboros/agent_task_pipeline.py
+++ b/ouroboros/agent_task_pipeline.py
@@ -13,16 +13,14 @@ from typing import Any, Callable, Dict, List
 
 from ouroboros.cost_projection import cost_projection
 from ouroboros.task_results import (
-    STATUS_COMPLETED,
-    STATUS_FAILED,
+    STATUS_COMPLETED,  # noqa: F401 — re-exported for tests / callers
+    STATUS_FAILED,  # noqa: F401 — re-exported for tests / callers
     load_task_result,
     write_task_result,
 )
 from ouroboros.artifacts import collect_task_artifact_records, merge_artifact_records
 from ouroboros.outcomes import (
     EXECUTION_BEST_EFFORT,
-    EXECUTION_FAILED,
-    EXECUTION_INFRA_FAILED,
     EXECUTION_OK,
     apply_receipt_absent_flag,
     artifact_bundle_from_result,
@@ -55,6 +53,7 @@ from ouroboros.task_finalization import (
     sealed_final_prompt_section, terminal_result_fields,
 )
 from ouroboros.dialogue_provenance import is_presence_task, presence_provenance_fields
+from ouroboros.work_uncommitted import downgrade_outcome_for_uncommitted_work, work_uncommitted_task_eval_ok, work_uncommitted_terminal_status
 from ouroboros.presence_runner import build_presence_result_event
 
 log = logging.getLogger(__name__)
@@ -601,6 +600,7 @@ def _derive_host_bound_loop_outcome(
     """Derive once from the current durable mutation-evidence binding."""
     _attach_host_mutation_projection(env, task, llm_trace)
     loop_outcome = apply_skill_publish_receipt_veto(derive_loop_outcome(text or "", usage, llm_trace), task, llm_trace)
+    loop_outcome = downgrade_outcome_for_uncommitted_work(loop_outcome, env, task, llm_trace)
     return _apply_terminal_custody_outcome(env, task, loop_outcome)
 
 
@@ -707,7 +707,7 @@ def emit_task_results(
     if not _ephemeral:
         try:
             append_jsonl(drive_logs / "events.jsonl", {
-                "ts": utc_now_iso(), "type": "task_eval", "ok": execution_status not in {EXECUTION_FAILED, EXECUTION_INFRA_FAILED},
+                "ts": utc_now_iso(), "type": "task_eval", "ok": work_uncommitted_task_eval_ok(execution_status, reason_code, task),
                 "task_id": task.get("id"), "task_type": task.get("type"),
                 "outcome_axes": outcome_axes,
                 "reason_code": reason_code,
@@ -1019,11 +1019,8 @@ def _store_task_result(env: Any, task: Dict[str, Any], text: str,
             )
         execution_status = str((outcome_axes.get("execution") or {}).get("status") or "")
         reason_code = str(loop_outcome.get("reason_code") or "")
-        status = (
-            STATUS_FAILED
-            if str(existing.get("status") or "") == STATUS_FAILED
-            or execution_status in {EXECUTION_FAILED, EXECUTION_INFRA_FAILED}
-            else STATUS_COMPLETED
+        status = work_uncommitted_terminal_status(
+            str(existing.get("status") or ""), execution_status, reason_code, task,
         )
         task_contract = build_task_contract(task)
         task = {**task, "task_contract": task_contract}

--- a/ouroboros/loop.py
+++ b/ouroboros/loop.py
@@ -38,6 +38,7 @@ from ouroboros.acceptance_dialogue import (  # noqa: F401 — re-export
 from ouroboros.config import adaptive_quorum, get_context_mode, get_light_model, get_review_enforcement, get_task_review_mode, resolve_effort
 from ouroboros.outcomes import ACCEPTANCE_BYPASS_REASON_BY_RAIL, ACCEPTANCE_DECISION_STATUSES, ACCEPTANCE_FINALIZED_UNACCEPTED, ACCEPTANCE_REVISION_REQUESTED, REASON_DELIVERY_CONTROL_DEGRADED, REASON_OWNER_REQUESTED_FINALIZATION, RESULT_INFRA_FAILED, extract_final_answer, latest_agent_defined_verification, latest_unreconciled_failed_verification, latest_unreconciled_masked_verification, reviewable_effect_projection, should_nudge_verification, turn_has_reviewable_effects
 from ouroboros.observability import new_execution_id
+from ouroboros.work_uncommitted import withhold_prose_for_uncommitted_work
 # Protocol leaf keeps historical names importable at this module's size ceiling.
 from ouroboros.delivery_protocol import (
     CHILD_ABSORPTION_HOLD_CONTROL as _CHILD_ABSORPTION_HOLD_CONTROL,
@@ -3983,6 +3984,10 @@ def _no_tool_final_answer(
     content = controlled_content
     _project_child_result_dispositions(limit_ctx, llm_trace)
     if control_state == "fresh" and str(content or "").strip():
+        if withhold_prose_for_uncommitted_work(
+            tools, messages, llm_trace, str(content), emit_progress,
+        ):
+            return None
         candidate = _replace_delivery_candidate(
             tools, limit_ctx, llm_trace, str(content), control="candidate",
         )

--- a/ouroboros/work_uncommitted.py
+++ b/ouroboros/work_uncommitted.py
@@ -1,0 +1,303 @@
+"""Terminal-failure detection for a host-bound task that finalized cleanly but
+left the tracked files it was sent to change modified/staged with no commit.
+
+A leaf module (no import of ``outcomes`` or ``agent_task_pipeline``): the probe,
+the per-task attribution scope, the outcome post-processor, and the two
+lifecycle decisions all live here so the two size-gated call-site modules gain
+only imports and one-line calls.
+
+Contract: the probe is READ-ONLY (`git status --porcelain`), bounded, and fails
+OPEN — any ambiguity (attribution blocked, no task-owned candidates, git error)
+skips it entirely rather than widening it into a false-positive gate.
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+from typing import Any, Dict, Iterable, List, Optional
+
+log = logging.getLogger(__name__)
+
+# A task that ran (no provider failure, no tool errors, no delivery-control
+# degradation) but TERMINATED with staged/modified tracked files left
+# uncommitted. Distinct from a clean no-op: the agent DID change tracked files;
+# it just did not commit. Surfaced through outcome_axes.execution.reason_code.
+REASON_WORK_UNCOMMITTED = "work_uncommitted"
+
+
+def detect_work_uncommitted(
+    repo_dir: Any,
+    *,
+    max_files: int = 50,
+    timeout_sec: float = 5.0,
+) -> List[str]:
+    """Return porcelain lines for tracked-file changes left uncommitted in ``repo_dir``.
+
+    The shape is the same as ``git status --porcelain`` (e.g. ``" M ouroboros/x.py"``,
+    ``"M  ouroboros/y.py"``). Untracked-file entries (``??``) are NOT included — they
+    are a different surface, not "work the agent should have committed". The returned
+    list is bounded to ``max_files``. Returns an empty list when the working tree is
+    clean OR when the repository is unreadable / not a git repo.
+
+    READ-ONLY by construction — ``git status --porcelain`` never mutates state.
+    ``repo_dir`` may be a string or ``pathlib.Path``. The timeout is short: the
+    check is in the task-finalization hot path and a stuck git invocation here must
+    never delay finalization beyond the loop's own budget.
+    """
+    if not repo_dir:
+        return []
+    try:
+        repo_path = pathlib.Path(str(repo_dir))
+    except (TypeError, ValueError):
+        return []
+    if not repo_path.exists() or not repo_path.is_dir():
+        return []
+    try:
+        import subprocess  # local import: keep the module import-time cheap
+
+        completed = subprocess.run(
+            ["git", "status", "--porcelain", "--untracked-files=no"],
+            cwd=str(repo_path),
+            capture_output=True,
+            text=True,
+            timeout=timeout_sec,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return []
+    if completed.returncode != 0:
+        return []
+    lines: List[str] = []
+    for raw_line in (completed.stdout or "").splitlines():
+        line = raw_line.rstrip("\r")
+        if not line or len(line) < 3:
+            continue
+        if line.startswith("?? "):
+            continue  # untracked: explicitly excluded (see docstring)
+        lines.append(line)
+        if len(lines) >= max_files:
+            break
+    return lines
+
+
+def _failure_block_for_work_uncommitted(files: List[str]) -> Dict[str, Any]:
+    """The ``failure`` block for a ``work_uncommitted`` reason. Centralised so the
+    reason-chain and any future consumer share one shape. ``files`` is the output
+    of ``detect_work_uncommitted`` (bounded at the source)."""
+    return {
+        "kind": "work_uncommitted",
+        "reason_code": REASON_WORK_UNCOMMITTED,
+        "files": list(files or []),
+    }
+
+
+def _porcelain_relpath(line: str) -> str:
+    """Extract the repo-relative path from one ``git status --porcelain`` line.
+
+    Plain porcelain (without ``-z``) uses ``" -> "`` for renames / copies, so a
+    rename row reads ``"R  oldname -> newname"``; the post-target half is the
+    path the task owns. For every other row the path occupies columns 3 onward
+    (``"XY path"``). Untracked rows are filtered upstream so this never sees them.
+    Returns ``""`` for malformed input — the caller treats that as a no-match.
+    """
+    text = str(line or "").rstrip("\r")
+    if len(text) < 4:
+        return ""
+    body = text[3:].strip()
+    if not body:
+        return ""
+    if " -> " in body:
+        return body.split(" -> ", 1)[1].strip()
+    return body
+
+
+def filter_work_uncommitted_to_attributed(
+    files: List[str],
+    attributed_paths: Optional[Iterable[str]],
+) -> List[str]:
+    """Narrow a ``detect_work_uncommitted`` result to the per-task attributed set.
+
+    ``attributed_paths=None`` preserves the raw observation. When the caller passes
+    an iterable, only lines whose repo-relative path appears in it survive — the
+    "only flag files this task's own mutation evidence attributes to it" contract.
+    Empty input + iterable yields an empty list, not a baseline-missing error.
+    """
+    if attributed_paths is None:
+        return list(files or [])
+    allowed = {
+        str(item).strip()
+        for item in attributed_paths
+        if str(item or "").strip()
+    }
+    if not allowed:
+        return []
+    return [
+        line for line in (files or [])
+        if _porcelain_relpath(line) in allowed
+    ]
+
+
+def resolve_work_uncommitted_scope(
+    env: Any,
+    task: Dict[str, Any],
+    llm_trace: Dict[str, Any],
+) -> tuple[Any, Any]:
+    """Resolve the probe's working tree and attributed-path filter.
+
+    - **Isolated worktree** — ``task.repo_dir`` distinct from ``env.repo_dir``:
+      concurrent dirt cannot reach it, so the raw probe is safe and the filter
+      is ``None``.
+    - **Shared tree** — host-bound tasks share ``env.repo_dir``: a naive
+      ``git status`` would attribute a concurrent task's dirt to whichever task
+      finalized first, so the per-task attribution (``attributed_git_candidates``)
+      is loaded and its candidate set becomes the filter.
+
+    Returns ``(None, None)`` when the probe must be skipped (attribution blocked,
+    no task-owned candidates, no shared-tree root). Skipping is the honest
+    response when attribution cannot establish a clean task-owned set — an
+    attribution gap must never widen the probe into a false-positive gate.
+    """
+    from ouroboros.mutation_attribution import attributed_git_candidates
+
+    shared_repo_dir = getattr(env, "repo_dir", None)
+    if shared_repo_dir is None:
+        return None, None
+
+    task_repo_dir_raw = task.get("repo_dir")
+    task_repo_dir: Optional[pathlib.Path]
+    if task_repo_dir_raw:
+        task_repo_dir = pathlib.Path(task_repo_dir_raw)
+    else:
+        task_repo_dir = None
+    try:
+        shared_root = pathlib.Path(shared_repo_dir).expanduser().resolve(strict=False)
+        task_root = (
+            task_repo_dir.expanduser().resolve(strict=False)
+            if task_repo_dir is not None
+            else None
+        )
+    except (OSError, ValueError, TypeError):
+        return None, None
+    if task_root is not None and task_root != shared_root:
+        return task_root, None
+
+    drive_root = (
+        task.get("budget_drive_root")
+        or getattr(env, "drive_root", None)
+    )
+    if drive_root is None:
+        return None, None
+    root_task_id = str(
+        task.get("root_task_id") or task.get("id") or ""
+    ).strip()
+    if not root_task_id:
+        return None, None
+    try:
+        attribution = attributed_git_candidates(
+            pathlib.Path(drive_root), root_task_id, shared_root,
+        )
+    except Exception:
+        log.debug(
+            "work-uncommitted attribution lookup failed for %s", root_task_id,
+            exc_info=True,
+        )
+        return None, None
+    blockers = [str(b) for b in (attribution.get("blockers") or []) if str(b or "").strip()]
+    if blockers:
+        return None, None
+    candidates = [
+        str(p).strip() for p in (attribution.get("candidates") or [])
+        if str(p or "").strip()
+    ]
+    if not candidates:
+        return None, None
+    return shared_root, candidates
+
+
+def _is_subagent(task: Dict[str, Any]) -> bool:
+    return str((task or {}).get("delegation_role") or "").lower() == "subagent"
+
+
+def downgrade_outcome_for_uncommitted_work(
+    loop_outcome: Dict[str, Any],
+    env: Any,
+    task: Dict[str, Any],
+    llm_trace: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Post-process a derived loop outcome: an otherwise-``EXECUTION_OK`` run that
+    left its OWN mutation-attributed tracked files uncommitted is downgraded to
+    ``EXECUTION_DEGRADED`` / ``REASON_WORK_UNCOMMITTED`` with a typed failure
+    block. Mutates and returns ``loop_outcome`` in place; a no-op for any
+    non-clean run, when the scope resolver skips, or when the attributed set is
+    clean. The probe runs after outcome derivation (not inside it) so the size-
+    and function-gated ``derive_loop_outcome`` stays byte-identical.
+    """
+    from ouroboros.outcomes import EXECUTION_DEGRADED, EXECUTION_OK
+
+    axes = loop_outcome.get("outcome_axes") if isinstance(loop_outcome, dict) else None
+    execution = axes.get("execution") if isinstance(axes, dict) else None
+    if not isinstance(execution, dict):
+        return loop_outcome
+    if str(execution.get("status") or "") != EXECUTION_OK:
+        return loop_outcome
+
+    repo_dir, attributed_paths = resolve_work_uncommitted_scope(env, task, llm_trace)
+    if repo_dir is None:
+        return loop_outcome
+    dirty = detect_work_uncommitted(repo_dir)
+    if attributed_paths is not None:
+        dirty = filter_work_uncommitted_to_attributed(dirty, attributed_paths)
+    if not dirty:
+        return loop_outcome
+
+    failure = _failure_block_for_work_uncommitted(dirty)
+    execution["status"] = EXECUTION_DEGRADED
+    execution["reason_code"] = REASON_WORK_UNCOMMITTED
+    execution["failure"] = failure
+    loop_outcome["reason_code"] = REASON_WORK_UNCOMMITTED
+    loop_outcome["finish_reason"] = REASON_WORK_UNCOMMITTED
+    loop_outcome["failure"] = failure
+    return loop_outcome
+
+
+def work_uncommitted_task_eval_ok(
+    execution_status: str, reason_code: str, task: Dict[str, Any],
+) -> bool:
+    """``task_eval.ok`` including the work-uncommitted adjustment: a host-bound
+    (non-subagent) run that finalized ``work_uncommitted`` is NOT ok, so
+    reflection does not learn a false success. A subagent's status stays
+    ``completed`` so its ``ok`` must not disagree — it keeps the ordinary rule.
+    """
+    from ouroboros.outcomes import EXECUTION_FAILED, EXECUTION_INFRA_FAILED
+
+    if execution_status in {EXECUTION_FAILED, EXECUTION_INFRA_FAILED}:
+        return False
+    if reason_code == REASON_WORK_UNCOMMITTED and not _is_subagent(task):
+        return False
+    return True
+
+
+def work_uncommitted_terminal_status(
+    existing_status: str, execution_status: str, reason_code: str,
+    task: Dict[str, Any],
+) -> str:
+    """The lifecycle status for a stored task result, including the
+    work-uncommitted promotion. A host-bound (non-subagent) task that finalized
+    ``REASON_WORK_UNCOMMITTED`` has NOT delivered — the uncommitted diff IS the
+    failure — so it is promoted to ``STATUS_FAILED`` alongside the existing
+    failed / infra-failed cases. A subagent stays ``STATUS_COMPLETED`` (the
+    typed reason is still recorded on the axes)."""
+    from ouroboros.outcomes import EXECUTION_FAILED, EXECUTION_INFRA_FAILED
+    from ouroboros.task_results import STATUS_COMPLETED, STATUS_FAILED
+
+    work_uncommitted_failure = (
+        reason_code == REASON_WORK_UNCOMMITTED and not _is_subagent(task)
+    )
+    if (
+        str(existing_status or "") == STATUS_FAILED
+        or execution_status in {EXECUTION_FAILED, EXECUTION_INFRA_FAILED}
+        or work_uncommitted_failure
+    ):
+        return STATUS_FAILED
+    return STATUS_COMPLETED

--- a/ouroboros/work_uncommitted.py
+++ b/ouroboros/work_uncommitted.py
@@ -301,3 +301,153 @@ def work_uncommitted_terminal_status(
     ):
         return STATUS_FAILED
     return STATUS_COMPLETED
+
+
+# --- Fresh-prose delivery guard (relates to upstream #449) --------------------
+# A host-bound task that produced tracked-file edits and then wrote a prose
+# summary gets that prose turned into a terminal delivery candidate; from then
+# on every further edit re-arms effect_revision_required and the JSON-only
+# delivery-control prompt makes commit_reviewed unreachable until the acceptance
+# capsule is spent. Before a FRESH prose turn becomes a candidate, if the task
+# still has its own uncommitted tracked edits, re-loop with a reminder to land
+# or discard them instead. Bounded so a task that genuinely cannot commit still
+# finalizes (as work_uncommitted, unchanged) once the nudges are spent.
+MAX_UNCOMMITTED_DELIVERY_NUDGES = 4
+
+
+def _effect_write_paths(args: Dict[str, Any]) -> List[str]:
+    """Every repo-relative write target named in one coding-tool call's args.
+
+    Covers all four root write tools: ``edit_text`` / single ``write_file``
+    (``args['path']``), multi-file ``write_file`` (``args['files'][*]['path']``),
+    ``edit_batch`` (``args['edits'][*]['path']``), and ``apply_patch`` (the
+    ``*** Update/Add/Delete File:`` headers inside ``args['patch']``). Also
+    accepts a bare ``args['paths']`` list. Raw path strings; the caller
+    normalizes them against the repo root.
+    """
+    out: List[str] = []
+    if args.get("path"):
+        out.append(str(args["path"]))
+    if isinstance(args.get("paths"), list):
+        out.extend(str(p) for p in args["paths"] if p)
+    for key in ("files", "edits"):
+        rows = args.get(key)
+        if isinstance(rows, list):
+            out.extend(
+                str(row["path"]) for row in rows
+                if isinstance(row, dict) and row.get("path")
+            )
+    patch = args.get("patch")
+    if isinstance(patch, str) and patch:
+        for line in patch.splitlines():
+            for hdr in ("*** Update File:", "*** Add File:", "*** Delete File:"):
+                if line.startswith(hdr):
+                    out.append(line[len(hdr):].strip())
+                    break
+    return [p for p in out if p]
+
+
+def _uncommitted_attributed_paths(tools: Any, llm_trace: Dict[str, Any]) -> List[str]:
+    """Repo-tracked files this task edited that are still uncommitted.
+
+    ``detect_work_uncommitted`` + ``filter_work_uncommitted_to_attributed``
+    intersected with the paths this task's own coding-tool effects touched, so a
+    concurrent task's dirty state on the shared tree does not count. Read-only,
+    fail-open (``[]`` on any probe error or a missing/absolute repo). Host-bound
+    (non-subagent) tasks only — a subagent's worktree is absorbed by its parent.
+    """
+    ctx = getattr(tools, "_ctx", None)
+    if ctx is None:
+        return []
+    try:
+        if tools._ctx_is_delegated_subagent():
+            return []
+    except Exception:
+        return []
+    repo_dir = getattr(ctx, "repo_dir", None)
+    if not repo_dir:
+        return []
+    try:
+        from ouroboros.outcomes import reviewable_effect_projection
+
+        dirty = detect_work_uncommitted(repo_dir)
+        if not dirty:
+            return []
+        repo_path = pathlib.Path(str(repo_dir))
+        attributed: set[str] = set()
+        for effect in reviewable_effect_projection(llm_trace) or []:
+            args = effect.get("args") if isinstance(effect.get("args"), dict) else {}
+            for raw in _effect_write_paths(args):
+                text = str(raw or "").strip()
+                if not text:
+                    continue
+                p = pathlib.Path(text)
+                if p.is_absolute():
+                    try:
+                        text = str(p.relative_to(repo_path))
+                    except ValueError:
+                        continue
+                attributed.add(text.lstrip("./"))
+        if not attributed:
+            return []
+        hits = filter_work_uncommitted_to_attributed(dirty, attributed)
+        return [_porcelain_relpath(line) or line for line in hits]
+    except Exception:
+        log.debug("uncommitted-attributed probe failed (non-fatal)", exc_info=True)
+        return []
+
+
+def _uncommitted_delivery_reminder(paths: List[str]) -> str:
+    listed = "\n".join(f"  - {p}" for p in paths[:20])
+    more = f"\n  … and {len(paths) - 20} more" if len(paths) > 20 else ""
+    return (
+        "[UNCOMMITTED_WORK]\n"
+        "You produced a prose answer, but these tracked files were changed by "
+        "this task and are NOT committed:\n"
+        f"{listed}{more}\n"
+        "A summary is not a delivery. Do ONE of:\n"
+        "  1. Call commit_reviewed(commit_message='…') now to land the changes. "
+        "Advisory review runs inline on the commit_reviewed call — you do NOT "
+        "need to run preflight_review first.\n"
+        "  2. If the changes are wrong or abandoned, discard them with "
+        "vcs_restore(paths=[…]) before finalizing.\n"
+        "Leaving tracked changes uncommitted will finalize the task as FAILED."
+    )
+
+
+def withhold_prose_for_uncommitted_work(
+    tools: Any,
+    messages: List[Dict[str, Any]],
+    llm_trace: Dict[str, Any],
+    content: str,
+    emit_progress: Any,
+) -> bool:
+    """Keep a FRESH prose turn from latching a terminal delivery candidate while
+    the task's own tracked edits are still uncommitted.
+
+    Returns ``True`` (caller re-loops so ``commit_reviewed`` stays reachable)
+    when the task has uncommitted mutation-attributed changes and the per-task
+    nudge budget is not spent; ``False`` to let finalization proceed unchanged.
+    """
+    from ouroboros.loop import _append_or_merge_user_message
+
+    uncommitted = _uncommitted_attributed_paths(tools, llm_trace)
+    if not uncommitted:
+        return False
+    nudges = int(getattr(tools._ctx, "_uncommitted_delivery_nudges", 0) or 0)
+    if nudges >= MAX_UNCOMMITTED_DELIVERY_NUDGES:
+        return False
+    tools._ctx._uncommitted_delivery_nudges = nudges + 1
+    if content.strip():
+        messages.append({"role": "assistant", "content": content})
+    _append_or_merge_user_message(messages, _uncommitted_delivery_reminder(uncommitted))
+    llm_trace["reasoning_notes"].append(
+        "Prose finalization withheld: task has uncommitted tracked changes; "
+        "commit_reviewed or explicit revert required "
+        f"(nudge {nudges + 1}/{MAX_UNCOMMITTED_DELIVERY_NUDGES})."
+    )
+    emit_progress(
+        f"Uncommitted tracked changes ({len(uncommitted)} file(s)) — call "
+        "commit_reviewed to land them or revert before finalizing."
+    )
+    return True

--- a/tests/test_agent_task_pipeline.py
+++ b/tests/test_agent_task_pipeline.py
@@ -1660,3 +1660,97 @@ def test_emit_task_results_surfaces_receipt_absent_flag_in_event_stream(tmp_path
 
     # single source: the SAME flagged loop_outcome is threaded to _store_task_result (not re-derived)
     assert captured["loop_outcome"]["outcome_axes"]["objective"].get("warning") == "receipt_absent"
+
+
+def _work_uncommitted_loop_outcome(tmp_path):
+    """A ``derive_loop_outcome`` result put through the work-uncommitted
+    post-processor against a repo with an uncommitted tracked change — the
+    isolated-worktree regime (task tree != env tree), so the raw probe fires."""
+    import subprocess
+
+    from ouroboros.outcomes import derive_loop_outcome
+    from ouroboros.work_uncommitted import REASON_WORK_UNCOMMITTED
+    from ouroboros.work_uncommitted import downgrade_outcome_for_uncommitted_work
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for args in (("init", "-q"), ("config", "user.email", "t@t"), ("config", "user.name", "t")):
+        subprocess.run(["git", *args], cwd=str(repo), check=True, capture_output=True)
+    (repo / "a.py").write_text("x = 1\n")
+    subprocess.run(["git", "add", "."], cwd=str(repo), check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "base"], cwd=str(repo), check=True, capture_output=True)
+    (repo / "a.py").write_text("x = 2  # changed, never committed\n")
+
+    loop_outcome = derive_loop_outcome(
+        "I implemented the change to a.py; the tests pass.",
+        {"rounds": 3, "cost": 0.0},
+        {"tool_calls": [], "reasoning_notes": []},
+    )
+    loop_outcome = downgrade_outcome_for_uncommitted_work(
+        loop_outcome,
+        SimpleNamespace(repo_dir=str(tmp_path / "host_tree"), drive_root=tmp_path),
+        {"id": "task-a", "repo_dir": str(repo)},
+        {},
+    )
+    assert loop_outcome["reason_code"] == REASON_WORK_UNCOMMITTED
+    return loop_outcome
+
+
+def test_store_task_result_fails_host_bound_task_with_uncommitted_diff(tmp_path):
+    """ibl-local-27745117e0e1 enforcement: a host-bound task that left its own
+    tracked changes uncommitted finalizes STATUS_FAILED, not STATUS_COMPLETED —
+    the uncommitted diff IS the failure. The axes still carry the typed reason
+    and the file list."""
+    from ouroboros.task_results import STATUS_FAILED
+
+    env = SimpleNamespace(drive_root=tmp_path)
+    loop_outcome = _work_uncommitted_loop_outcome(tmp_path)
+
+    pipeline._store_task_result(
+        env=env,
+        task={"id": "task-uncommitted", "type": "task", "text": "implement it"},
+        text="I implemented the change to a.py; the tests pass.",
+        usage={"rounds": 3, "cost": 0.0},
+        llm_trace={"tool_calls": [], "reasoning_notes": []},
+        review_evidence={},
+        loop_outcome=loop_outcome,
+    )
+
+    payload = json.loads((tmp_path / "task_results" / "task-uncommitted.json").read_text(encoding="utf-8"))
+    assert payload["status"] == STATUS_FAILED
+    assert payload["reason_code"] == "work_uncommitted"
+    assert payload["outcome_axes"]["execution"]["status"] == "degraded"
+    assert any(
+        "a.py" in line
+        for line in payload["loop_outcome"]["failure"].get("files", [])
+    )
+
+
+def test_store_task_result_does_not_fail_subagent_with_uncommitted_diff(tmp_path):
+    """A subagent's uncommitted worktree is the parent's concern, not a task
+    failure — the enforcement is scoped to host-bound (non-subagent) tasks."""
+    from ouroboros.task_results import STATUS_COMPLETED
+
+    env = SimpleNamespace(drive_root=tmp_path)
+    loop_outcome = _work_uncommitted_loop_outcome(tmp_path)
+
+    pipeline._store_task_result(
+        env=env,
+        task={
+            "id": "task-sub-uncommitted", "type": "task", "text": "implement it",
+            "delegation_role": "subagent",
+        },
+        text="Implemented; parent will absorb the patch.",
+        usage={"rounds": 3, "cost": 0.0},
+        llm_trace={"tool_calls": [], "reasoning_notes": []},
+        review_evidence={},
+        loop_outcome=loop_outcome,
+    )
+
+    payload = json.loads(
+        (tmp_path / "task_results" / "task-sub-uncommitted.json").read_text(encoding="utf-8")
+    )
+    assert payload["status"] == STATUS_COMPLETED
+    # The typed reason is still recorded — observation preserved, verdict withheld.
+    assert payload["reason_code"] == "work_uncommitted"
+

--- a/tests/test_uncommitted_delivery_guard.py
+++ b/tests/test_uncommitted_delivery_guard.py
@@ -1,0 +1,141 @@
+"""ibl-d29bc3cc9d67: a FRESH prose turn must not latch a terminal delivery
+candidate while the task's own tracked edits are still uncommitted — the loop
+re-loops with a reminder so commit_reviewed stays reachable, bounded by a
+per-task nudge budget."""
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+import ouroboros.work_uncommitted as wu
+
+# _repo_with_committed_file spawns real `git` subprocesses (CONTRIBUTING §4).
+pytestmark = pytest.mark.serial
+
+
+def _git(repo, *args):
+    subprocess.run(["git", *args], cwd=str(repo), capture_output=True, check=True)
+
+
+def _repo_with_committed_file(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "mod.py").write_text("x = 1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    return repo
+
+
+def _fake_tools(repo, *, is_subagent=False):
+    ctx = SimpleNamespace(
+        repo_dir=str(repo),
+        _uncommitted_delivery_nudges=0,
+    )
+    return SimpleNamespace(
+        _ctx=ctx,
+        _ctx_is_delegated_subagent=lambda: is_subagent,
+    )
+
+
+def _trace_edit(path):
+    return {"tool_calls": [{"tool": "edit_text", "status": "ok", "args": {"path": path}}]}
+
+
+def test_attributed_probe_flags_own_uncommitted_edit(tmp_path):
+    repo = _repo_with_committed_file(tmp_path)
+    (repo / "mod.py").write_text("x = 2\n")  # uncommitted edit
+    hits = wu._uncommitted_attributed_paths(_fake_tools(repo), _trace_edit("mod.py"))
+    assert hits == ["mod.py"]
+
+
+def test_attributed_probe_ignores_unattributed_dirty_file(tmp_path):
+    repo = _repo_with_committed_file(tmp_path)
+    (repo / "mod.py").write_text("x = 2\n")  # dirty, but NOT in this trace
+    hits = wu._uncommitted_attributed_paths(
+        _fake_tools(repo), _trace_edit("other_file.py")
+    )
+    assert hits == []
+
+
+def test_attributed_probe_clean_tree_returns_empty(tmp_path):
+    repo = _repo_with_committed_file(tmp_path)
+    hits = wu._uncommitted_attributed_paths(_fake_tools(repo), _trace_edit("mod.py"))
+    assert hits == []
+
+
+def test_attributed_probe_skips_subagents(tmp_path):
+    repo = _repo_with_committed_file(tmp_path)
+    (repo / "mod.py").write_text("x = 2\n")
+    hits = wu._uncommitted_attributed_paths(
+        _fake_tools(repo, is_subagent=True), _trace_edit("mod.py")
+    )
+    assert hits == []
+
+
+def test_withhold_reloops_then_relents_after_budget(tmp_path):
+    repo = _repo_with_committed_file(tmp_path)
+    (repo / "mod.py").write_text("x = 2\n")
+    tools = _fake_tools(repo)
+    trace = {"reasoning_notes": [], **_trace_edit("mod.py")}
+    progress: list[str] = []
+
+    # First _MAX_UNCOMMITTED_DELIVERY_NUDGES calls withhold (re-loop).
+    for i in range(wu.MAX_UNCOMMITTED_DELIVERY_NUDGES):
+        msgs: list = []
+        assert wu.withhold_prose_for_uncommitted_work(
+            tools, msgs, trace, "done, changes on disk", progress.append
+        ) is True
+        assert any("UNCOMMITTED_WORK" in str(m.get("content", "")) for m in msgs)
+        assert tools._ctx._uncommitted_delivery_nudges == i + 1
+
+    # Budget spent → let finalization proceed unchanged.
+    msgs = []
+    assert wu.withhold_prose_for_uncommitted_work(
+        tools, msgs, trace, "done", progress.append
+    ) is False
+    assert msgs == []
+
+
+def test_withhold_noop_when_tree_clean(tmp_path):
+    repo = _repo_with_committed_file(tmp_path)
+    tools = _fake_tools(repo)
+    trace = {"reasoning_notes": [], **_trace_edit("mod.py")}
+    assert wu.withhold_prose_for_uncommitted_work(
+        tools, [], trace, "analysis complete", lambda _s: None
+    ) is False
+    assert tools._ctx._uncommitted_delivery_nudges == 0
+
+
+def test_reminder_names_the_files_and_both_exits(tmp_path):
+    text = wu._uncommitted_delivery_reminder(["ouroboros/a.py", "tests/b.py"])
+    assert "ouroboros/a.py" in text and "tests/b.py" in text
+    assert "commit_reviewed" in text
+    assert "vcs_restore" in text
+
+
+def test_attributed_probe_covers_edit_batch_and_apply_patch(tmp_path):
+    """The multi-file coding tools carry paths under different arg keys —
+    edit_batch: args['edits'][*]['path']; apply_patch: `*** Update File:`
+    headers in args['patch']; multi-file write_file: args['files'][*]['path']."""
+    repo = _repo_with_committed_file(tmp_path)
+    (repo / "mod.py").write_text("x = 2\n")
+    (repo / "two.py").write_text("y = 1\n")
+    (repo / "three.py").write_text("z = 1\n")
+    _git(repo, "add", "two.py", "three.py")
+    _git(repo, "commit", "-qm", "more")
+    (repo / "two.py").write_text("y = 2\n")
+    (repo / "three.py").write_text("z = 2\n")
+
+    trace = {"tool_calls": [
+        {"tool": "edit_batch", "status": "ok",
+         "args": {"edits": [{"path": "mod.py"}, {"path": "two.py"}]}},
+        {"tool": "apply_patch", "status": "ok",
+         "args": {"patch": "*** Begin Patch\n*** Update File: three.py\n*** End Patch\n"}},
+    ]}
+    hits = sorted(wu._uncommitted_attributed_paths(_fake_tools(repo), trace))
+    assert hits == ["mod.py", "three.py", "two.py"]

--- a/tests/test_work_uncommitted_surface.py
+++ b/tests/test_work_uncommitted_surface.py
@@ -1,0 +1,414 @@
+"""Tests for the work_uncommitted observability surface (ibl-local-27745117e0e1).
+
+A task can finalize cleanly — no provider failure, no tool error — yet leave
+tracked files modified/staged without a commit. ``detect_work_uncommitted`` is
+the SSOT probe; ``downgrade_outcome_for_uncommitted_work`` and
+``_store_task_result`` act on it.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+
+import pytest
+
+from ouroboros.work_uncommitted import (
+    REASON_WORK_UNCOMMITTED,
+    _failure_block_for_work_uncommitted,
+    detect_work_uncommitted,
+)
+
+# The repo fixtures spawn real `git` subprocesses (CONTRIBUTING §4).
+pytestmark = pytest.mark.serial
+
+
+def _git(*args, cwd):
+    subprocess.run(["git", *args], cwd=str(cwd), check=True,
+                   capture_output=True, text=True)
+
+
+@pytest.fixture()
+def repo(tmp_path):
+    _git("init", "-q", cwd=tmp_path)
+    _git("config", "user.email", "t@t", cwd=tmp_path)
+    _git("config", "user.name", "t", cwd=tmp_path)
+    (tmp_path / "a.txt").write_text("one\n")
+    _git("add", "a.txt", cwd=tmp_path)
+    _git("commit", "-qm", "init", cwd=tmp_path)
+    return tmp_path
+
+
+def test_clean_tree_returns_empty(repo):
+    assert detect_work_uncommitted(repo) == []
+
+
+def test_modified_tracked_file_is_reported(repo):
+    (repo / "a.txt").write_text("two\n")
+    lines = detect_work_uncommitted(repo)
+    assert any(line.endswith("a.txt") and line.strip().startswith("M") for line in lines)
+
+
+def test_staged_tracked_file_is_reported(repo):
+    (repo / "a.txt").write_text("three\n")
+    _git("add", "a.txt", cwd=repo)
+    lines = detect_work_uncommitted(repo)
+    assert any("a.txt" in line for line in lines)
+
+
+def test_untracked_file_is_not_reported(repo):
+    (repo / "new.txt").write_text("brand new\n")
+    assert detect_work_uncommitted(repo) == []
+
+
+def test_non_repo_path_returns_empty(tmp_path):
+    assert detect_work_uncommitted(tmp_path / "does-not-exist") == []
+    assert detect_work_uncommitted("") == []
+
+
+def test_failure_block_shape(repo):
+    (repo / "a.txt").write_text("changed\n")
+    files = detect_work_uncommitted(repo)
+    block = _failure_block_for_work_uncommitted(files)
+    assert block["kind"] == "work_uncommitted"
+    assert block["reason_code"] == REASON_WORK_UNCOMMITTED
+    assert block["files"] == files
+
+
+def test_max_files_bound(repo):
+    for i in range(10):
+        (repo / f"f{i}.txt").write_text(f"v{i}\n")
+        _git("add", f"f{i}.txt", cwd=repo)
+    _git("commit", "-qm", "more", cwd=repo)
+    for i in range(10):
+        (repo / f"f{i}.txt").write_text(f"changed{i}\n")
+    lines = detect_work_uncommitted(repo, max_files=3)
+    assert len(lines) == 3
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Activation (ibl-local-27745117e0e1): scope detect_work_uncommitted through the
+# per-task mutation-attribution machinery so concurrent tasks' dirty state
+# cannot bleed into this task's verdict. Raw probe still fires in the isolated
+# worktree regime where the worktree itself isolates the task.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_porcelain_relpath_extracts_modified_path(repo):
+    from ouroboros.work_uncommitted import _porcelain_relpath
+    # Modified tracked file: "XY path" format starting at column 3.
+    assert _porcelain_relpath(" M ouroboros/utils.py") == "ouroboros/utils.py"
+    # Staged addition.
+    assert _porcelain_relpath("A  ouroboros/utils.py") == "ouroboros/utils.py"
+    # Staged modification.
+    assert _porcelain_relpath("M  ouroboros/utils.py") == "ouroboros/utils.py"
+    # Rename picks the post-target half (plain porcelain, no -z).
+    assert (
+        _porcelain_relpath("R  oldname -> newname") == "newname"
+    )
+    # Malformed input yields "" — the caller treats that as a no-match.
+    assert _porcelain_relpath("") == ""
+    assert _porcelain_relpath("XY") == ""
+
+
+def test_filter_work_uncommitted_to_attributed_passes_through_when_none(repo):
+    from ouroboros.work_uncommitted import filter_work_uncommitted_to_attributed
+    files = [" M ouroboros/utils.py", " M ouroboros/agent.py"]
+    # None preserves the raw observation — the isolated-worktree regime.
+    assert filter_work_uncommitted_to_attributed(files, None) == files
+
+
+def test_filter_work_uncommitted_to_attributed_narrows_to_attributed_set(repo):
+    from ouroboros.work_uncommitted import filter_work_uncommitted_to_attributed
+    files = [
+        " M ouroboros/utils.py",       # task A owns this
+        " M ouroboros/concurrent.py",  # task B left this dirty
+        " M ouroboros/agent.py",       # task A owns this
+    ]
+    attributed = ["ouroboros/utils.py", "ouroboros/agent.py"]
+    narrowed = filter_work_uncommitted_to_attributed(files, attributed)
+    paths = [line.split()[-1] for line in narrowed]
+    assert paths == ["ouroboros/utils.py", "ouroboros/agent.py"]
+
+
+def test_filter_work_uncommitted_to_attributed_empty_iterable_yields_empty(repo):
+    from ouroboros.work_uncommitted import filter_work_uncommitted_to_attributed
+    files = [" M ouroboros/utils.py", " M ouroboros/agent.py"]
+    # Empty attributed set: every observed dirty file is concurrent dirt;
+    # the activation must NOT degrade this task.
+    assert filter_work_uncommitted_to_attributed(files, []) == []
+
+
+def test_filter_work_uncommitted_to_attributed_rename_target(repo):
+    from ouroboros.work_uncommitted import filter_work_uncommitted_to_attributed
+    files = ["R  ouroboros/old.py -> ouroboros/new.py"]
+    # Attribution keyed on the post-target (the path the task actually owns).
+    assert filter_work_uncommitted_to_attributed(
+        files, ["ouroboros/new.py"],
+    ) == files
+    assert filter_work_uncommitted_to_attributed(
+        files, ["ouroboros/old.py"],
+    ) == []
+
+
+def _clean_ok_outcome():
+    """A minimal loop-outcome dict shaped like ``derive_loop_outcome``'s return,
+    with the execution axis at ``EXECUTION_OK`` so the downgrade post-processor
+    is eligible to act on it."""
+    from ouroboros.outcomes import EXECUTION_OK, REASON_FINAL_MESSAGE
+
+    return {
+        "reason_code": REASON_FINAL_MESSAGE,
+        "finish_reason": REASON_FINAL_MESSAGE,
+        "failure": None,
+        "outcome_axes": {
+            "execution": {"status": EXECUTION_OK, "reason_code": REASON_FINAL_MESSAGE, "failure": None},
+        },
+    }
+
+
+def test_downgrade_attribute_filter_prevents_concurrent_dirt_blame(repo, monkeypatch):
+    """Task A finishes while task B left the shared tree dirty — the failure
+    block cites ONLY A's own mutation-attributed file, never B's concurrent dirt.
+    """
+    import ouroboros.work_uncommitted as wu
+
+    (repo / "task_a_owned.py").write_text("base\n")
+    (repo / "task_b_concurrent.py").write_text("base\n")
+    _git("add", ".", cwd=repo)
+    _git("commit", "-qm", "shared baseline", cwd=repo)
+    (repo / "task_b_concurrent.py").write_text("B's change\n")   # concurrent dirt
+    (repo / "task_a_owned.py").write_text("A's change\n")        # A's own
+
+    # Shared-tree regime: the resolver returns the shared root + A's attributed set.
+    monkeypatch.setattr(wu, "resolve_work_uncommitted_scope",
+                        lambda *_a, **_k: (repo, ["task_a_owned.py"]))
+
+    outcome = wu.downgrade_outcome_for_uncommitted_work(
+        _clean_ok_outcome(), object(), {"id": "task-a"}, {},
+    )
+
+    failure = outcome.get("failure") or {}
+    reported_paths = [
+        line.split()[-1].split(" -> ")[-1] for line in (failure.get("files") or [])
+    ]
+    assert "task_a_owned.py" in reported_paths
+    assert "task_b_concurrent.py" not in reported_paths
+    assert outcome.get("reason_code") == REASON_WORK_UNCOMMITTED
+    assert outcome["outcome_axes"]["execution"]["status"] == "degraded"
+
+
+def test_downgrade_shared_tree_skips_pure_concurrent_dirt(repo, monkeypatch):
+    """Task A owns nothing (empty attributed set); the downgrade is skipped
+    entirely — A is not blamed for concurrent dirt."""
+    import ouroboros.work_uncommitted as wu
+
+    (repo / "shared_clean.txt").write_text("base\n")
+    _git("add", ".", cwd=repo)
+    _git("commit", "-qm", "init", cwd=repo)
+    (repo / "shared_clean.txt").write_text("concurrent\n")
+
+    monkeypatch.setattr(wu, "resolve_work_uncommitted_scope",
+                        lambda *_a, **_k: (repo, []))  # A owns nothing
+
+    outcome = wu.downgrade_outcome_for_uncommitted_work(
+        _clean_ok_outcome(), object(), {"id": "task-a"}, {},
+    )
+
+    assert not outcome.get("failure")
+    assert outcome.get("reason_code") != REASON_WORK_UNCOMMITTED
+
+
+def test_downgrade_is_noop_when_scope_resolver_skips(repo, monkeypatch):
+    """The resolver returns ``(None, None)`` on any attribution ambiguity — the
+    downgrade must be a pure no-op (a gap never widens the probe into a gate)."""
+    import ouroboros.work_uncommitted as wu
+
+    (repo / "f.py").write_text("dirty, but attribution is blocked\n")
+    monkeypatch.setattr(wu, "resolve_work_uncommitted_scope", lambda *_a, **_k: (None, None))
+
+    outcome = wu.downgrade_outcome_for_uncommitted_work(
+        _clean_ok_outcome(), object(), {"id": "task-a"}, {},
+    )
+    assert not outcome.get("failure")
+    assert outcome.get("reason_code") != REASON_WORK_UNCOMMITTED
+
+
+def test_downgrade_is_noop_for_a_non_ok_run(repo, monkeypatch):
+    """A run that is already degraded/failed is never touched by the
+    work-uncommitted post-processor, even with attributed dirt present."""
+    import ouroboros.work_uncommitted as wu
+
+    (repo / "f.py").write_text("dirty\n")
+    monkeypatch.setattr(wu, "resolve_work_uncommitted_scope", lambda *_a, **_k: (repo, ["f.py"]))
+
+    outcome = _clean_ok_outcome()
+    outcome["outcome_axes"]["execution"]["status"] = "failed"
+    outcome["reason_code"] = "tool_failure"
+
+    result = wu.downgrade_outcome_for_uncommitted_work(outcome, object(), {"id": "t"}, {})
+    assert result["reason_code"] == "tool_failure"
+    assert result["outcome_axes"]["execution"]["status"] == "failed"
+
+
+def test_resolve_work_uncommitted_scope_isolated_worktree_returns_task_root(tmp_path):
+    """When ``task.repo_dir`` differs from ``env.repo_dir`` the raw probe is safe."""
+    from ouroboros.work_uncommitted import resolve_work_uncommitted_scope as _resolve_work_uncommitted_scope
+
+    shared_repo = tmp_path / "shared"
+    isolated_worktree = tmp_path / "task_a_worktree"
+    for root in (shared_repo, isolated_worktree):
+        root.mkdir()
+        _git("init", "-q", cwd=root)
+        _git("config", "user.email", "t@t", cwd=root)
+        _git("config", "user.name", "t", cwd=root)
+
+    class _Env:
+        pass
+
+    env = _Env()
+    env.repo_dir = shared_repo
+    env.drive_root = tmp_path / "drive"
+
+    task = {"id": "task-a", "root_task_id": "task-a", "repo_dir": str(isolated_worktree)}
+    repo_dir, attributed_paths = _resolve_work_uncommitted_scope(env, task, {})
+    assert pathlib.Path(repo_dir).resolve(strict=False) == pathlib.Path(
+        isolated_worktree,
+    ).resolve(strict=False)
+    assert attributed_paths is None, (
+        "isolated worktree regime must NOT carry an attributed filter — the "
+        "worktree itself isolates the task"
+    )
+
+
+def test_resolve_work_uncommitted_scope_shared_tree_narrows_via_attribution(tmp_path):
+    """Shared-tree regime narrows the probe to this task's clean-at-baseline
+    candidate set (``attributed_git_candidates`` — the same notion the commit
+    gate uses). A file that was ALREADY dirty when task A started is
+    pre-existing WIP and is excluded from A's set, so a concurrent task whose
+    change merely persists that pre-existing dirt cannot enter A's verdict.
+    """
+    from ouroboros.work_uncommitted import resolve_work_uncommitted_scope as _resolve_work_uncommitted_scope
+    from ouroboros.mutation_attribution import capture_mutation_baseline
+    from ouroboros.task_results import STATUS_RUNNING, write_task_result
+
+    shared_repo = tmp_path / "shared"
+    shared_repo.mkdir()
+    _git("init", "-q", cwd=shared_repo)
+    _git("config", "user.email", "t@t", cwd=shared_repo)
+    _git("config", "user.name", "t", cwd=shared_repo)
+    (shared_repo / "clean.txt").write_text("base\n")
+    (shared_repo / "preexisting.txt").write_text("base\n")
+    _git("add", ".", cwd=shared_repo)
+    _git("commit", "-qm", "base", cwd=shared_repo)
+
+    drive_root = tmp_path / "drive"
+    write_task_result(drive_root, "task-a", STATUS_RUNNING)
+
+    # preexisting.txt is ALREADY dirty when task A starts — owner/other WIP.
+    (shared_repo / "preexisting.txt").write_text("preexisting WIP\n")
+    capture_mutation_baseline(
+        drive_root,
+        "task-a",
+        [{"surface_type": "system_repo", "host_root": str(shared_repo)}],
+    )
+
+    # Task A touches a clean-at-baseline file and adds a new one. The
+    # pre-existing dirty file is left exactly as it was at baseline (a change
+    # to it after baseline would raise a `preexisting_dirty_changed` blocker,
+    # which is its own tested path below).
+    (shared_repo / "clean.txt").write_text("A's change\n")
+    (shared_repo / "new_by_a.txt").write_text("new by A\n")
+
+    class _Env:
+        pass
+
+    env = _Env()
+    env.repo_dir = shared_repo
+    env.drive_root = drive_root
+
+    task = {"id": "task-a", "root_task_id": "task-a"}
+    repo_dir, attributed_paths = _resolve_work_uncommitted_scope(env, task, {})
+    assert pathlib.Path(repo_dir).resolve(strict=False) == pathlib.Path(
+        shared_repo,
+    ).resolve(strict=False)
+    # A's candidate set: clean-at-baseline files A changed. The pre-existing
+    # dirty file is excluded evidence — it never enters A's work-uncommitted
+    # verdict even though it kept changing after A's baseline.
+    assert sorted(attributed_paths) == ["clean.txt", "new_by_a.txt"]
+
+
+def test_resolve_work_uncommitted_scope_returns_none_when_attribution_blocked(tmp_path):
+    """Missing baseline must NOT silently widen the probe back to a false-positive gate."""
+    from ouroboros.work_uncommitted import resolve_work_uncommitted_scope as _resolve_work_uncommitted_scope
+
+    shared_repo = tmp_path / "shared"
+    shared_repo.mkdir()
+    _git("init", "-q", cwd=shared_repo)
+    _git("config", "user.email", "t@t", cwd=shared_repo)
+    _git("config", "user.name", "t", cwd=shared_repo)
+    (shared_repo / "any.txt").write_text("x\n")
+    _git("add", ".", cwd=shared_repo)
+    _git("commit", "-qm", "init", cwd=shared_repo)
+    (shared_repo / "any.txt").write_text("dirt\n")
+
+    class _Env:
+        pass
+
+    env = _Env()
+    env.repo_dir = shared_repo
+    env.drive_root = tmp_path / "drive"  # no task result / baseline at all
+
+    task = {"id": "task-a", "root_task_id": "task-a"}
+    repo_dir, attributed_paths = _resolve_work_uncommitted_scope(env, task, {})
+    # Skipping the probe entirely — no attribution gap may produce a
+    # false-positive verdict for the host-bound task.
+    assert repo_dir is None
+    assert attributed_paths is None
+
+
+def test_resolve_work_uncommitted_scope_returns_none_when_preexisting_dirt_changed(tmp_path):
+    """A pre-existing dirty file that keeps changing after baseline raises the
+    ``preexisting_dirty_changed`` attribution blocker — the system's own signal
+    that it can no longer cleanly separate this task's writes from other WIP.
+    The probe must SKIP entirely rather than degrade the task on ambiguous
+    evidence.
+    """
+    from ouroboros.work_uncommitted import resolve_work_uncommitted_scope as _resolve_work_uncommitted_scope
+    from ouroboros.mutation_attribution import capture_mutation_baseline
+    from ouroboros.task_results import STATUS_RUNNING, write_task_result
+
+    shared_repo = tmp_path / "shared"
+    shared_repo.mkdir()
+    _git("init", "-q", cwd=shared_repo)
+    _git("config", "user.email", "t@t", cwd=shared_repo)
+    _git("config", "user.name", "t", cwd=shared_repo)
+    (shared_repo / "wip.txt").write_text("base\n")
+    _git("add", ".", cwd=shared_repo)
+    _git("commit", "-qm", "base", cwd=shared_repo)
+
+    drive_root = tmp_path / "drive"
+    write_task_result(drive_root, "task-a", STATUS_RUNNING)
+
+    # wip.txt is dirty at baseline...
+    (shared_repo / "wip.txt").write_text("owner WIP\n")
+    capture_mutation_baseline(
+        drive_root,
+        "task-a",
+        [{"surface_type": "system_repo", "host_root": str(shared_repo)}],
+    )
+    # ...and it changes again during A's window (owner or concurrent task).
+    (shared_repo / "wip.txt").write_text("owner WIP, more\n")
+
+    class _Env:
+        pass
+
+    env = _Env()
+    env.repo_dir = shared_repo
+    env.drive_root = drive_root
+
+    task = {"id": "task-a", "root_task_id": "task-a"}
+    repo_dir, attributed_paths = _resolve_work_uncommitted_scope(env, task, {})
+    # Ambiguous attribution → skip, never a false-positive degradation.
+    assert repo_dir is None
+    assert attributed_paths is None


### PR DESCRIPTION
## Summary

**Depends on 551** (this branch is stacked on
`ibl/work-uncommitted-not-completed` for `detect_work_uncommitted` /
`filter_work_uncommitted_to_attributed`). **Relates to #449.**

A host-bound task that edits tracked files and then writes a prose summary
("changes on disk, awaiting `commit_reviewed`") has that prose turn converted to
a terminal `_delivery_candidate`. From then on the post-tool budget context
re-arms `effect_revision_required` on every further edit, and the JSON-only
delivery-control prompt ("return exactly one JSON object and no other text")
makes `commit_reviewed` unreachable — the task spins keep/replace until the
acceptance capsule is spent and finalizes `work_uncommitted` with
`commit_reviewed` never called. This is also why an inline-advisory or an
argv-autocorrect fix alone was never enough for these tasks: they never reached
the commit gate.

Before a FRESH prose turn becomes a candidate (`_no_tool_final_answer`, the
`control_state == "fresh"` branch), `_withhold_prose_for_uncommitted_work`
checks whether the task still has its OWN uncommitted tracked edits — the
`detect_work_uncommitted` + `filter_work_uncommitted_to_attributed` SSOT
intersected with the paths this task's coding-tool effects touched, so a
concurrent task's dirty state on the shared tree does not count. If so, it
appends an `[UNCOMMITTED_WORK]` reminder (call `commit_reviewed` — advisory
runs inline — or `git checkout --` the files) and re-loops so `commit_reviewed`
stays reachable, instead of latching the candidate.

Bounded: `_MAX_UNCOMMITTED_DELIVERY_NUDGES = 4` per task. Once spent,
finalization proceeds unchanged (still `work_uncommitted` — honest, same as
today) so a task that genuinely cannot commit is not wedged. Host-bound
(non-subagent) only; read-only; fail-open (`[]`) on any git-probe error or a
missing/absolute repo. No change to the delivery-control invariants
(`_delivery_replace_required` latch, no-raw-JSON-to-chat, short-ack cannot
become the answer) — those paths run only once a candidate exists, which this
prevents.

## Scope

In scope:

- `ouroboros/loop.py`: `_uncommitted_attributed_paths`,
  `_withhold_prose_for_uncommitted_work`, `_uncommitted_delivery_reminder`, and
  the single call in the fresh-prose branch of `_no_tool_final_answer`.

Non-goals:

- The STATUS_FAILED mapping for a spent-nudge task (that is the dependency PR,
  unchanged here).
- The delivery-control invariants — untouched.

## Verification

- [x] Focused tests for the changed behavior pass.
- [x] Adjacent delivery / loop suites pass.
- [ ] `make test` — NOT_RUN in this environment; adjacent suites run instead.
- [x] `python -m py_compile` on every touched module.

```text
$ python -m pytest tests/test_uncommitted_delivery_guard.py -q
7 passed

$ python -m pytest tests/test_delivery_forced_finalization.py tests/test_delivery_candidate.py \
    tests/test_delivery_control_lineage.py tests/test_loop_misc.py -q
199 passed
```

## Visual evidence

- [x] No visible UI change.

## Review evidence

The CONTRIBUTING separate-context scope review (8-item Intent / Scope checklist)
is queued but could not complete before this PR was opened — the reviewing
agent session hit an upstream rate limit. Opened as a **draft**; the JSON
checklist result will be posted as a comment once the review runs. Base
`cc2eac50` → head of `ibl/withhold-prose-for-uncommitted-work` (includes the
dependency PR's commit as its parent).
