### PR TITLE
e2e_live: spend from the product ledger, skill fixture runtime, landing skip flags checked

### DIFF
--- a/devtools/e2e_live/run_live_lanes.py
+++ b/devtools/e2e_live/run_live_lanes.py
@@ -234,19 +234,19 @@ def credit_preflight(key: str, *, timeout: float = 10.0) -> dict:
 # --------------------------------------------------------------------------- #
 
 def lane_spend(data_root: pathlib.Path) -> tuple[float, int]:
-    """``(USD summed over the lane's durable llm_usage rows, rows whose cost is unknown)``. The system-E2E
-    harness oracle is the reader (the same ``logs/events.jsonl`` the runtime writes); the server-level file
-    carries every row of the lane — task loops, review organs, safety — verified on the first paid run
-    against the ``task_results`` accounting. A row without a numeric cost is counted, never priced."""
-    from tests.system_e2e import harness  # durable readers (runtime-only import, outside the audit walk)
-
+    """``(USD over the lane's SETTLED physical-attempt ledger rows, unknown-cost rows)``: ``state/usage_attempts.jsonl`` is
+    the product's money authority; ``llm_usage`` telemetry misses skill review/advisory/synthesis (run3: 114.81 vs 141.63)."""
+    path = pathlib.Path(data_root) / "state" / "usage_attempts.jsonl"
     spent, unknown = 0.0, 0
-    for row in harness.ArtifactOracle(data_root).events("llm_usage"):
-        cost = row.get("cost")
-        if isinstance(cost, (int, float)) and not isinstance(cost, bool):
-            spent += float(cost)
-        else:
-            unknown += 1
+    for line in (path.read_text(encoding="utf-8").splitlines() if path.is_file() else []):
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(row, dict) and row.get("state") == "settled" and row.get("cost_final") is True:
+            cost = row.get("cost_usd")
+            priced = isinstance(cost, (int, float)) and not isinstance(cost, bool)
+            spent, unknown = spent + (float(cost) if priced else 0.0), unknown + (0 if priced else 1)
     return spent, unknown
 
 

--- a/devtools/e2e_live/scenarios.py
+++ b/devtools/e2e_live/scenarios.py
@@ -73,6 +73,7 @@ name: {SK1_SKILL}
 description: Loopback probe extension authored by the live E2E stand SK1 scenario.
 version: 0.1.0
 type: extension
+runtime: python3
 entry: plugin.py
 plugin_api: "2.0"
 permissions: ["tool", "inject_chat", "net"]
@@ -196,7 +197,13 @@ def commit_refusal_facts(ledger: dict, tools_rows: list, stored: dict) -> dict:
         match = _REFUSAL_CODE_RE.search(str(row.get("result_preview") or ""))
         calls.append({"tool": str(row.get("tool") or ""), "status": str(row.get("status") or ""),
                       "code": match.group(1) if match else ""})
+    landing = next((row for row in reversed(tools_rows) if str(row.get("tool") or "") == "commit_reviewed"
+                    and str(row.get("result_preview") or "").startswith("OK:")), None)
+    landing_args = (landing or {}).get("args") if isinstance((landing or {}).get("args"), dict) else {}
     return {
+        # The documented SM1 path has NO skip flags on the landing call (DEVELOPMENT.md): rc.15 run2 and run3
+        # landed twice through review_rebuttal + skip_advisory_review=True and the stand did not tell.
+        "landing_skip_flags": sorted(k for k, v in landing_args.items() if str(k).startswith("skip_") and v),
         "commit_attempts": [{"attempt": a.get("attempt"), "phase": str(a.get("phase") or ""),
                              "status": str(a.get("status") or ""), "block_reason": str(a.get("block_reason") or "")}
                             for a in attempts],
@@ -533,6 +540,8 @@ def run_sm1(ctx: LaneContext) -> None:
     ctx.check("advisory_ledger_row_present", any(advisory_run_is_real(r) for r in runs))
     tools_rows = task_oracle.tools_rows()
     ctx.facts["commit_reviewed_refusals"] = commit_refusal_facts(ledger, tools_rows, stored)
+    ctx.check("landed_without_skip_flags", ctx.checks["commit_landed"]
+              and not ctx.facts["commit_reviewed_refusals"]["landing_skip_flags"])
     # A FACT, not a check: the reviewers judge the UI evidence (development_compliance 2(i)).
     vision = vision_evidence_rows(tools_rows)
     ctx.facts["vision_evidence_present"] = bool(vision)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1297,7 +1297,8 @@ the run-root `effective_settings.json` is REDACTED and the value reaches disk
 only in each lane's 0600 settings file, disclosed by fingerprint as the runtime
 grant); the preflight takes `min(key limit remaining, account credits)` and
 refuses below `--min-credit-usd`. `--total-budget` (default 100) is the RUN-WIDE
