### PR TITLE
e2e_live: the stand runs a cheap three-family review panel at effort low

### DIFF
--- a/devtools/e2e_live/run_live_lanes.py
+++ b/devtools/e2e_live/run_live_lanes.py
@@ -64,7 +64,7 @@ from devtools.benchmarks.common.server_runner import (
     seed_owner_state,
 )
 from devtools.e2e_live import stub_lane
-from devtools.e2e_live.scenarios import SCENARIOS, LaneContext, diff_sha256, head_sha, now_iso
+from devtools.e2e_live.scenarios import SCENARIOS, STAND_PANEL_SETTINGS, LaneContext, diff_sha256, head_sha, now_iso
 from devtools.e2e_live.ui_probe import resolve_ui_client
 from ouroboros.provider_models import ALL_PROVIDER_CREDENTIAL_KEYS, declared_model_settings
 
@@ -128,6 +128,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
                          "(never a live worktree)")
     ap.add_argument("--source-repo", default="", help="checkout the seed ref is resolved in (default: this tree)")
     ap.add_argument("--stub", action="store_true", help="loopback stub model, no key, no money")
+    ap.add_argument("--production-panel", action="store_true", help="the tree's default review panel and efforts, not the stand's cheap panel")
     ap.add_argument("--watch-interval", type=float, default=30.0)
     ap.add_argument("--prune-clones", action="store_true", help="delete lane clones after each lane (results stay)")
     args = ap.parse_args(argv)
@@ -179,11 +180,10 @@ def effective_settings(args: argparse.Namespace, key: str) -> dict:
         "OUROBOROS_PER_TASK_COST_USD": float(args.per_task_usd),
         "OUROBOROS_POST_TASK_EVOLUTION": "true" if args.self_mod else "false",
         **({"OUROBOROS_POST_TASK_EVOLUTION_CADENCE": "every_n:1"} if args.self_mod else {}),
+        **({} if args.stub or args.production_panel else STAND_PANEL_SETTINGS),   # scenarios.STAND_REVIEW_PANEL
+        **({"OUROBOROS_MODEL": str(args.model)} if args.model else {}),
+        **({"OPENROUTER_API_KEY": key} if key else {}),
     }
-    if args.model:
-        overrides["OUROBOROS_MODEL"] = str(args.model)
-    if key:
-        overrides["OPENROUTER_API_KEY"] = key
     return build_isolated_settings({}, **overrides)
 
 

--- a/devtools/e2e_live/scenarios.py
+++ b/devtools/e2e_live/scenarios.py
@@ -146,6 +146,22 @@ SK1_ECHO_MESSAGE = "ping-e2e-live"
 SK1_ECHO_EXPECTED = f"echo: {SK1_ECHO_MESSAGE}"   # exactly what ``_echo`` in SK1_PLUGIN returns AND relays
 
 
+# The STAND's review panel (the owner's choice of 2026-09-06, questions 1-4 = A): cheap, three model families, every
+# reviewer at effort low, task and evolution at medium. The product's own defaults (gemini/terra/opus triad, terra
+# scope, sonnet advisory, high efforts) stay untouched for installs; ``--production-panel`` runs them on the stand.
+# run3 on the defaults cost 141.63 USD, 75% of it review and opus alone 39%; this panel is estimated at ~40%.
+_ROW = lambda slot_id, model: {"slot_id": slot_id, "route": {"kind": "api_chat", "target_id": model}, "effort": "low"}  # noqa: E731
+STAND_REVIEW_PANEL = {
+    "triad": [_ROW("t_gemini", "google/gemini-3.8-flash"), _ROW("t_luna", "openai/gpt-5.6-luna"),
+              _ROW("t_deepseek", "deepseek/deepseek-v4-pro")],
+    "scope": [_ROW("s_deepseek", "deepseek/deepseek-v4-pro")],
+    "advisory": {"route": {"kind": "api_chat", "target_id": "anthropic/claude-sonnet-5"}, "effort": "low"},
+}
+STAND_PANEL_SETTINGS = {"OUROBOROS_REVIEWER_SLOTS": json.dumps(STAND_REVIEW_PANEL), "OUROBOROS_EFFORT_TASK": "medium",
+                        "OUROBOROS_EFFORT_EVOLUTION": "medium", "OUROBOROS_EFFORT_REVIEW": "low",
+                        "OUROBOROS_EFFORT_SCOPE_REVIEW": "low"}
+
+
 def _git(args: list[str], cwd: pathlib.Path) -> str:
     proc = subprocess.run(["git", *args], cwd=str(cwd), check=False, capture_output=True, text=True)
     return (proc.stdout or "").strip()

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1389,7 +1389,11 @@ server and resolves `-n auto` to the host CPU count, so the stand sets
 (`IsolatedServer` keeps that one key through the settings-authoritative sweep;
 `preflight_runner._preflight_env` still scrubs it from the candidate suite) and
 records the applied value as `extra.preflight_test_workers` in the manifest and
-`preflight_test_workers` in every lane row. `--self-mod` enables post-task evolution with the real
+`preflight_test_workers` in every lane row. Paid lanes run the stand's review panel
+(`scenarios.STAND_PANEL_SETTINGS`): triad gemini-3.8-flash / gpt-5.6-luna / deepseek-v4-pro, scope
+deepseek-v4-pro, advisory claude-sonnet-5, every reviewer at effort low, task and evolution at medium —
+three model families at a fraction of the default panel's cost; `--production-panel` runs the tree's
+own defaults instead, and the product's defaults for installs are untouched. `--self-mod` enables post-task evolution with the real
 re-exec restart — a settings fact (`OUROBOROS_POST_TASK_EVOLUTION` + cadence `every_n:1`) while the
 lane seeds `owner_chat_id` ONLY, never a campaign: the scenario task's post-task promotion
 (`apply_pending_request`) enables the one-shot campaign whose cycle lands, restarts and absorbs.

