### PR TITLE
Include environment templates in skill review and publication

### DIFF
--- a/docs/CHECKLISTS.md
+++ b/docs/CHECKLISTS.md
@@ -406,7 +406,8 @@ review pack:
   `.idea`, `.vscode`, `.tox`, `__pycache__`, `node_modules`, `.DS_Store`
   (silently excluded — a byte-flip in a cache file does not
   invalidate a PASS review).
-- **Sensitive file shapes HARD-BLOCK the skill**: `.env*`, `.pem`,
+- **Sensitive file shapes HARD-BLOCK the skill**: `.env` and its explicitly
+  listed runtime variants in the shared `_SENSITIVE_NAMES` policy, `.pem`,
   `.key`, `.p12`, `.pfx`, `.jks`, `.keystore`, `credentials.json`,
   `service-account.json`, `secrets.yaml`, `secrets.json`,
   `.git-credentials`, `.netrc`, `.npmrc`, `.pypirc`. (Allowlist
@@ -418,6 +419,8 @@ review pack:
   tree. Rationale: silently excluding the file would leave it
   runtime-reachable via `open('.env').read()`, so a reviewed skill
   could still exfiltrate credentials the reviewer never saw.
+  `.env.example` is ordinary reviewed payload: its bytes remain in the
+  freshness hash and the existing publication scan.
 - Symlinks whose targets resolve outside `skill_dir` (confinement
   guard — otherwise a symlink to `/etc/passwd` would leak into the
   review pack sent to external reviewer models).

--- a/docs/CREATING_SKILLS.md
+++ b/docs/CREATING_SKILLS.md
@@ -1390,6 +1390,10 @@ manifest exists, ordinary discovery, preflight, and fresh review resume.
 Grouping directories, unknown or colliding identities, nested manifests, and
 path escapes are still refused; no parallel `external` payload is created.
 
+An ordinary `.env.example` is included in the payload hash, review and publication
+snapshot, including after ClawHub archive import. Its name does not exempt its
+contents from the existing publication scan.
+
 Only literal Betterleaks `high` confidence blocks an outbound publication call.
 `medium`, `low`, missing, and unknown confidence remain redacted warnings. For
 an intentional provider-shaped fixture, Ouroboros may add Betterleaks's

--- a/ouroboros/marketplace/fetcher.py
+++ b/ouroboros/marketplace/fetcher.py
@@ -33,7 +33,7 @@ _ALLOWED_EXTENSIONS = frozenset({
 
 _ALLOWED_BARE_BASENAMES = frozenset({
     "LICENSE", "COPYING", "NOTICE", "README", "CHANGELOG", "AUTHORS", "CONTRIBUTORS", "AGENTS",
-    ".gitignore", ".npmignore", ".editorconfig", ".gitattributes", ".eslintrc", ".prettierrc", ".nvmrc",
+    ".gitignore", ".npmignore", ".editorconfig", ".gitattributes", ".eslintrc", ".prettierrc", ".nvmrc", ".env.example",
 })
 
 

--- a/ouroboros/tools/review_file_pack.py
+++ b/ouroboros/tools/review_file_pack.py
@@ -59,8 +59,8 @@ _SENSITIVE_EXTENSIONS = frozenset({
 
 _SENSITIVE_NAMES = frozenset({
     ".env", ".env.local", ".env.production", ".env.staging",
-    # Env-file variants are credential-shaped even when named for examples/tests.
-    ".env.development", ".env.dev", ".env.test", ".env.example",
+    # Runtime env files remain credential-shaped; .env.example is reviewed content.
+    ".env.development", ".env.dev", ".env.test",
     "credentials.json", "service-account.json", "secrets.yaml", "secrets.json",
     "secrets.toml", "secrets.ini",
     "aws-credentials.json", "gcp-service-account.json",

--- a/tests/test_review_context_atlas.py
+++ b/tests/test_review_context_atlas.py
@@ -215,7 +215,7 @@ def test_atlas_devtools_manifest_only_unless_touched(tmp_path):
 
 
 def test_atlas_marks_sensitive_binary_oversized_and_vendored_files(tmp_path):
-    _write(tmp_path / ".env.example", "TOKEN=secret\n")
+    _write(tmp_path / ".env.production", "TOKEN=secret\n")
     (tmp_path / "image.png").write_bytes(b"\x89PNG\r\n\x00")
     _write(tmp_path / "script.min.js", "minified();\n")
     (tmp_path / "huge.py").write_bytes(b"x" * (1_048_576 + 1))
@@ -227,7 +227,7 @@ def test_atlas_marks_sensitive_binary_oversized_and_vendored_files(tmp_path):
     pack = compile_review_context_atlas(
         ReviewContextAtlasRequest(
             repo_dir=tmp_path,
-            tracked_paths=(".env.example", "image.png", "script.min.js", "huge.py", "normal.py"),
+            tracked_paths=(".env.production", "image.png", "script.min.js", "huge.py", "normal.py"),
             fixed_prompt_tokens=100,
             target_total_tokens=20_000,
             hard_total_tokens=25_000,
@@ -235,9 +235,9 @@ def test_atlas_marks_sensitive_binary_oversized_and_vendored_files(tmp_path):
     )
 
     coverage = _coverage(pack)
-    assert coverage[".env.example"]["disposition"] == "sensitive"
-    assert coverage[".env.example"]["sha256"] == ""
-    assert coverage[".env.example"]["size"] == 0
+    assert coverage[".env.production"]["disposition"] == "sensitive"
+    assert coverage[".env.production"]["sha256"] == ""
+    assert coverage[".env.production"]["size"] == 0
     assert coverage["image.png"]["disposition"] == "binary_media"
     assert coverage["script.min.js"]["disposition"] == "vendored_minified"
     assert coverage["huge.py"]["disposition"] == "oversized"

--- a/tests/test_skill_publish_scanner_real.py
+++ b/tests/test_skill_publish_scanner_real.py
@@ -175,7 +175,8 @@ def test_pinned_engine_version_ruleset_and_contextual_fixture_multiset(tmp_path)
     }
 
 
-def test_pinned_engine_high_warning_sentinel_and_redaction_contract(tmp_path):
+@pytest.mark.parametrize("filename", ["generated_corpus.py", ".env.example"])
+def test_pinned_engine_high_warning_sentinel_and_redaction_contract(tmp_path, filename):
     binary = _binary()
     provider_tail = "".join(("aB3dE5fG", "7hJ9kL2m", "N4pQ6rS8", "tV0wX2yZ", "5cD7"))
     provider_candidate = "".join(("gh", "p_", provider_tail))
@@ -206,7 +207,7 @@ def test_pinned_engine_high_warning_sentinel_and_redaction_contract(tmp_path):
     ).encode("utf-8")
 
     result = scan_named_bytes(
-        {"generated_corpus.py": materialized},
+        {filename: materialized},
         executable=_executable(binary),
         drive_root=tmp_path / "drive",
     )
@@ -229,7 +230,8 @@ def test_pinned_engine_high_warning_sentinel_and_redaction_contract(tmp_path):
         _safe_absence(generated, serialized)
 
 
-def test_pinned_engine_annotation_audit_and_derived_forced_ignore(tmp_path):
+@pytest.mark.parametrize("filename", ["annotated.py", ".env.example"])
+def test_pinned_engine_annotation_audit_and_derived_forced_ignore(tmp_path, filename):
     binary = _binary()
     candidate = "".join(
         (
@@ -245,12 +247,12 @@ def test_pinned_engine_annotation_audit_and_derived_forced_ignore(tmp_path):
     annotated = f"token = {candidate!r}  # betterleaks:allow\n".encode("utf-8")
 
     payload = scan_named_bytes(
-        {"annotated.py": annotated},
+        {filename: annotated},
         executable=_executable(binary),
         drive_root=tmp_path / "payload-drive",
     )
     derived = scan_named_bytes(
-        {"annotated.py": annotated},
+        {filename: annotated},
         executable=_executable(binary),
         drive_root=tmp_path / "derived-drive",
         honor_inline_allowances=False,

--- a/tests/test_skill_publish_snapshot.py
+++ b/tests/test_skill_publish_snapshot.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import dataclasses
 import hashlib
+import io
+import json
 import os
 import pathlib
+import zipfile
 
 import pytest
 
@@ -126,6 +129,47 @@ def test_snapshot_hash_parity_and_full_public_control_views(tmp_path):
     assert snapshot.manifest.install_specs() == [{"kind": "pip", "package": "example-package"}]
     with pytest.raises(dataclasses.FrozenInstanceError):
         snapshot.skill = "other"  # type: ignore[misc]
+
+
+def test_environment_template_roundtrips_import_list_review_and_publish(tmp_path, monkeypatch):
+    from ouroboros.marketplace.fetcher import stage
+    from ouroboros.skill_review_packs import _build_skill_file_packs
+    from ouroboros.tools.registry import ToolContext
+    from ouroboros.tools.skill_exec import _handle_list_skills
+    from ouroboros.tools.review_file_pack import build_touched_file_pack
+
+    drive = tmp_path / "drive"
+    payload = _write_skill(drive / "skills" / "external" / "demo")
+    template = payload / ".env.example"
+    content = b"APP_NAME=example\nAPI_TOKEN=\n"
+    template.write_bytes(content)
+    loaded = _reviewed_skill(payload, drive)
+    monkeypatch.setenv("OUROBOROS_SKILLS_REPO_PATH", "")
+    summary = json.loads(_handle_list_skills(ToolContext(repo_dir=tmp_path, drive_root=drive)))
+    row = next(item for item in summary["skills"] if item["name"] == "demo")
+    assert not row["load_error"] and row["content_hash"] == loaded.content_hash
+    packs = _build_skill_file_packs(payload, expected_content_hash=loaded.content_hash)
+    assert "### .env.example" in "\n".join(packs)
+    assert content.decode() in "\n".join(packs)
+    touched, omitted = build_touched_file_pack(payload, [".env.example"])
+    assert not omitted and "APP_NAME=example" in touched
+    snapshot = capture_skill_publish_snapshot(loaded)
+    assert snapshot.file(".env.example").content == content
+    assert ".env.example" in {item.path for item in snapshot.public_files}
+    archive = io.BytesIO()
+    with zipfile.ZipFile(archive, "w") as packed:
+        for item in snapshot.public_files:
+            packed.writestr(item.path, item.content)
+    staged = stage(archive.getvalue(), slug="demo", version="1.2.3")
+    try:
+        assert (staged.staging_dir / ".env.example").read_bytes() == content
+        assert compute_content_hash(staged.staging_dir) == snapshot.content_hash
+    finally:
+        staged.cleanup()
+    template.write_bytes(content + b"APP_MODE=development\n")
+    assert loaded.review.is_stale_for(compute_content_hash(payload))
+    with pytest.raises(SkillPublishSnapshotError, match="snapshot_review_stale"):
+        capture_skill_publish_snapshot(loaded)
 
 
 def test_manifest_precedence_and_each_inventory_file_read_once(tmp_path, monkeypatch):
@@ -297,14 +341,15 @@ def test_snapshot_fails_closed_on_sensitive_or_unreadable_payload(tmp_path, monk
 
 
 @pytest.mark.skipif(os.name == "nt", reason="symlink creation is not portable on Windows")
-def test_snapshot_excludes_symlink_escape(tmp_path):
+@pytest.mark.parametrize("name", ["escape.txt", ".env.example"])
+def test_snapshot_excludes_symlink_escape(tmp_path, name):
     drive_root = tmp_path / "drive"
     skill_dir = _write_skill(drive_root / "skills" / "external" / "demo")
     outside = tmp_path / "outside.txt"
     outside.write_bytes(b"outside")
-    os.symlink(outside, skill_dir / "escape.txt")
+    os.symlink(outside, skill_dir / name)
     loaded = _reviewed_skill(skill_dir, drive_root)
 
     snapshot = capture_skill_publish_snapshot(loaded)
 
-    assert "escape.txt" not in {item.path for item in snapshot.full_files}
+    assert name not in {item.path for item in snapshot.full_files}


### PR DESCRIPTION
Skills can include an ordinary .env.example in import, listing, review and publication. Its full contents participate in the freshness hash and publication scan, so changing the template invalidates an old review. Runtime credential files and real secrets keep the existing checks.

The follow-up synchronizes the skill review checklist with this behavior using the exact text approved by the owner. It closes the documentation inconsistency found during the initial review without adding another scanner or permission flow.

Validation covers template round trips, stale reviews, runtime credential rejection, real Betterleaks rejection and audited allowances. The combined startup/template candidate also passed 210 targeted tests and the repository's mechanical checks. Final synthesis passed independent Astra and Fable review (31 PASS each) and scope review (8 PASS). The exact combined candidate de389b1b passed the complete Linux, macOS and Windows CI matrix: https://github.com/razzant/ouroboros/actions/runs/34162441150.

This completes the template fix found during the larger skill application acceptance for #656. No version, tag or release change.

An earlier standalone run timed out in an unchanged Telegram test before its fake server started; the same test passed in the final combined quick and full suites. The triggering condition remains unconfirmed, and its historical failure is retained.
