### PR TITLE
fix(context): degrade scratchpad section when it exceeds the context budget

### DIFF
--- a/ouroboros/context.py
+++ b/ouroboros/context.py
@@ -13,8 +13,10 @@ from ouroboros.config import get_context_mode
 from ouroboros.context_budget import (
     LARGE_CONTEXT_SECTION_CHARS,
     MAX_RECENT_CHAT_TAIL,
+    SCRATCHPAD_MAX_CONTENT_CHARS,
     SCRATCHPAD_SECTION_BUDGET_CHARS,
 )
+from ouroboros.memory import _SCRATCHPAD_MAX_BLOCKS
 from ouroboros.context_fit import (
     ContextCore as _ContextCore,
 )
@@ -757,6 +759,90 @@ def _warn_if_over_budget(name: str, content: str) -> None:
         log.warning("Context section '%s' exceeds budget: %d chars > %d", name, len(content), budget)
 
 
+def _render_scratchpad_for_context(memory: "Memory", budget: int) -> str:
+    """Render the scratchpad SECTION BODY for context, with block-boundary degradation.
+
+    ibl-2b09abdadd25: when scratchpad.md exceeds the consumer budget, return
+    the newest WHOLE blocks that fit (drop oldest-first) instead of the raw
+    file. Always retain the single newest block (even if it alone exceeds
+    budget) paired with an in-band gap marker (BIBLE P1 — never silent).
+    Falls back to raw markdown when scratchpad_blocks.json is absent/empty
+    (legacy flat scratchpad) so a missing source-switch does not introduce
+    silent amnesia. Block-boundary cuts only — never mid-block, never
+    mid-string. The caller wraps the returned body with the section header
+    ("## Scratchpad (from `memory/scratchpad.md` ...)") inline, same as before.
+    """
+    raw = memory.load_scratchpad()
+    if len(raw) <= budget:
+        return raw
+
+    blocks = memory.load_scratchpad_blocks()
+    if not blocks:
+        # Legacy fallback: scratchpad.md has content but blocks.json is
+        # missing or unparseable. Return raw unchanged; we cannot trim by
+        # block. _has_retired_flat_scratchpad_without_blocks elsewhere
+        # already prevents NEW writes on this state.
+        return raw
+
+    # Render each block the way _write_scratchpad_markdown would
+    # (ouroboros/memory.py:_write_scratchpad_markdown).
+    def _render_block(b: Dict[str, Any]) -> str:
+        ts = str(b.get("ts", ""))[:16]
+        source = b.get("source", "?")
+        content = b.get("content", "")
+        out = f"### [{ts} — {source}]\n{content}\n\n---\n"
+        metadata = b.get("metadata") if isinstance(b.get("metadata"), dict) else {}
+        source_ref = metadata.get("source_ref") if isinstance(metadata.get("source_ref"), dict) else {}
+        entry_id = str(source_ref.get("entry_id") or "")
+        if entry_id:
+            out += (
+                "Exact replaced blocks: `read_file(root='runtime_data', "
+                "path='memory/scratchpad_journal.jsonl', start_line=1)`; "
+                f"locate `entry_id={entry_id}`.\n\n"
+            )
+        return out
+
+    rendered_blocks = [_render_block(b) for b in blocks]
+    n_total = len(blocks)
+
+    def _build(kept_rendered: List[str]) -> str:
+        n = len(kept_rendered)
+        parts = [f"## Scratchpad (working memory — {n}/{_SCRATCHPAD_MAX_BLOCKS} blocks)\n\n"]
+        if memory.journal_path().exists():
+            parts.append(
+                "Exact retired/replaced source blocks remain readable with "
+                "`read_file(root='runtime_data', "
+                "path='memory/scratchpad_journal.jsonl', start_line=1)`.\n\n"
+            )
+        parts.extend(kept_rendered)
+        return "".join(parts)
+
+    # Find the largest k (newest-first kept) such that the section fits.
+    n_kept = n_total
+    while n_kept > 1:
+        section = _build(rendered_blocks[-n_kept:])
+        if len(section) <= budget:
+            break
+        n_kept -= 1
+    # Always retain at least the single newest, even if it alone exceeds
+    # budget (BIBLE P1 — never silent, paired with the gap marker below).
+    n_kept = max(1, n_kept)
+    section = _build(rendered_blocks[-n_kept:])
+    omitted = n_total - n_kept
+    # Fire the gap marker whenever older blocks were dropped OR the retained
+    # newest block(s) alone still exceed budget (n_kept forced to 1 above) —
+    # both are a silent-looking truncation from the consumer's point of view
+    # and BIBLE P1 requires either be disclosed in-band, not just logged.
+    if omitted > 0 or len(section) > budget:
+        section += (
+            f"\n⚠️ [budget gap: {omitted} block(s) omitted from this context build "
+            f"for size; exact retired/replaced blocks remain readable with "
+            "`read_file(root='runtime_data', "
+            "path='memory/scratchpad_journal.jsonl', start_line=1)`.]\n"
+        )
+    return section
+
+
 def build_memory_sections(memory: Memory, partition: str = "all", durable_dialogue_gaps_out: Optional[List[Dict[str, Any]]] = None) -> List[str]:
     sections = []
 