--- a/tests/test_e2e_live_panel.py
+++ b/tests/test_e2e_live_panel.py
@@ -1,0 +1,36 @@
+"""The stand's review panel (owner decision 2026-09-06): three model families at effort low on every reviewer,
+task and evolution at medium, written into every paid lane's settings as the ONE structured reviewer surface the
+product reads; ``--production-panel`` leaves the tree's own defaults in place and the stub lane keeps its loopback
+rows. The document must parse with the product's own parser, or the review organ would fall back silently."""
+from __future__ import annotations
+
+import json
+
+from devtools.e2e_live import run_live_lanes, scenarios
+from ouroboros.reviewer_slot_config import parse_reviewer_slots
+
+FAKE_KEY = "sk-or-v1-e2e-live-test-key-value-never-printed-0123456789"
+
+
+def test_the_stand_panel_parses_with_the_product_parser_and_names_three_families():
+    cfg = parse_reviewer_slots(scenarios.STAND_PANEL_SETTINGS["OUROBOROS_REVIEWER_SLOTS"])
+    triad = [(slot.target_id, slot.effort) for slot in cfg.triad]
+    assert triad == [("google/gemini-3.8-flash", "low"), ("openai/gpt-5.6-luna", "low"), ("deepseek/deepseek-v4-pro", "low")]
+    assert [(slot.target_id, slot.effort) for slot in cfg.scope] == [("deepseek/deepseek-v4-pro", "low")]
+    assert cfg.advisory is not None and cfg.advisory.target_id == "anthropic/claude-sonnet-5" and cfg.advisory.effort == "low"
+    assert {m.split("/")[0] for m, _ in triad} == {"google", "openai", "deepseek"}
+    assert scenarios.STAND_PANEL_SETTINGS["OUROBOROS_EFFORT_TASK"] == "medium"
+    assert scenarios.STAND_PANEL_SETTINGS["OUROBOROS_EFFORT_EVOLUTION"] == "medium"
+    assert scenarios.STAND_PANEL_SETTINGS["OUROBOROS_EFFORT_REVIEW"] == scenarios.STAND_PANEL_SETTINGS["OUROBOROS_EFFORT_SCOPE_REVIEW"] == "low"
+
+
+def test_paid_lanes_carry_the_panel_unless_production_panel_or_stub(monkeypatch):
+    monkeypatch.setenv("TMPDIR", "/tmp")
+    paid = run_live_lanes.effective_settings(run_live_lanes.parse_args(["--out", "/tmp/x"]), FAKE_KEY)
+    assert json.loads(paid["OUROBOROS_REVIEWER_SLOTS"]) == scenarios.STAND_REVIEW_PANEL
+    assert paid["OUROBOROS_EFFORT_REVIEW"] == "low" and paid["OUROBOROS_EFFORT_TASK"] == "medium"
+    production = run_live_lanes.effective_settings(run_live_lanes.parse_args(["--out", "/tmp/x", "--production-panel"]), FAKE_KEY)
+    assert not production.get("OUROBOROS_REVIEWER_SLOTS") and "OUROBOROS_EFFORT_REVIEW" not in production
+    stub = run_live_lanes.effective_settings(run_live_lanes.parse_args(["--stub", "--out", "/tmp/x"]), "")
+    assert stub.get("OUROBOROS_REVIEWER_SLOTS") != scenarios.STAND_PANEL_SETTINGS["OUROBOROS_REVIEWER_SLOTS"]
+    assert "OUROBOROS_EFFORT_REVIEW" not in stub


### PR DESCRIPTION
Fix-forward for the live E2E stand (no version bump). No product runtime file is touched; the product's default review panel and efforts for installs stay exactly as they are.

The owner's choice of 2026-09-06 for the stand: a cheaper review panel that still covers three model families. run3 on the default panel cost 141.63 dollars by the product ledger, 75 percent of it review and claude-opus-5 alone 39 percent.

Paid lanes now write OUROBOROS_REVIEWER_SLOTS, the one structured reviewer surface the product reads: triad google/gemini-3.8-flash, openai/gpt-5.6-luna, deepseek/deepseek-v4-pro; scope deepseek/deepseek-v4-pro (the scope pack is input-heavy, so the cheapest 1M-context input wins); advisory anthropic/claude-sonnet-5 (the Anthropic family stays in the loop where it is cheapest, an inspection rather than a packet); every reviewer at effort low; task and evolution efforts at medium. --production-panel runs the tree's own defaults instead, and the keyless stub lane keeps its loopback rows. The manifest's model snapshot already records OUROBOROS_REVIEWER_SLOTS, so the panel is part of every run's provenance; the CI e2e-live job inherits the panel through the same runner.

tests/test_e2e_live_panel.py parses the document with the product's own parser (a document it rejected would fall back to the default panel silently), pins the three families and the efforts, and pins the production-panel and stub exceptions. Local gates: 123 passed across the stand and docs modules, ruff --select F clean over the tree, regenerate_size_ratchet.py --check ok. A paid canary (one attempt of each scenario) on the merged tip follows and lands as a comment on PR #692 with the measured price.
