### PR TITLE
chore: pin Claudexor 3.9.7

### DIFF
--- a/ouroboros/claudexor_runtime_pin.json
+++ b/ouroboros/claudexor_runtime_pin.json
@@ -1,12 +1,12 @@
 {
  "schema_version": 1,
  "release": {
-  "version": "3.9.5",
-  "build_sha": "519390b6172264d0d7a27a442c564a5aa88873eb",
+  "version": "3.9.7",
+  "build_sha": "28f7a9fe008bc031cc41ab6fcc2eb3b382e23706",
   "protocol_major": 3,
-  "archive_url": "https://github.com/razzant/claudexor/releases/download/v3.9.5/claudexor-runtime-3.9.5.tar.gz",
-  "sha256": "b2fb651aa6d3693abd4c0aea82683deeac964cb11e1441de7766c9783314c79c",
-  "size_bytes": 21998929,
+  "archive_url": "https://github.com/razzant/claudexor/releases/download/v3.9.7/claudexor-runtime-3.9.7.tar.gz",
+  "sha256": "7a0b4c66fb0fd2594860e356cf82092f3753607d336603609e5959ce9b748ef4",
+  "size_bytes": 22000614,
   "node_version": "24.16.0",
   "node_artifacts": {
    "darwin-arm64": {

--- a/tests/test_claudexor_runtime_delivery.py
+++ b/tests/test_claudexor_runtime_delivery.py
@@ -154,7 +154,7 @@ def test_tracked_pin_names_a_cli_capable_release():
     of this proposal converged on while the pin was still pre-CLI 3.6.0)."""
     pin = runtime.load_runtime_pin()
     assert pin is not None
-    assert pin.version == "3.9.5"
+    assert pin.version == "3.9.7"
     assert pin.cli_entrypoint == "claudexor.bundle.cjs"
 
 


### PR DESCRIPTION
Bumps the reviewed Claudexor runtime pin from 3.9.5 to the published 3.9.7 (razzant/claudexor#264, fixes razzant/claudexor#263): background quota polling no longer lets one revoked, never-logged-in, or failing profile pin its vendor's healthy profiles to the 15-minute retry ceiling, and the Claude OAuth source stops re-presenting a rejected token every cycle, so the Claudexor Quotas widget shows fresh readings again.

Pin: version 3.9.7, build_sha 28f7a9fe008bc031cc41ab6fcc2eb3b382e23706, archive claudexor-runtime-3.9.7.tar.gz sha256 7a0b4c66fb0fd2594860e356cf82092f3753607d336603609e5959ce9b748ef4 (matches the release SHA256SUMS), size 22000614. The closure's longest relative member is unchanged (172). 3.9.7 was published under Claudexor's owner publication exception (no in-app engine update manifests); the exact URL/sha256/size pin used here does not depend on those manifests, as with 3.9.0.

Tests: tests/test_claudexor_runtime_delivery.py and tests/test_claudexor_platform_smoke.py (84 passed) with isolated paths.

Closes #566.