### PR TITLE
chore: pin managed Claudexor runtime to 3.9.8

### DIFF
--- a/ouroboros/claudexor_runtime_pin.json
+++ b/ouroboros/claudexor_runtime_pin.json
@@ -1,12 +1,12 @@
 {
  "schema_version": 1,
  "release": {
-  "version": "3.9.7",
-  "build_sha": "28f7a9fe008bc031cc41ab6fcc2eb3b382e23706",
+  "version": "3.9.8",
+  "build_sha": "529e512f5f112af9009dea55d0b2c2d08b57b6a5",
   "protocol_major": 3,
-  "archive_url": "https://github.com/razzant/claudexor/releases/download/v3.9.7/claudexor-runtime-3.9.7.tar.gz",
-  "sha256": "7a0b4c66fb0fd2594860e356cf82092f3753607d336603609e5959ce9b748ef4",
-  "size_bytes": 22000614,
+  "archive_url": "https://github.com/razzant/claudexor/releases/download/v3.9.8/claudexor-runtime-3.9.8.tar.gz",
+  "sha256": "8b2df52be3f32e1e785551a55140beeb0d2e2f2a310808bd53e4e28fb948757f",
+  "size_bytes": 22013987,
   "node_version": "24.16.0",
   "node_artifacts": {
    "darwin-arm64": {

--- a/tests/test_claudexor_runtime_delivery.py
+++ b/tests/test_claudexor_runtime_delivery.py
@@ -154,7 +154,7 @@ def test_tracked_pin_names_a_cli_capable_release():
     of this proposal converged on while the pin was still pre-CLI 3.6.0)."""
     pin = runtime.load_runtime_pin()
     assert pin is not None
-    assert pin.version == "3.9.7"
+    assert pin.version == "3.9.8"
     assert pin.cli_entrypoint == "claudexor.bundle.cjs"
 
 


### PR DESCRIPTION
## Summary

Update the managed Claudexor runtime from 3.9.7 to [3.9.8](https://github.com/razzant/claudexor/releases/tag/v3.9.8), making Astra/Ultra and Fable 5.1 available through the released adapters. Ordinary Agent runs inherit Claudexor's new opt-in internal review default.

## Scope

Only the exact runtime pin (version, build SHA, archive URL, SHA-256, size) and the existing expected-version assertion change. Protocol 3, Node 24.16.0, all five Node artifacts, and both entrypoints are unchanged. Ouroboros release metadata is unchanged.

The pin selects the engine on the next natural managed-daemon start; this PR does not restart or hot-swap a running daemon. The separate delegation wording/design work in #653 is outside this PR.

## Verification

- `python scripts/fetch_claudexor_runtime.py --verify-only --output-dir <verified-release-cache>`: PASS, exit 0. Cached archive bytes match the current public GitHub asset digest and size.
- `python -m pytest -q -o addopts= tests/test_claudexor_runtime_delivery.py tests/test_claudexor_platform_smoke.py tests/test_claudexor_owned_daemon.py`: 188 passed in 2.71s, exit 0, isolated test data.
- `git diff --check HEAD~1 HEAD`: PASS, exit 0.
- Archive inspection: both pinned entrypoints are present.
- Full local suite and new native-provider/VM runs: NOT_RUN for this two-file pin change. The Claudexor release has its own acceptance evidence; the focused Python suites test Ouroboros delivery/lifecycle with fixtures and do not prove live adoption. PR CI provides separate platform results.

Pinned release identity:

```text
Version: 3.9.8
Build SHA: 529e512f5f112af9009dea55d0b2c2d08b57b6a5
Archive: claudexor-runtime-3.9.8.tar.gz
SHA-256: 8b2df52be3f32e1e785551a55140beeb0d2e2f2a310808bd53e4e28fb948757f
Size: 22013987 bytes
```

## Visual evidence

Not applicable: this PR changes dependency metadata and its existing test assertion, with no Ouroboros UI changes.

## Governance and documentation

The change uses the existing reviewed-pin delivery contract. No protected policy, prompt, contract, workflow, release-version carrier, credential, runtime state, or generated artifact is changed. The separate reviewer follows CONTRIBUTING.md and its Intent / Scope checklist.

## Review evidence

- Review status: PASS, no findings.
- Authoring context: Codex desktop, /root.
- Separate review context: /root/pin_contract_audit, read-only; model/effort not independently exposed.
- Reviewed base: `db6d7cf872df840e8c05e0cc2651d5bcff14b422`.
- Reviewed head: `12e2b7ca6d1d9acb7e468ce63283338f18ca39cd`.
- Scope receipt validation: `python scripts/validate_scope_receipt.py <review-receipt.json>` passed, exit 0, all 8 items covered.

| Item | Verdict | Evidence |
| --- | --- | --- |
| intent_alignment | PASS | ouroboros/claudexor_runtime_pin.json selects the published Claudexor 3.9.8 archive and build 529e512f5f112af9009dea55d0b2c2d08b57b6a5. The complete diff changes only the five release-identity values and the existing expected-version assertion, matching the requested pin-update PR. |
| forgotten_touchpoints | PASS | The repository-wide search found one coupled 3.9.7 assertion, test_tracked_pin_names_a_cli_capable_release, and it is updated. scripts/fetch_claudexor_runtime.py and the dependency-graph/platform-gate workflows read the pin directly; their Node 24.16.0 setting still matches the unchanged pin. |
| cross_surface_consistency | PASS | ClaudexorRuntimePin.load/validate, managed installation, and both CLI/daemon entrypoint consumers retain the same schema, protocol major 3, and five platform Node artifacts. No Ouroboros release-version carrier or live-runtime setting changes. |
| regression_surface | PASS | Existing tests cover exact archive integrity, preserved runtime rollback trees, no repair of a serving tree, and activation only on the next natural daemon start. I read the supplied 188-pass test log and producer-exit receipt; the newly selected archive also independently matches the committed size and digest. |
| prompt_doc_sync | PASS | ARCHITECTURE.md names claudexor_runtime_pin.json as the single exact selector, and claudexor_runtime.py documents next-spawn activation with no hot swap. Those descriptions remain accurate; CONTRIBUTING.md and DEVELOPMENT.md require unchanged release carriers for this contributor PR. |
| architecture_fit | PASS | The change reuses the existing immutable runtime-pin mechanism and adds no resolver, scheduler, model allowlist, account state, or update policy. This is the smallest change that makes the newly released engine available to managed starts. |
| cross_module_bugs | PASS | ClaudexorGateway.get_run returns dictionaries, tools/delegate.py::_terminal_payload forwards outcomeFacts, and delegate_output.py preserves structured facts or their full artifact. They do not reject the additive review_requested field, while config.EFFORT_SCALE already admits ultra and configured session targets retain opaque model IDs. |
| implicit_contracts | PASS | Protocol major 3, the two bundle entrypoints, Node 24.16.0, and every platform Node digest remain byte-identical to the base. Both entrypoints exist in the hash-matched archive; no frozen Ouroboros contract or independently configured review/acceptance gate is edited. |

<details>
<summary>Full separate-context review and checklist JSON</summary>

Verdict: PASS

Goal: open a focused Ouroboros pull request updating its managed Claudexor pin from 3.9.7 to the published 3.9.8 release. Merge, release, live daemon restart, account changes, and issue #653 implementation are outside this review.

Reviewer: separate read-only agent context /root/pin_contract_audit. The model identifier is not independently exposed by this review tool. The reviewer made no candidate edits and did not rerun runtime processes or tests.

Reviewed base: db6d7cf872df840e8c05e0cc2651d5bcff14b422
Reviewed head: 12e2b7ca6d1d9acb7e468ce63283338f18ca39cd
Reviewed tree: 18803c7bdbdc2ebcb696b5bb65581f48a43e0515
Complete diff SHA-256: 8b61b15d8fc1250471cd0f889c260d0672cf11ea919e13da4ae41b7c159e251d
The candidate was clean when inspected and remained clean at report generation.

Preparation and scope

Read CONTRIBUTING.md and all 878 lines of docs/CHECKLISTS.md in untruncated chunks. Mapped BIBLE.md, ARCHITECTURE.md, DEVELOPMENT.md, and DESIGN.md by headings and read the sections relevant to the narrow data-only pin change, including version-neutral contribution rules, minimalism/SSOT, runtime delivery/activation, delegation transport, testing/isolation, dependency graph and platform packaging. No visual surface changes, so rendered UI verification is not applicable.

Inspected the complete two-file diff and both complete touched files. Examined the pin loader, integrity verifier, immutable install identity, serving-role resolver, probe identity binding, gateway handshake/run transport, terminal output forwarding, effort admission, existing runtime-delivery and activation tests, and pin-reading build/CI consumers.

Evidence

The committed archive is claudexor-runtime-3.9.8.tar.gz, 22013987 bytes, SHA-256 8b2df52be3f32e1e785551a55140beeb0d2e2f2a310808bd53e4e28fb948757f. I independently recalculated its size and digest from the cached release asset and inspected the archive member inventory: both claudexord.bundle.cjs and claudexor.bundle.cjs are present. Only version, build_sha, archive_url, sha256, and size_bytes change in the pin.

The supplied VERIFICATION.json and complete focused.log record python -m pytest -q -o addopts= tests/test_claudexor_runtime_delivery.py tests/test_claudexor_platform_smoke.py tests/test_claudexor_owned_daemon.py: 188 passed in 2.71 seconds, producer exit 0. The wrapper elapsed time is 3.17 seconds. scripts/fetch_claudexor_runtime.py --verify-only also records producer exit 0. These executions were performed by the authoring context and read by this reviewer, not repeated here.

Compatibility and operational boundary

The managed client keeps outcomeFacts as a dictionary, so Claudexor 3.9.8's additive review_requested field is not rejected by an older closed client schema here. The inherited ordinary Agent default changes to internal review off in the released dependency; independently configured Ouroboros review/acceptance remains unchanged. Issue #653's delegate_start wording and further integration decisions stay separate. Model targets are opaque, and ultra is already in the existing effort SSOT.

A pin change selects the next natural managed daemon start. This review does not claim that an already running Ouroboros-managed daemon adopted 3.9.8, and no restart is required to open the PR.

Findings and disposition

No material or advisory findings. All eight Intent / Scope checklist items pass with artifact-specific reasoning below.

Coverage limitations

Full Ouroboros default suite: NOT_RUN for this focused pin PR. New live-provider, native VM battery, and multi-OS runtime execution: NOT_RUN for this pin PR. Prior Claudexor release acceptance is separate evidence and is not represented as a new integration run on this Ouroboros candidate. Public release metadata was freshly checked by the authoring context; this reviewer independently verified the cached matching archive, not the remote asset service. CI results after PR creation are outside this pre-publication review.

Checklist JSON

```json
[
  {
    "item": "intent_alignment",
    "verdict": "PASS",
    "severity": "advisory",
    "reason": "ouroboros/claudexor_runtime_pin.json selects the published Claudexor 3.9.8 archive and build 529e512f5f112af9009dea55d0b2c2d08b57b6a5. The complete diff changes only the five release-identity values and the existing expected-version assertion, matching the requested pin-update PR."
  },
  {
    "item": "forgotten_touchpoints",
    "verdict": "PASS",
    "severity": "advisory",
    "reason": "The repository-wide search found one coupled 3.9.7 assertion, test_tracked_pin_names_a_cli_capable_release, and it is updated. scripts/fetch_claudexor_runtime.py and the dependency-graph/platform-gate workflows read the pin directly; their Node 24.16.0 setting still matches the unchanged pin."
  },
  {
    "item": "cross_surface_consistency",
    "verdict": "PASS",
    "severity": "advisory",
    "reason": "ClaudexorRuntimePin.load/validate, managed installation, and both CLI/daemon entrypoint consumers retain the same schema, protocol major 3, and five platform Node artifacts. No Ouroboros release-version carrier or live-runtime setting changes."
  },
  {
    "item": "regression_surface",
    "verdict": "PASS",
    "severity": "advisory",
    "reason": "Existing tests cover exact archive integrity, preserved runtime rollback trees, no repair of a serving tree, and activation only on the next natural daemon start. I read the supplied 188-pass test log and producer-exit receipt; the newly selected archive also independently matches the committed size and digest."
  },
  {
    "item": "prompt_doc_sync",
    "verdict": "PASS",
    "severity": "advisory",
    "reason": "ARCHITECTURE.md names claudexor_runtime_pin.json as the single exact selector, and claudexor_runtime.py documents next-spawn activation with no hot swap. Those descriptions remain accurate; CONTRIBUTING.md and DEVELOPMENT.md require unchanged release carriers for this contributor PR."
  },
  {
    "item": "architecture_fit",
    "verdict": "PASS",
    "severity": "advisory",
    "reason": "The change reuses the existing immutable runtime-pin mechanism and adds no resolver, scheduler, model allowlist, account state, or update policy. This is the smallest change that makes the newly released engine available to managed starts."
  },
  {
    "item": "cross_module_bugs",
    "verdict": "PASS",
    "severity": "advisory",
    "reason": "ClaudexorGateway.get_run returns dictionaries, tools/delegate.py::_terminal_payload forwards outcomeFacts, and delegate_output.py preserves structured facts or their full artifact. They do not reject the additive review_requested field, while config.EFFORT_SCALE already admits ultra and configured session targets retain opaque model IDs."
  },
  {
    "item": "implicit_contracts",
    "verdict": "PASS",
    "severity": "advisory",
    "reason": "Protocol major 3, the two bundle entrypoints, Node 24.16.0, and every platform Node digest remain byte-identical to the base. Both entrypoints exist in the hash-matched archive; no frozen Ouroboros contract or independently configured review/acceptance gate is edited."
  }
]
```

</details>