-cap: a ledger sums the lanes' durable `llm_usage` costs, reserves
+cap: a ledger sums the lanes' settled physical-attempt ledger rows (`state/usage_attempts.jsonl`, the
+product's money authority; the `llm_usage` telemetry misses skill review, advisory and synthesis), reserves
 `max(0.01, --per-task-usd × (root tasks + 1 with --self-mod for the scenario that absorbs))` per attempt (SM1 and SW1 one root — scouts spend
 under their root's `OUROBOROS_PER_TASK_COST_USD` fence — SK1 two; with `--self-mod` SM1's
 one post-task evolution cycle is one more root (SW1/SK1 pin promotion off) (the rc.14 paid run showed a second, generic

--- a/tests/test_e2e_live_runner.py
+++ b/tests/test_e2e_live_runner.py
@@ -263,13 +263,13 @@ def test_config_sha256_is_secret_free_and_key_independent():
 # The run-wide budget ledger
 # --------------------------------------------------------------------------- #
 
-def test_lane_spend_sums_durable_llm_usage_rows_and_counts_unknown_costs(tmp_path):
-    logs = tmp_path / "data" / "logs"
-    logs.mkdir(parents=True)
-    rows = [{"type": "llm_usage", "cost": 1.5}, {"type": "llm_usage", "cost": 0.25},
-            {"type": "llm_usage", "cost": None, "cost_known": False}, {"type": "task_done", "cost": 99.0},
-            {"type": "llm_usage", "cost": True}]
-    (logs / "events.jsonl").write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+def test_lane_spend_sums_the_settled_product_ledger_and_counts_unknown_costs(tmp_path):
+    """rc.15 run3: telemetry summed 114.81, the product ledger 141.63 (skill review, advisory, synthesis write no row)."""
+    (state := tmp_path / "data" / "state").mkdir(parents=True)
+    rows = [{"state": "settled", "cost_final": True, "cost_usd": 1.5}, {"state": "settled", "cost_final": True, "cost_usd": 0.25},
+            {"state": "settled", "cost_final": True, "cost_usd": None}, {"state": "settled", "cost_final": False, "cost_usd": 99.0},
+            {"state": "pending", "cost_usd": 99.0}, {"state": "settled", "cost_final": True, "cost_usd": True}, "not json"]
+    (state / "usage_attempts.jsonl").write_text("\n".join(r if isinstance(r, str) else json.dumps(r) for r in rows) + "\n", encoding="utf-8")
     assert run_live_lanes.lane_spend(tmp_path / "data") == (1.75, 2)
     assert run_live_lanes.lane_spend(tmp_path / "absent") == (0.0, 0)
 

--- a/tests/test_e2e_live_sm1_checks.py
+++ b/tests/test_e2e_live_sm1_checks.py
@@ -40,3 +40,17 @@ def test_any_other_untracked_or_modified_path_still_fails_the_clean_check(tmp_pa
     (root / "a.txt").write_text("changed\n", encoding="utf-8")
     clean, porcelain, transient = scenarios.worktree_after_commit(root)
     assert clean is False and "M a.txt" in porcelain and transient == ["?? .ouroboros/"]   # ``_git`` strips the leading column
+
+
+def test_the_landing_commit_call_records_its_skip_flags():
+    """rc.15 run2/run3: two SM1 lanes landed through review_rebuttal + skip_advisory_review=True; the documented
+    path has no skip flags, so the landing call's truthy ``skip_*`` arguments are a recorded fact and a check."""
+    rows = [{"tool": "commit_reviewed", "result_preview": "⚠️ REVIEW_BLOCKED (attempt 1)", "args": {"skip_advisory_review": True}},
+            {"tool": "commit_reviewed", "result_preview": "OK: committed to ouroboros: x",
+             "args": {"skip_advisory_review": True, "skip_tests": False, "paths": ["a"]}},
+            {"tool": "read_file", "result_preview": "OK", "args": {"skip_advisory_review": True}}]
+    facts = scenarios.commit_refusal_facts({}, rows, {})
+    assert facts["landing_skip_flags"] == ["skip_advisory_review"]
+    clean = [{"tool": "commit_reviewed", "result_preview": "OK: committed", "args": {"paths": ["a"]}}]
+    assert scenarios.commit_refusal_facts({}, clean, {})["landing_skip_flags"] == []
+    assert scenarios.commit_refusal_facts({}, [], {})["landing_skip_flags"] == []


### PR DESCRIPTION
Fix-forward for the live E2E stand (no version bump, owner rule of 2026-09-05). Three stand corrections from the deep read of rc.15 run3; no product runtime file is touched.

Money. lane_spend summed the llm_usage telemetry rows, which the product itself calls compatibility telemetry (pricing.py); the money authority is the settled physical-attempt ledger, state/usage_attempts.jsonl. run3 read 114.81 by telemetry and 141.63 by the ledger, because the skill-review triad, the advisory pre-review through the agent SDK and the post-task synthesis write no telemetry row, so the run cap admitted attempts on a short count. The reader now sums settled, cost-final ledger rows and counts an unpriced one as unknown; the docstring's claim that the telemetry carried every row is gone. Re-read by the ledger, the rc.15 stand work cost about 336 dollars, not the 285 reported from telemetry.

Skill fixture. The stand's reference SKILL.md declares type extension with no runtime, which CREATING_SKILLS.md says is required for extensions; the model copied the fixture byte for byte in all three run3 lanes and the terra reviewer failed manifest_schema, a hard-critical item, in two of them. The fixture now declares runtime: python3. (The product's loader does not require it, so the docs and the loader still disagree; that is a separate product question.)

Landing path. DEVELOPMENT.md describes the SM1 landing as commit_reviewed with no skip flags and a real advisory row, but the stand only checked that some advisory run in the ledger was real. run2 SM1_a1 and run3 SM1_a1 landed through review_rebuttal plus skip_advisory_review=True and still counted. commit_refusal_facts now records the landing call's truthy skip_* arguments as landing_skip_flags and run_sm1 checks landed_without_skip_flags, so a bypass landing becomes a typed failed check with the facts beside it. This makes the SM1 verdict match its documented contract; it is stricter than the run3 evaluation (run3's SM1_a1 would have failed this check too, SM1_a3 passes it).

Tests: the spend test reads the ledger shape; tests/test_e2e_live_sm1_checks.py pins the skip-flag fact. Local gates: 100 passed across the stand modules, ruff --select F clean, regenerate_size_ratchet.py --check ok (runner and runner-test modules stay at their band ceilings).
