### PR TITLE
Pin Claudexor 3.10.1 to prevent background AGY sign-in

### DIFF
--- a/ouroboros/claudexor_runtime_pin.json
+++ b/ouroboros/claudexor_runtime_pin.json
@@ -1,12 +1,12 @@
 {
  "schema_version": 1,
  "release": {
-  "version": "3.10.0",
-  "build_sha": "671e2b140cba5476f3dca1cd6ea6a19793dc6a93",
+  "version": "3.10.1",
+  "build_sha": "0caf16a714f4eb8933e1885e3e2a5a40abd3be11",
   "protocol_major": 3,
-  "archive_url": "https://github.com/razzant/claudexor/releases/download/v3.10.0/claudexor-runtime-3.10.0.tar.gz",
-  "sha256": "8c99641f87354901ab9d238c66974ea7b077d36cd0a7df598585c642466d396b",
-  "size_bytes": 7684620,
+  "archive_url": "https://github.com/razzant/claudexor/releases/download/v3.10.1/claudexor-runtime-3.10.1.tar.gz",
+  "sha256": "d2a5422752e22f55266454514113b1614c3f1eb71a4c1bc777cf04452f411ddc",
+  "size_bytes": 7684246,
   "node_version": "24.16.0",
   "node_artifacts": {
    "darwin-arm64": {

--- a/tests/test_claudexor_runtime_delivery.py
+++ b/tests/test_claudexor_runtime_delivery.py
@@ -154,7 +154,7 @@ def test_tracked_pin_names_a_cli_capable_release():
     of this proposal converged on while the pin was still pre-CLI 3.6.0)."""
     pin = runtime.load_runtime_pin()
     assert pin is not None
-    assert pin.version == "3.10.0"
+    assert pin.version == "3.10.1"
     assert pin.cli_entrypoint == "claudexor.bundle.cjs"
 
 


### PR DESCRIPTION
## Summary

Pin the managed Claudexor runtime to [3.10.1](https://github.com/razzant/claudexor/releases/tag/v3.10.1), build `0caf16a714f4eb8933e1885e3e2a5a40abd3be11`.

The release fixes unrequested AGY interactive sign-in from background `/model` and `/quota` diagnostics, preserves current refresh failures beside stale quota, and includes the reviewed Windows ConPTY standard-handle correction. The upstream code and delta reviews are published in [Claudexor #279](https://github.com/razzant/claudexor/pull/279) and [#280](https://github.com/razzant/claudexor/pull/280).

## Scope

- Update the engine version, build SHA, archive URL, SHA256 and size in the existing runtime pin.
- Update the expected version in the existing runtime-delivery test.
- Preserve protocol 3, Node 24.16.0, all five Node archive descriptors, entrypoints, and every Ouroboros release-version carrier.

Non-goals: no account/authentication changes, new polling policy, runtime adoption/restart changes, new runtime code, or Ouroboros version bump. The diff is two files, 6 insertions and 6 deletions.

## Verification

- Published runtime archive: 7,684,246 bytes, SHA256 `d2a5422752e22f55266454514113b1614c3f1eb71a4c1bc777cf04452f411ddc`.
- Both downloaded signed release manifests byte-match the sealed candidate signatures and pass the upstream verifiers against the final build and exact archives. Published SHA256SUMS verifies all 11 listed payloads.
- Upstream [candidate](https://github.com/razzant/claudexor/actions/runs/34248342889) and [publish](https://github.com/razzant/claudexor/actions/runs/34251962112) workflows succeeded. The first publish smoke attempt hit npm tarball propagation 404s before CLI startup; one unchanged failed-jobs rerun passed. All 31 npm packages resolve latest/next to 3.10.1 with provenance.
- Focused runtime, daemon, passive status, custody, startup, restart and reconnect tests: 285 passed, producer exit 0. One existing Starlette deprecation warning; no leaked test threads.
- Runtime cache fetch and `--verify-only`: producer exit 0.
- `python scripts/claudexor_platform_smoke.py --managed-runtime --lane fixture --max-seconds 300`: producer exit 0 using a disposable, credential-free data root and the exact verified engine/Node archives. Engine 3.10.1, exact build above, protocol 3, Node 24.16.0; primary artifact read to EOF (33/33 bytes), fixture edit confirmed, graceful daemon stop confirmed, test PID gone.
- `git diff --check`: pass. All Ouroboros version carriers are unchanged from the recorded base.

Exact test selection (executed with isolated `HOME`, `TMPDIR`, `OUROBOROS_APP_ROOT`, `OUROBOROS_DATA_DIR` and `OUROBOROS_SETTINGS_PATH`, with inherited credentials and daemon overrides removed):

```sh
python -m pytest \
  tests/test_claudexor_runtime_delivery.py \
  tests/test_claudexor_owned_daemon.py \
  tests/test_claudexor_status_passive.py \
  tests/test_claudexor_platform_smoke.py \
  tests/test_claudexor_startup_lifetime.py \
  tests/test_claudexor_custody_lifetime.py \
  tests/test_manual_restart_execution.py \
  tests/test_planned_restart_engine_pin.py \
  tests/test_restart_reconnect.py
python scripts/fetch_claudexor_runtime.py --output-dir "$ISOLATED_DATA/state/cx/cache"
python scripts/fetch_claudexor_runtime.py --output-dir "$ISOLATED_DATA/state/cx/cache" --verify-only
python scripts/claudexor_platform_smoke.py --managed-runtime --lane fixture --max-seconds 300
```

The full local Ouroboros test suite was not rerun for this metadata-only pin; focused tests and PR CI cover this delivery. The keyless fixture proves gateway/platform wiring, not a real subscription model, delegated custody, or a real harness child sandbox. Real AGY diagnostics were tested separately upstream; representative Google generation returned unsupported-location after successful authentication, which remains a vendor eligibility limitation.

## Visual evidence

Not applicable: no Ouroboros UI code or visual behavior is changed.

## Governance

CONTRIBUTING and CHECKLISTS were read in full, with canonical architecture/Bible context and relevant development guidance. No secrets, runtime state, logs, caches, generated outputs, or release-version bumps are included in the commit.

## Review evidence

Authoring context: the parent Codex task and its release-path implementation subagent. Separate reviewer: the independent accounts/quota research subagent, reviewing the frozen final pin without editing it. The upstream Claudexor Grok 4.6 and Opus 5 reviews are separate from this Ouroboros contributor review.

Recorded base: `53eaecdfdbd85d6436cb0b0cad917d2139267d2e`.
Recorded head: `b91c139103306ab3ee9935ef09a76abedce6cb55`.

Review status: PASS; eight justified PASS rows, no material findings. The independent reviewer validated the receipt against the repository contract. Required native platform CI remains a merge condition. No model identity is claimed without an observed runtime receipt.

| Item | Verdict | Evidence |
| --- | --- | --- |
| intent_alignment | PASS | The complete diff updates the canonical runtime pin from 3.10.0 to the published 3.10.1 source 0caf16a714f4eb8933e1885e3e2a5a40abd3be11 and updates its existing literal-version test. |
| forgotten_touchpoints | PASS | scripts/fetch_claudexor_runtime.py and the three platform build scripts consume the same tracked pin; Ouroboros.spec includes the resulting runtime seed. |
| cross_surface_consistency | PASS | ClaudexorRuntimeManager.status continues to distinguish serving, target and staged versions, while OwnedClaudexorDaemon.ensure_running preserves an authenticated live old engine. |
| regression_surface | PASS | The existing runtime-delivery tests cover exact size/digest verification, cache reuse, unsafe extraction refusal, retained older trees, Node/npm selection and failed-promotion recovery. |
| prompt_doc_sync | PASS | ARCHITECTURE's runtime-pin, owned-daemon, platform-gate and shutdown descriptions remain accurate: the reviewed pin selects immutable next-start bytes and does not hot-swap a serving process. |
| architecture_fit | PASS | The contribution adopts an already released adapter-level repair through the existing runtime pin authority. |
| cross_module_bugs | PASS | load_runtime_pin, verify_runtime_archive, _obtain_archive, _promote_archive and _probe continue to agree on the updated immutable identity. |
| implicit_contracts | PASS | The schema-version-1 pin retains its exact field set, five supported Node targets, protocol major and safe entrypoint names; both entrypoints and the Windows helper exist in the published archive. |

<details>
<summary>Full independent review and validated checklist JSON</summary>

# Independent contributor review: Claudexor 3.10.1 runtime pin

Verdict: PASS. No material finding requires a change to this two-file contribution. Merge remains conditional on the pull request's required CI and maintainer authority.

## Exact reviewed subject

- Repository: razzant/ouroboros; contribution target: ouroboros.
- Base: `53eaecdfdbd85d6436cb0b0cad917d2139267d2e`.
- Head: `b91c139103306ab3ee9935ef09a76abedce6cb55`.
- Head tree: `f92768bb972dbb4a696dd4482dcdc6f890c211cb`.
- Binary base-to-head diff SHA-256: `2b5401e3a2867029a6270de7ca63d5fea3c97b7336e4ad205f575363c0988a93`.
- Complete change: `ouroboros/claudexor_runtime_pin.json` and `tests/test_claudexor_runtime_delivery.py`, 6 insertions and 6 deletions. The committed worktree was clean at review completion.
- Reviewer: separate Codex subagent context `accounts_quota_meta_plan`, independent of the pin author. Model identity is not asserted from an unavailable runtime receipt.
- Goal: select the published Claudexor 3.10.1 engine containing the reviewed AGY diagnostic-input and Windows ConPTY fixes. Non-goals: Ouroboros version changes, new polling/authentication logic, settings, runtime adoption, and restart-policy changes.

## Intent / Scope checklist

```json
[
  {
    "item": "intent_alignment",
    "verdict": "PASS",
    "severity": "advisory",
    "reason": "The complete diff updates the canonical runtime pin from 3.10.0 to the published 3.10.1 source 0caf16a714f4eb8933e1885e3e2a5a40abd3be11 and updates its existing literal-version test. The archive URL, SHA-256 and exact size match independently read GitHub release metadata, the published engine manifest and measured cached archive bytes."
  },
  {
    "item": "forgotten_touchpoints",
    "verdict": "PASS",
    "severity": "advisory",
    "reason": "scripts/fetch_claudexor_runtime.py and the three platform build scripts consume the same tracked pin; Ouroboros.spec includes the resulting runtime seed. Protocol 3, both engine/CLI entrypoints, Node 24.16.0 and all five Node artifact descriptors remain unchanged, so the platform workflow's Node version and existing loader contracts need no paired edit."
  },
  {
    "item": "cross_surface_consistency",
    "verdict": "PASS",
    "severity": "advisory",
    "reason": "ClaudexorRuntimeManager.status continues to distinguish serving, target and staged versions, while OwnedClaudexorDaemon.ensure_running preserves an authenticated live old engine. No browser, CLI, account, or restart control is changed, and every Ouroboros release carrier is byte-identical to the base."
  },
  {
    "item": "regression_surface",
    "verdict": "PASS",
    "severity": "advisory",
    "reason": "The existing runtime-delivery tests cover exact size/digest verification, cache reuse, unsafe extraction refusal, retained older trees, Node/npm selection and failed-promotion recovery. The inspected 285-test evidence also covers owned-daemon lifetime, passive status, manual/planned restart and reconnect; the isolated managed fixture proves the new engine can start, answer, produce an edit and stop gracefully on Darwin."
  },
  {
    "item": "prompt_doc_sync",
    "verdict": "PASS",
    "severity": "advisory",
    "reason": "ARCHITECTURE's runtime-pin, owned-daemon, platform-gate and shutdown descriptions remain accurate: the reviewed pin selects immutable next-start bytes and does not hot-swap a serving process. DEVELOPMENT's Process Custody Rule and contributor no-version-bump rule remain satisfied; no prompt or user interaction contract changes."
  },
  {
    "item": "architecture_fit",
    "verdict": "PASS",
    "severity": "advisory",
    "reason": "The contribution adopts an already released adapter-level repair through the existing runtime pin authority. It introduces no duplicate updater, daemon owner, credential logic, provider-specific branch, cache, timer or policy in Ouroboros."
  },
  {
    "item": "cross_module_bugs",
    "verdict": "PASS",
    "severity": "advisory",
    "reason": "load_runtime_pin, verify_runtime_archive, _obtain_archive, _promote_archive and _probe continue to agree on the updated immutable identity. server_restart._stop_owned_daemon_for_new_pin still compares the landed pin with the serving handshake only during an existing planned restart, preserving attach and custody behavior before adoption."
  },
  {
    "item": "implicit_contracts",
    "verdict": "PASS",
    "severity": "advisory",
    "reason": "The schema-version-1 pin retains its exact field set, five supported Node targets, protocol major and safe entrypoint names; both entrypoints and the Windows helper exist in the published archive. The measured longest archive member is 114 characters, below the existing 172-character fixture bound, and the existing tracked-pin test still asserts CLI availability."
  }
]
```

## Preparation and checks

Read CONTRIBUTING.md, docs/CHECKLISTS.md and BIBLE.md in full. Read the entire 590,401-character docs/ARCHITECTURE.md in contiguous bounded chunks through EOF. Mapped DEVELOPMENT and DESIGN headings and read the relevant complete sections: role/boundaries, documentation, external facts, review/contributor/release rules, managed update, process custody, platform abstraction, build/CI, design authority and account-row semantics. The canonical design document is docs/DESIGN.md; there is no docs/DESIGN_SYSTEM.md in this repository.

Inspected the complete committed diff and both touched files, the exact runtime loader/delivery/probe functions, daemon attachment behavior, planned-restart pin comparison, packaging fetch consumers and the complete Claudexor platform workflow. No candidate source or runtime state was modified by this review.

Independent read-only verification:

- GitHub release v3.10.1, release ID 384935502, is published, non-draft and non-prerelease. Published engine asset metadata names size 7684246 and SHA-256 `d2a5422752e22f55266454514113b1614c3f1eb71a4c1bc777cf04452f411ddc`.
- Measured the cached engine archive's exact size and SHA-256 independently; both match the pin and the published manifest. The cached published manifest's SHA-256 `eec77320bd3ebb2bea0e790fdc45d947837d85ae9c6fe247e4596e17c58d8c8c` also matches GitHub asset metadata.
- Ran the candidate's `scripts/fetch_claudexor_runtime.py --verify-only --output-dir <verified-release-assets>` using Python 3.10.19: producer exit 0. No download, extraction, daemon or vendor invocation occurred.
- An initial invocation using an existing Python 3.9.7 failed during import because `dataclass(slots=True)` requires the repository's declared Python >=3.10 floor. The same verification passed with the supported interpreter; this is an environment mismatch, not a candidate defect.
- `git diff --check <base> <head>`: exit 0. The diff across all Ouroboros release carriers is empty. Archive inspection found both `claudexord.bundle.cjs` and `claudexor.bundle.cjs`, plus `native/claudexor-conpty-helper.exe`; longest member name is 114 characters.

Implementation evidence read in full: PIN_VERIFICATION.md, focused-tests.log, managed-smoke.log and PUBLISHED_RELEASE.md. The root retained producer exit 0 for 285 focused tests, cache verification and the isolated managed-runtime fixture. That fixture reports exact engine 3.10.1/build 0caf16a7, Node 24.16.0/protocol 3, a 33-byte primary artifact read to EOF, an on-disk FAKE_CHANGE.txt and confirmed graceful exit. These checks ran on the complete two-file content before it was committed; this report does not claim that the final commit already existed during their execution.

Public release evidence:

- https://github.com/razzant/claudexor/releases/tag/v3.10.1
- https://github.com/razzant/claudexor/actions/runs/34248342889
- https://github.com/razzant/claudexor/actions/runs/34251962112

## Findings and limits

No critical or advisory code finding requires another edit to this pin PR. Existing Claudexor release review findings and their dispositions are retained with that release; this is not another full Claudexor audit.

The local managed fixture is keyless and Darwin-only. Its fake harness runs in process: it does not prove vendor authentication, model generation, native child containment, production nanny/cost custody or the delegated-marker lane. The artifact EOF proof is size-based, not an invented artifact hash. The PR's Linux/Windows/Darwin fixture CI remains separate evidence required before merge. A full Ouroboros test suite and visible UI smoke were not rerun in this independent review; no UI source changed.

The pin does not assert that an already running installation has adopted 3.10.1. Adoption continues through the unchanged runtime lifecycle. The existing AGY account's vendor location refusal and the disclosed older-Windows terminal-rendering limitation are not repaired by changing the pin and must not be described as fixed by this contribution.

Final verdict: PASS for base `53eaecdfdbd85d6436cb0b0cad917d2139267d2e` to head `b91c139103306ab3ee9935ef09a76abedce6cb55`.

</details>

## Final checklist

- [x] Targets the `ouroboros` branch, from the recorded current base.
- [x] One coherent metadata-only dependency update, with no version bump or generated artifacts.
- [x] Focused verification and separate-context final-range review completed.
- [x] Coverage limitations and the distinction between published pin and live adoption are disclosed.
- [x] Native PR CI passed before merge: [Linux/Windows/macOS fixture gate](https://github.com/razzant/ouroboros/actions/runs/34259997921) and [CI](https://github.com/razzant/ouroboros/actions/runs/34259997994), on the exact recorded head. Each platform's log confirms engine 3.10.1/build 0caf16a7, protocol 3, artifact EOF, fixture mutation and graceful shutdown. Paid/subscription and release-only lanes are skipped by the existing PR policy, not claimed as passed.