@@ -765,8 +851,13 @@ def build_memory_sections(memory: Memory, partition: str = "all", durable_dialog
 
     if include_volatile:
         scratchpad_raw = memory.load_scratchpad()
+        # WARNING is preserved on the RAW (pre-trim) value: it signals the rot
+        # class is present, even when the helper trims it down for the consumer.
+        # ibl-2b09abdadd25 closes the gap where the trimmed output alone would
+        # never re-fire the warning.
         _warn_if_over_budget("scratchpad", scratchpad_raw)
-        sections.append("## Scratchpad (from `memory/scratchpad.md` — already loaded; do not re-read via read_file(root='runtime_data', path='memory/scratchpad.md'))\n\n" + scratchpad_raw)
+        scratchpad_body = _render_scratchpad_for_context(memory, SCRATCHPAD_SECTION_BUDGET_CHARS)
+        sections.append("## Scratchpad (from `memory/scratchpad.md` — already loaded; do not re-read via read_file(root='runtime_data', path='memory/scratchpad.md'))\n\n" + scratchpad_body)
 
     if include_stable:
         identity_raw = memory.load_identity()

--- a/ouroboros/context.py
+++ b/ouroboros/context.py
@@ -13,7 +13,6 @@ from ouroboros.config import get_context_mode
 from ouroboros.context_budget import (
     LARGE_CONTEXT_SECTION_CHARS,
     MAX_RECENT_CHAT_TAIL,
-    SCRATCHPAD_MAX_CONTENT_CHARS,
     SCRATCHPAD_SECTION_BUDGET_CHARS,
 )
 from ouroboros.memory import _SCRATCHPAD_MAX_BLOCKS

--- a/ouroboros/context_budget.py
+++ b/ouroboros/context_budget.py
@@ -213,6 +213,18 @@ SCRATCHPAD_SECTION_BUDGET_CHARS = 90_000
 SCRATCHPAD_BLOAT_WARN_CHARS = 50_000
 # Block-storage consolidation trigger (consolidator compresses oldest blocks).
 SCRATCHPAD_CONSOLIDATION_THRESHOLD_CHARS = 30_000
+# Source-side content cap for Memory.append_scratchpad_block (ibl-2b09abdadd25).
+# SINGLE SOURCE OF TRUTH for the new content cap; obeys the ordering invariant
+#   SCRATCHPAD_CONSOLIDATION_THRESHOLD_CHARS (30_000)
+#     < SCRATCHPAD_MAX_CONTENT_CHARS (60_000)
+#     <= SCRATCHPAD_SECTION_BUDGET_CHARS (90_000) - RENDERING_HEADROOM
+# Pinned at 60_000 so the consolidator (trigger at >30_000) still fires before
+# this cap kicks in, AND the rendered section's framing (header + per-block
+# '### [...]' / '---' / journal-pointer lines) fits under the section budget
+# at the 10-block cap. Measured in characters (len(str)), matching the family
+# naming convention. The count cap (_SCRATCHPAD_MAX_BLOCKS in ouroboros/memory.py)
+# is AND'd with this cap (single-pass eviction), not replaced by it.
+SCRATCHPAD_MAX_CONTENT_CHARS = 60_000
 
 # --- Hot-store growth thresholds (health invariant; bytes) -------------------
 # Deterministic tripwires for the append-only stores whose interactive readers

--- a/ouroboros/memory.py
+++ b/ouroboros/memory.py
@@ -230,24 +230,38 @@ class Memory:
         if metadata:
             new_block["metadata"] = dict(metadata)
 
+        # Lazy import keeps ouroboros.context_budget optional at import time,
+        # matching ouroboros/consolidator.py:~674.
+        from ouroboros.context_budget import SCRATCHPAD_MAX_CONTENT_CHARS
+
         try:
             def _append(blocks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 updated = [*blocks, new_block]
-                if len(updated) <= _SCRATCHPAD_MAX_BLOCKS:
-                    return updated
-                evicted = updated[:-_SCRATCHPAD_MAX_BLOCKS]
-                for eb in evicted:
+                # Evict oldest-first (FIFO) until BOTH caps are satisfied:
+                #   - _SCRATCHPAD_MAX_BLOCKS (count cap)
+                #   - SCRATCHPAD_MAX_CONTENT_CHARS (content-size cap, ibl-2b09abdadd25:
+                #     a count-only cap still lets N blocks' combined content run
+                #     well past the context section's char budget)
+                # The block we just appended (updated[-1]) is never an
+                # eviction target. Each eviction is journalled with a
+                # source_ref and FAILS HARD if the journal write does not
+                # land (no silent amputation, BIBLE P1).
+                while len(updated) > 1 and (
+                    len(updated) > _SCRATCHPAD_MAX_BLOCKS
+                    or sum(len(b.get("content", "")) for b in updated) > SCRATCHPAD_MAX_CONTENT_CHARS
+                ):
+                    evicted_block = updated.pop(0)
                     written = append_jsonl(self.journal_path(), {
                         "ts": utc_now_iso(),
                         "type": "block_evicted",
-                        "evicted_block_ts": eb.get("ts", ""),
-                        "evicted_block_source": eb.get("source", ""),
-                        "evicted_block_content": eb.get("content", ""),
+                        "evicted_block_ts": evicted_block.get("ts", ""),
+                        "evicted_block_source": evicted_block.get("source", ""),
+                        "evicted_block_content": evicted_block.get("content", ""),
                         "source_ref": self.scratchpad_journal_source_ref(),
                     })
                     if not written:
                         raise RuntimeError("scratchpad eviction journal write failed")
-                return updated[-_SCRATCHPAD_MAX_BLOCKS:]
+                return updated
 
             self.mutate_scratchpad_blocks(_append)
         except Exception:

--- a/ouroboros/size_ratchet_manifest.py
+++ b/ouroboros/size_ratchet_manifest.py
@@ -135,6 +135,7 @@ BAND_PATHS = {
     "ouroboros/loop_tool_execution.py": None,
     "ouroboros/marketplace/ouroboroshub.py": "Entered the band from 373 lines: the hubflow sprint added the adopt transaction (eligibility prelude, CAS re-verification, move-aside + state-quintet snapshot, verified rollback with per-step error collection, retention finalize) beside the existing install/update flows (hubflow sprint, adopt-in-ouroboroshub owner decision D4).",
     "ouroboros/mcp_client.py": "F3.1 typed-organ producer cutover (D05 entry 7b) plus E5+s2r2 (#447): the MCP transport keeps the SDK-owned error bit as a typed ToolResult, follows nextCursor pagination with injective 12-hex slugs, and discloses collision/pagination omissions; grew into the band from 984 lines, shrink-only otherwise.",
+    "ouroboros/memory.py": "ibl-2b09abdadd25: scratchpad content-size cap added alongside the existing block-count cap in append_scratchpad_block's eviction loop",
     "ouroboros/observability.py": "Entered the band from 820 lines: child task copy-back now promotes only promised observability CAS manifests/blobs and task-owned source handles into canonical storage before headless GC, with typed unavailable gaps and retry metadata.",
     "ouroboros/preflight_runner.py": None,
     "ouroboros/projects_registry.py": "Entered the band from 999 lines: the stuck-Working liveness sprint homed the project-thread membership lens (mtime-cached) and its broadcast-choke marker here \u2014 registry semantics belong to the registry, not to message_bus.",

--- a/tests/test_scratchpad_byte_cap.py
+++ b/tests/test_scratchpad_byte_cap.py
@@ -1,0 +1,267 @@
+"""Regression tests for ibl-2b09abdadd25: scratchpad content cap + degradation.
+
+Two layers covered:
+
+1. **Source-side content cap** (ouroboros/memory.py::Memory.append_scratchpad_block).
+   SCRATCHPAD_MAX_CONTENT_CHARS (60_000, declared in ouroboros/context_budget.py
+   alongside the existing scratchpad thresholds) bounds total block content.
+   The cap is AND'd with the count cap (_SCRATCHPAD_MAX_BLOCKS=10) in a single
+   pass: while EITHER cap is violated, evict the oldest ELIGIBLE (non-pinned)
+   block. Each eviction is journaled as ``block_evicted`` and FAILS HARD on
+   journal-write failure (existing ibl-3d7b7b7d5dc9 contract preserved).
+
+2. **Consumer-side degradation**
+   (ouroboros/context.py::_render_scratchpad_for_context).
+   When the raw scratchpad exceeds SCRATCHPAD_SECTION_BUDGET_CHARS
+   (90_000) AND scratchpad_blocks.json has blocks: render the newest WHOLE
+   blocks that fit, drop oldest-first, ALWAYS retain the single newest
+   (even if it alone exceeds), and append an in-band gap marker (BIBLE P1
+   — omission is never silent). When scratchpad_blocks.json is absent /
+   empty (legacy flat scratchpad), return raw unmodified (legacy fallback
+   so the source switch introduces no silent amnesia).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ouroboros.context import _render_scratchpad_for_context
+from ouroboros.context_budget import (
+    SCRATCHPAD_MAX_CONTENT_CHARS,
+    SCRATCHPAD_SECTION_BUDGET_CHARS,
+)
+from ouroboros.memory import Memory, _SCRATCHPAD_MAX_BLOCKS
+
+
+# ---------- helpers ----------------------------------------------------------
+
+
+def _mem(tmp_path):
+    drive = tmp_path / "data"
+    (drive / "memory").mkdir(parents=True)
+    (drive / "logs").mkdir(parents=True)
+    mem = Memory(drive_root=drive)
+    mem.ensure_files()
+    return mem
+
+
+def _blocks(mem):
+    bp = mem.scratchpad_blocks_path()
+    return json.loads(bp.read_text(encoding="utf-8")) if bp.exists() else []
+
+
+def _journal_types(mem):
+    jp = mem.journal_path()
+    if not jp.exists():
+        return []
+    out = []
+    for line in jp.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            out.append(json.loads(line).get("type"))
+    return out
+
+
+def _force_oversized_via_json(tmp_path, n_blocks=4, each_chars=20_000):
+    """Write scratchpad_blocks.json with n blocks each containing `each_chars`
+    of content, bypassing the source-side cap. Lets the test exercise the
+    consumer-side degradation path with a scratchpad that exceeded the cap
+    by some other route (legacy import, corruption recovery, future
+    regressions that bypass the source cap)."""
+    mem = _mem(tmp_path)
+    bp = mem.scratchpad_blocks_path()
+    blocks = [
+        {
+            "ts": f"2026-09-01T12:0{i}:00+00:00",
+            "source": "forced",
+            "content": "x" * each_chars,
+        }
+        for i in range(n_blocks)
+    ]
+    bp.write_text(json.dumps(blocks), encoding="utf-8")
+    # Regenerate the scratchpad.md so load_scratchpad returns the oversized file.
+    mem._write_scratchpad_markdown(blocks)
+    return mem
+
+
+# ---------- source-side content cap ------------------------------------------
+
+
+def test_content_cap_evicts_oldest_when_under_count_cap(tmp_path):
+    """2 blocks of 40_000 chars each = 80_000 total > 60_000 cap. Count cap
+    not violated (2 < 10), so eviction is content-driven only."""
+    mem = _mem(tmp_path)
+    mem.append_scratchpad_block("a" * 40_000, source="task")
+    mem.append_scratchpad_block("b" * 40_000, source="task")
+    kept = _blocks(mem)
+    # Oldest (40_000 a's) evicted to satisfy content cap.
+    assert len(kept) == 1
+    assert kept[0]["content"].startswith("b")
+    assert "block_evicted" in _journal_types(mem)
+
+
+def test_content_cap_evicts_until_under_both_caps(tmp_path):
+    """5 blocks of 20_000 = 100_000 > 60_000; count cap not violated (5 < 10).
+    Eviction should leave enough blocks to satisfy BOTH caps."""
+    mem = _mem(tmp_path)
+    for i in range(5):
+        mem.append_scratchpad_block(("c" * 20_000) + f"-{i}", source="task")
+    kept = _blocks(mem)
+    total = sum(len(b["content"]) for b in kept)
+    assert total <= SCRATCHPAD_MAX_CONTENT_CHARS
+    assert len(kept) <= _SCRATCHPAD_MAX_BLOCKS
+    # The newest block is always retained.
+    assert kept[-1]["content"].endswith("-4")
+
+
+def test_content_cap_with_count_cap_active_evicts_in_single_pass(tmp_path):
+    """12 blocks of 10_000 = 120_000; both caps violated simultaneously.
+    Single-pass eviction should leave us under BOTH caps."""
+    mem = _mem(tmp_path)
+    for i in range(12):
+        mem.append_scratchpad_block(("d" * 10_000) + f"-{i}", source="task")
+    kept = _blocks(mem)
+    assert len(kept) <= _SCRATCHPAD_MAX_BLOCKS
+    total = sum(len(b["content"]) for b in kept)
+    assert total <= SCRATCHPAD_MAX_CONTENT_CHARS
+    # Newest three must be the last three we wrote.
+    assert kept[-1]["content"].endswith("-11")
+    assert kept[-2]["content"].endswith("-10")
+    assert kept[-3]["content"].endswith("-9")
+
+
+def test_content_cap_respects_pinning(tmp_path):
+    """A pinned block is exempt from BOTH caps, consistent with ibl-3d7b7b7d5dc9.
+    When the only eligible victims are pinned, the list grows past both caps."""
+    mem = _mem(tmp_path)
+    pinned = mem.append_scratchpad_block("p" * 50_000, source="task")
+    mem.pin_scratchpad_block(pinned["ts"])
+    # This block is so big that even with the pinned one removed, we'd need
+    # to evict many. Pin the second too so both are exempt.
+    pinned2 = mem.append_scratchpad_block("q" * 50_000, source="task")
+    mem.pin_scratchpad_block(pinned2["ts"])
+    # One more block pushes us over the cap.
+    mem.append_scratchpad_block("r" * 50_000, source="task")
+    kept = _blocks(mem)
+    # Two pinned blocks + one new = 3; both are exempt from eviction.
+    assert len(kept) == 3
+    pinned_tss = {pinned["ts"], pinned2["ts"]}
+    assert pinned_tss.issubset({b["ts"] for b in kept})
+
+
+def test_content_cap_does_not_evict_when_already_under(tmp_path):
+    """Sanity: small blocks don't trigger content-cap eviction."""
+    mem = _mem(tmp_path)
+    for i in range(3):
+        mem.append_scratchpad_block(f"small block {i}", source="task")
+    kept = _blocks(mem)
+    assert len(kept) == 3
+    assert "block_evicted" not in _journal_types(mem)
+
+
+# ---------- consumer-side degradation ----------------------------------------
+
+
+def test_render_scratchpad_passes_through_when_under_budget(tmp_path):
+    """If the raw scratchpad fits, the helper returns the raw markdown
+    unchanged (the trim path is a no-op)."""
+    mem = _mem(tmp_path)
+    mem.append_scratchpad_block("a normal block", source="task")
+    raw = mem.load_scratchpad()
+    # Use a budget larger than raw — nothing to trim.
+    body = _render_scratchpad_for_context(mem, budget=SCRATCHPAD_SECTION_BUDGET_CHARS)
+    assert body == raw
+
+
+def test_render_scratchpad_trims_with_gap_marker(tmp_path):
+    """When the raw exceeds budget AND blocks.json has blocks, return the
+    newest whole blocks that fit, drop oldest, and append the in-band gap
+    marker (BIBLE P1)."""
+    # 4 * 25_000 = 100_000 content chars (+ per-block framing overhead)
+    # comfortably exceeds the 90_000 section budget; dropping just the
+    # oldest block brings 3 * 25_000 = 75_000 (+overhead) back under it.
+    mem = _force_oversized_via_json(tmp_path, n_blocks=4, each_chars=25_000)
+    raw = mem.load_scratchpad()
+    assert len(raw) > SCRATCHPAD_SECTION_BUDGET_CHARS
+    # Tight budget forces the helper to drop oldest blocks.
+    body = _render_scratchpad_for_context(mem, budget=SCRATCHPAD_SECTION_BUDGET_CHARS)
+    assert len(body) < len(raw)
+    assert "budget gap" in body
+    assert "omitted" in body
+    # Newest block is retained (its content shows up in the rendered body).
+    # _render_block truncates ts to [:16] (drops seconds/offset), matching
+    # _write_scratchpad_markdown's own rendering convention.
+    assert "2026-09-01T12:03" in body
+
+
+def test_render_scratchpad_legacy_fallback_returns_raw(tmp_path):
+    """Legacy flat scratchpad.md with no scratchpad_blocks.json: the helper
+    returns the raw markdown unchanged. This is the source-switch fallback
+    (no silent amnesia)."""
+    mem = _mem(tmp_path)
+    # Force a legacy state: scratchpad.md exists, blocks.json absent.
+    mem.scratchpad_path().write_text(
+        "## Scratchpad (legacy flat)\n\nSome legacy note here.\n",
+        encoding="utf-8",
+    )
+    raw = mem.load_scratchpad()
+    body = _render_scratchpad_for_context(mem, budget=len(raw) - 100)
+    # raw is bigger than budget, but no blocks to trim by — must return raw.
+    assert body == raw
+
+
+def test_render_scratchpad_always_retains_newest_even_if_over_budget(tmp_path):
+    """When the single newest block alone exceeds the budget, retain it
+    anyway and append the gap marker (BIBLE P1 — never silent)."""
+    mem = _mem(tmp_path)
+    # Single huge block: content alone is bigger than the budget.
+    mem.append_scratchpad_block("z" * 200_000, source="task")
+    body = _render_scratchpad_for_context(mem, budget=1_000)
+    # The newest block IS retained even though it exceeds.
+    assert "z" in body
+    # And the gap marker fires.
+    assert "budget gap" in body
+
+
+def test_render_scratchpad_block_boundary_invariant(tmp_path):
+    """Block-boundary cuts only — no mid-block, no mid-string truncation.
+    Verify that no rendered block's content is split across the budget."""
+    mem = _force_oversized_via_json(tmp_path, n_blocks=3, each_chars=30_000)
+    body = _render_scratchpad_for_context(mem, budget=SCRATCHPAD_SECTION_BUDGET_CHARS)
+    # Find each block marker in the body and confirm its content begins with
+    # the canned "xxxx" content (full block, not a truncated slice).
+    import re
+    for m in re.finditer(r"### \[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2} — forced\]\n(x+)", body):
+        # Each retained block has at least one 'x' before the trailing \n.
+        block_xs = m.group(1)
+        assert len(block_xs) > 0
+        # And the block boundary ends with our separator.
+        assert "---" in body[m.end():m.end() + 10]
+
+
+def test_render_scratchpad_no_mid_string_truncation(tmp_path):
+    """No block is sliced mid-content. Each retained block must contain its
+    FULL canned payload (all-x's)."""
+    mem = _force_oversized_via_json(tmp_path, n_blocks=4, each_chars=25_000)
+    body = _render_scratchpad_for_context(mem, budget=SCRATCHPAD_SECTION_BUDGET_CHARS)
+    # Each rendered block should contain a long run of 'x's (not a slice).
+    import re
+    long_x = re.search(r"x{1000,}", body)
+    assert long_x is not None
+    # The gap marker should be present (some blocks omitted).
+    assert "budget gap" in body
+
+
+# ---------- ordering invariant -----------------------------------------------
+
+
+def test_constant_ordering_holds():
+    """The invariant asserted in ouroboros/context_budget.py must hold at
+    runtime: SCRATCHPAD_CONSOLIDATION_THRESHOLD_CHARS < SCRATCHPAD_MAX_CONTENT_CHARS
+    <= SCRATCHPAD_SECTION_BUDGET_CHARS - rendering headroom."""
+    from ouroboros.context_budget import (
+        SCRATCHPAD_CONSOLIDATION_THRESHOLD_CHARS,
+    )
+    assert SCRATCHPAD_CONSOLIDATION_THRESHOLD_CHARS < SCRATCHPAD_MAX_CONTENT_CHARS
+    assert SCRATCHPAD_MAX_CONTENT_CHARS <= SCRATCHPAD_SECTION_BUDGET_CHARS - 1_000

--- a/tests/test_scratchpad_byte_cap.py
+++ b/tests/test_scratchpad_byte_cap.py
@@ -24,8 +24,6 @@ from __future__ import annotations
 
 import json
 
-import pytest
-
 from ouroboros.context import _render_scratchpad_for_context
 from ouroboros.context_budget import (
     SCRATCHPAD_MAX_CONTENT_CHARS,

--- a/tests/test_scratchpad_byte_cap.py
+++ b/tests/test_scratchpad_byte_cap.py
@@ -131,25 +131,6 @@ def test_content_cap_with_count_cap_active_evicts_in_single_pass(tmp_path):
     assert kept[-3]["content"].endswith("-9")
 
 
-def test_content_cap_respects_pinning(tmp_path):
-    """A pinned block is exempt from BOTH caps, consistent with ibl-3d7b7b7d5dc9.
-    When the only eligible victims are pinned, the list grows past both caps."""
-    mem = _mem(tmp_path)
-    pinned = mem.append_scratchpad_block("p" * 50_000, source="task")
-    mem.pin_scratchpad_block(pinned["ts"])
-    # This block is so big that even with the pinned one removed, we'd need
-    # to evict many. Pin the second too so both are exempt.
-    pinned2 = mem.append_scratchpad_block("q" * 50_000, source="task")
-    mem.pin_scratchpad_block(pinned2["ts"])
-    # One more block pushes us over the cap.
-    mem.append_scratchpad_block("r" * 50_000, source="task")
-    kept = _blocks(mem)
-    # Two pinned blocks + one new = 3; both are exempt from eviction.
-    assert len(kept) == 3
-    pinned_tss = {pinned["ts"], pinned2["ts"]}
-    assert pinned_tss.issubset({b["ts"] for b in kept})
-
-
 def test_content_cap_does_not_evict_when_already_under(tmp_path):
     """Sanity: small blocks don't trigger content-cap eviction."""
     mem = _mem(tmp_path)


### PR DESCRIPTION
## What

\`ouroboros/context.py::_warn_if_over_budget\` only LOGS a warning when the scratchpad context section exceeds \`SCRATCHPAD_SECTION_BUDGET_CHARS\` (90,000 chars) — the raw file still gets shipped whole into every context build. Root cause: \`_SCRATCHPAD_MAX_BLOCKS\` is a block-COUNT cap only, with no byte-size cap, so N blocks can still add up to well past the char budget (observed 213KB / 2.4x budget in production).

## Fix

- **\`ouroboros/context_budget.py\`**: new \`SCRATCHPAD_MAX_CONTENT_CHARS = 60_000\` — a source-side content cap for \`Memory.append_scratchpad_block\`, ANDed with the existing block-count cap.
- **\`ouroboros/memory.py\`**: \`append_scratchpad_block\` now evicts oldest-first (FIFO) until BOTH the count cap and the new content cap are satisfied, not just the count cap.
- **\`ouroboros/context.py\`**: new \`_render_scratchpad_for_context\` degrades the CONSUMER side too — when the scratchpad section still exceeds budget (e.g. from a legacy/imported state that predates the source-side cap), it keeps the newest whole blocks that fit (block-boundary cuts only, never mid-string), always retains at least the single newest block, and appends an in-band gap-marker disclosure whenever older blocks were dropped or the retained block(s) alone still exceed budget — the raw \`_warn_if_over_budget\` log is preserved so the underlying condition stays visible.
- **\`tests/test_scratchpad_byte_cap.py\`** (new): covers both the source-side content cap and the render-side degrade path (legacy fallback, gap marker on drop, gap marker on the always-retained-newest-alone case, block-boundary/no-mid-string invariants).

## Notes for this branch

This fork's block-pinning feature (\`Memory.pin_scratchpad_block\`) doesn't exist on \`ouroboros\` upstream, so the eviction loop here is plain FIFO (\`pop(0)\`) rather than pin-aware; the corresponding pinning test was dropped from the cherry-picked test file for the same reason. Everything else is unchanged from the original fix.

## Verification

- \`tests/test_scratchpad_byte_cap.py\`, \`tests/test_memory_blocks.py\`, \`tests/test_context.py\`, \`tests/test_memory_tool_hints.py\` all green on this branch.
- Broader \`-k "context or memory or scratchpad"\` sweep green; the one failure (\`test_context_mode_guard_does_not_block_readonly_diagnostics\`) is pre-existing/unrelated — needs a configured safety LLM provider, fails identically on a clean upstream checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZGh7G7f2g7w8KkQW74Z4V