### PR TITLE
feat(gc): bound task_results/ and tail-read the recent-activity logs (#139, #131)

### DIFF
--- a/ouroboros/agent_startup_checks.py
+++ b/ouroboros/agent_startup_checks.py
@@ -848,6 +848,32 @@ def hot_store_growth_notes(env: Any) -> list:
             "replay scans this chain on ownership questions. Investigate chain "
             "indexing/compaction; archives are durable history and are never deleted."
         )
+    # Mirror for ``task_results/<id>.json``: glob-walked on every /api/tasks
+    # request and every SSE child re-discovery tick (razzant/ouroboros#139).
+    # ``prune_task_results`` bounds it via the GC retention window — this is a
+    # pre-degradation tripwire, not a retention preference. Remediation points
+    # at prune + discovery bounding, never at shortening the retention window.
+    try:
+        task_results_dir_path = drive_root / "task_results"
+        task_results_count = 0
+        task_results_bytes = 0
+        if task_results_dir_path.is_dir():
+            for path in task_results_dir_path.glob("*.json"):
+                if path.is_file():
+                    task_results_count += 1
+                    task_results_bytes += path.stat().st_size
+    except OSError:
+        task_results_bytes = 0
+        task_results_count = 0
+    from ouroboros.context_budget import TASK_RESULTS_DIR_WARN_BYTES
+    if task_results_bytes > TASK_RESULTS_DIR_WARN_BYTES:
+        notes.append(
+            "WARNING: HOT STORE GROWTH — task_results/*.json totals "
+            f"{task_results_bytes / 1_000_000:.1f} MB across {task_results_count} files "
+            f"(threshold {TASK_RESULTS_DIR_WARN_BYTES // 1_000_000} MB). The directory is "
+            "glob-walked on every /api/tasks request and SSE tick. Bound with "
+            "prune_task_results or bounded discovery — do NOT shorten the GC retention."
+        )
     return notes
 
 

--- a/ouroboros/context.py
+++ b/ouroboros/context.py
@@ -1024,19 +1024,26 @@ def build_recent_sections(
             + json.dumps(coverage_projection, ensure_ascii=False, sort_keys=True, default=str)
         )
 
+    # razzant/ouroboros#131: these logs are unbounded and were fully streamed
+    # each prompt just to keep the last 200 rows. A ~1 MiB tail window comfortably
+    # holds 200 rows of any of them; a pathological giant-row log degrades to
+    # fewer rows rather than a full read.
+    _RECENT_LOG_TAIL_BYTES = 1_048_576
     for log_name, header, formatter in (
         ("progress.jsonl", "## Recent progress", lambda rows: memory.summarize_progress(rows, limit=50)),
         ("tools.jsonl", "## Recent tools", memory.summarize_tools),
         ("events.jsonl", "## Recent events", memory.summarize_events),
     ):
-        entries = memory.read_jsonl_tail(log_name, 200)
+        entries = memory.read_jsonl_tail(log_name, 200, tail_bytes=_RECENT_LOG_TAIL_BYTES)
         if task_id:
             entries = [e for e in entries if str(e.get("task_id", "")).strip() == task_id]
         summary = formatter(entries)
         if summary:
             sections.append(f"{header}\n\n{summary}")
 
-    supervisor_summary = memory.summarize_supervisor(memory.read_jsonl_tail("supervisor.jsonl", 200))
+    supervisor_summary = memory.summarize_supervisor(
+        memory.read_jsonl_tail("supervisor.jsonl", 200, tail_bytes=_RECENT_LOG_TAIL_BYTES)
+    )
     if supervisor_summary:
         sections.append("## Supervisor\n\n" + supervisor_summary)
 

--- a/ouroboros/context_budget.py
+++ b/ouroboros/context_budget.py
@@ -277,6 +277,13 @@ SKILL_REVIEW_ROOT_TASKS_WARN_BYTES = 20_000_000
 # explicit full-history read becomes seconds-scale; this is observability, not
 # a retention gate and never shortens the memory horizon.
 CHAT_ARCHIVE_SCAN_WARN_BYTES = 100_000_000
+# ``task_results/<id>.json`` is glob-walked on every /api/tasks request and
+# every SSE child-re-discovery tick (razzant/ouroboros#139). prune_task_results
+# bounds it via the GC retention window — this warning flags the discovery
+# window BEFORE the per-tick walk becomes latency-visible. Observability, not
+# a retention gate; remediation is prune_task_results or discovery bounding,
+# never shorter retention.
+TASK_RESULTS_DIR_WARN_BYTES = 200_000_000
 # Custody replay (delegate_custody) walks the WHOLE events chain — live file
 # plus archive/events_*.jsonl — on ownership questions. This inherits the
 # pre-rotation 100MB replay-degradation signal, now measured over the chain;

--- a/ouroboros/headless.py
+++ b/ouroboros/headless.py
@@ -345,6 +345,66 @@ def prune_task_drives(
     return report
 
 
+def prune_task_results(
+    parent_drive_root: pathlib.Path,
+    *,
+    retention_days: Optional[int] = None,
+    now: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Bound ``data/task_results/`` (razzant/ouroboros#139): drop the result JSON
+    and its ``artifacts/<id>/`` subtree for terminal tasks older than the GC
+    window, keeping any task with an open review continuation. Fail CLOSED: if
+    that continuation set cannot be read, prune nothing. Age is the newer of the
+    result-embedded timestamp and the file mtime, so a freshly rewritten result
+    carrying a stale ``artifact_finalized_at`` stays.
+    """
+    from ouroboros.retention import age_cutoff
+    from ouroboros.task_results import task_results_dir
+
+    parent = pathlib.Path(parent_drive_root)
+    base = task_results_dir(parent, create=False)
+    days = _resolve_retention_days(retention_days)
+    cutoff = age_cutoff(days, now)
+    report: Dict[str, Any] = {
+        "retention_days": days, "scanned": 0, "pruned": [], "skipped": [], "errors": [],
+    }
+    if not base.is_dir():
+        return report
+    try:
+        from ouroboros.task_continuation import list_review_continuations
+
+        protected = {str(c.task_id) for c in list_review_continuations(parent)[0]}
+    except Exception:
+        report["errors"].append({"task_id": "*", "error": "review-continuation set unreadable; skipped all"})
+        return report
+
+    for path in sorted(base.glob("*.json")):
+        task_id = path.stem
+        report["scanned"] += 1
+        try:
+            validate_task_id(task_id)
+            result = load_task_result(parent, task_id) or {}
+            status = str(result.get("status") or "").lower()
+            mtime = path.stat().st_mtime
+            if status not in _FINAL_STATUSES:
+                reason = "task_not_terminal"
+            elif task_id in protected:
+                reason = "open_review_continuation"
+            elif max(_timestamp_from_result(result, mtime), mtime) > cutoff:
+                reason = "younger_than_retention"
+            else:
+                path.unlink()
+                artifact_dir = base / "artifacts" / task_id
+                if artifact_dir.is_dir():
+                    shutil.rmtree(artifact_dir)
+                report["pruned"].append({"task_id": task_id, "path": str(path)})
+                continue
+            report["skipped"].append({"task_id": task_id, "reason": reason})
+        except Exception as exc:
+            report["errors"].append({"task_id": task_id, "error": f"{type(exc).__name__}: {exc}"})
+    return report
+
+
 def prune_task_trees(
     parent_drive_root: pathlib.Path,
     *,

--- a/ouroboros/memory.py
+++ b/ouroboros/memory.py
@@ -846,11 +846,12 @@ class Memory:
         log_name: str,
         max_entries: Optional[int] = None,
         exclude_a2a: bool = False,
+        tail_bytes: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         path = self.logs_path(log_name)
         try:
             def _rows(source, cap):
-                return [e for e in iter_jsonl_objects(source, max_entries=cap)
+                return [e for e in iter_jsonl_objects(source, max_entries=cap, tail_bytes=tail_bytes)
                         if not (exclude_a2a and is_a2a_chat_id(e.get("chat_id")))]
 
             entries = _rows(path, max_entries)
@@ -869,8 +870,14 @@ class Memory:
             log.warning("Failed to read JSONL entries from %s", log_name, exc_info=True)
             return []
 
-    def read_jsonl_tail(self, log_name: str, max_entries: int = 100) -> List[Dict[str, Any]]:
-        return self._read_jsonl_entries(log_name, max_entries=max_entries)
+    def read_jsonl_tail(
+        self, log_name: str, max_entries: int = 100, *, tail_bytes: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        # ``tail_bytes`` (razzant/ouroboros#131): seek to the last N bytes of an
+        # unbounded log instead of streaming the whole file to keep only
+        # ``max_entries``. A pathological giant-row log degrades to fewer rows
+        # rather than a full read.
+        return self._read_jsonl_entries(log_name, max_entries=max_entries, tail_bytes=tail_bytes)
 
     def read_jsonl_tail_after_offset(
         self,

--- a/ouroboros/server_maintenance.py
+++ b/ouroboros/server_maintenance.py
@@ -39,13 +39,37 @@ def _installed_skill_names():
 
 
 _LAST_CANCEL_INTENT_SWEEP = [0.0]
+_LAST_STORE_GC = [0.0]
+_STORE_GC_INTERVAL_SEC = 6 * 3600
+
+
+def _periodic_store_gc() -> None:
+    """Every ~6h: keep ``data/task_results/`` bounded without a restart
+    (razzant/ouroboros#139). ``_startup_prune_sweeps`` does the same on boot; a
+    long-lived supervisor needs it on a cadence too."""
+    if time.time() - _LAST_STORE_GC[0] < _STORE_GC_INTERVAL_SEC:
+        return
+    _LAST_STORE_GC[0] = time.time()
+    try:
+        from ouroboros.headless import prune_task_results
+
+        report = prune_task_results(DATA_DIR)
+        if report.get("pruned") or report.get("errors"):
+            from supervisor.state import append_jsonl
+
+            append_jsonl(DATA_DIR / "logs" / "events.jsonl", {
+                "ts": utc_now_iso(), "type": "periodic_store_gc", "task_results": report,
+            })
+    except Exception:
+        log.debug("Periodic store GC failed", exc_info=True)
 
 
 def _periodic_supervisor_maintenance(last_custody_reap: list, last_review_reconcile: list) -> None:
     """Throttled periodic upkeep extracted from the supervisor loop: cancel-intent
     watchdog and pending child-ref promotion replay (every 20s), custody reap of
     orphaned task-scoped processes (every 600s) + review-job zombie reconcile
-    (every 300s). Each cadence gates itself via its own last-run marker."""
+    (every 300s) + task_results store GC (every ~6h). Each cadence gates itself
+    via its own last-run marker."""
     if time.time() - _LAST_CANCEL_INTENT_SWEEP[0] > 20:
         _LAST_CANCEL_INTENT_SWEEP[0] = time.time()
         try:
@@ -97,6 +121,7 @@ def _periodic_supervisor_maintenance(last_custody_reap: list, last_review_reconc
     if time.time() - last_review_reconcile[0] > 300:
         last_review_reconcile[0] = time.time()
         _periodic_zombie_reconcile()
+    _periodic_store_gc()
 
 
 def _reconcile_delegated_runs(running_task_ids: set) -> None:
@@ -265,13 +290,18 @@ def _startup_prune_sweeps() -> None:
     from supervisor.state import append_jsonl
 
     try:
-        from ouroboros.headless import prune_headless_task_drives, prune_task_drives, prune_task_trees
+        from ouroboros.headless import (
+            prune_headless_task_drives, prune_task_drives, prune_task_results, prune_task_trees,
+        )
         from ouroboros.utils import sweep_stale_temp_files
 
         prune_report = prune_headless_task_drives(DATA_DIR)
         task_drive_report = prune_task_drives(DATA_DIR)
         # Ephemeral task-tree coordination ledgers age out with their terminal root.
         prune_task_trees(DATA_DIR)
+        # task_results/<id>.json + artifacts/<id>/ — glob-parsed on every
+        # /api/tasks request and SSE tick, previously never pruned (#139).
+        task_results_report = prune_task_results(DATA_DIR)
         # Reap orphaned atomic-write temp files (.*.tmp.*) left by a hard kill.
         sweep_stale_temp_files(DATA_DIR)
         if (
@@ -279,12 +309,15 @@ def _startup_prune_sweeps() -> None:
             or prune_report.get("errors")
             or task_drive_report.get("pruned")
             or task_drive_report.get("errors")
+            or task_results_report.get("pruned")
+            or task_results_report.get("errors")
         ):
             append_jsonl(DATA_DIR / "logs" / "events.jsonl", {
                 "ts": utc_now_iso(),
                 "type": "headless_task_drive_prune",
                 "report": prune_report,
                 "task_drives": task_drive_report,
+                "task_results": task_results_report,
             })
     except Exception:
         log.debug("Headless task drive prune failed", exc_info=True)

--- a/tests/test_phase3c_observability_gc.py
+++ b/tests/test_phase3c_observability_gc.py
@@ -808,3 +808,72 @@ def test_periodic_maintenance_invokes_pending_ref_promotion_sweep(
     server_maintenance._periodic_supervisor_maintenance([10_000.0], [10_000.0])
 
     assert calls == [tmp_path]
+
+
+def test_prune_task_results_removes_old_terminal_json_and_artifacts(tmp_path):
+    """razzant/ouroboros#139: bound task_results/. Old terminal results and
+    their artifact subtree go; young / non-terminal / open-review-continuation
+    results stay.
+    """
+    import time
+
+    from ouroboros.headless import prune_task_results
+    from ouroboros.task_continuation import ReviewContinuation, save_review_continuation
+
+    data = tmp_path / "data"
+    (data / "task_results").mkdir(parents=True)
+    now = _future_now()
+    old_iso = time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime(now - 30 * 86400))
+    fresh_iso = time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime(now))
+
+    write_task_result(data, "oldterminal", STATUS_COMPLETED, result="done", ts=old_iso)
+    write_task_result(data, "oldrunning", "running", result="working", ts=old_iso)
+    write_task_result(data, "freshterminal", STATUS_COMPLETED, result="done", ts=fresh_iso)
+    write_task_result(data, "oldbutreviewed", STATUS_COMPLETED, result="done", ts=old_iso)
+
+    art = data / "task_results" / "artifacts" / "oldterminal"
+    art.mkdir(parents=True)
+    (art / "patch.diff").write_text("diff", encoding="utf-8")
+
+    # An open review continuation pins oldbutreviewed's result.
+    save_review_continuation(
+        data,
+        ReviewContinuation(
+            task_id="oldbutreviewed", source="blocked_review", stage="preflight",
+            tool_name="commit_reviewed",
+        ),
+    )
+
+    report = prune_task_results(data, retention_days=7, now=now)
+
+    assert [item["task_id"] for item in report["pruned"]] == ["oldterminal"]
+    assert not (data / "task_results" / "oldterminal.json").exists()
+    assert not art.exists()
+    assert (data / "task_results" / "freshterminal.json").exists()
+    assert (data / "task_results" / "oldrunning.json").exists()
+    assert (data / "task_results" / "oldbutreviewed.json").exists()
+    reasons = {item["task_id"]: item["reason"] for item in report["skipped"]}
+    assert reasons["oldrunning"] == "task_not_terminal"
+    assert reasons["freshterminal"] == "younger_than_retention"
+    assert reasons["oldbutreviewed"] == "open_review_continuation"
+
+
+def test_prune_task_results_fails_closed_when_continuations_unreadable(tmp_path, monkeypatch):
+    """If the open-review-continuation set can't be read, prune NOTHING."""
+    import ouroboros.task_continuation as tc
+    from ouroboros.headless import prune_task_results
+
+    data = tmp_path / "data"
+    (data / "task_results").mkdir(parents=True)
+    write_task_result(data, "oldterminal", STATUS_COMPLETED, result="done",
+                      ts="2020-01-01T00:00:00+00:00")
+
+    monkeypatch.setattr(
+        tc, "list_review_continuations",
+        lambda _root: (_ for _ in ()).throw(RuntimeError("continuation store corrupt")),
+    )
+    report = prune_task_results(data, retention_days=7, now=_future_now())
+
+    assert report["pruned"] == []
+    assert report["errors"] and report["errors"][0]["task_id"] == "*"
+    assert (data / "task_results" / "oldterminal.json").exists()

--- a/tests/test_startup_hygiene.py
+++ b/tests/test_startup_hygiene.py
@@ -508,3 +508,39 @@ def test_check_uncommitted_changes_never_commits_even_when_launcher_managed(monk
     assert result["auto_committed"] is False
     assert result["auto_rescue_skipped"] == "supervisor_side_rescue_owns_this"
     assert calls == [["git", "status", "--porcelain"]]
+
+
+def _sparse_json(path: pathlib.Path, size_bytes: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as fh:
+        fh.truncate(size_bytes)
+
+
+def test_hot_store_growth_notes_warns_when_task_results_dir_exceeds_threshold(tmp_path):
+    from ouroboros.context_budget import TASK_RESULTS_DIR_WARN_BYTES
+
+    per_file = TASK_RESULTS_DIR_WARN_BYTES // 3  # 4 files -> ~1.33x threshold
+    for i in range(4):
+        _sparse_json(tmp_path / "task_results" / f"t{i}.json", per_file)
+
+    env = types.SimpleNamespace(drive_path=lambda rel: tmp_path / rel, drive_root=tmp_path)
+    notes = startup_mod.hot_store_growth_notes(env)
+
+    hit = [n for n in notes if "task_results/*.json totals" in n]
+    assert len(hit) == 1
+    assert "across 4 files" in hit[0]
+    assert "prune_task_results" in hit[0]
+    assert "do NOT shorten the GC retention" in hit[0]
+
+
+def test_hot_store_growth_notes_silent_when_task_results_dir_below_threshold(tmp_path):
+    from ouroboros.context_budget import TASK_RESULTS_DIR_WARN_BYTES
+
+    per_file = TASK_RESULTS_DIR_WARN_BYTES // 4  # 3 files -> 0.75x threshold
+    for i in range(3):
+        _sparse_json(tmp_path / "task_results" / f"t{i}.json", per_file)
+
+    env = types.SimpleNamespace(drive_path=lambda rel: tmp_path / rel, drive_root=tmp_path)
+    notes = startup_mod.hot_store_growth_notes(env)
+
+    assert not [n for n in notes if "task_results/*.json" in n]


### PR DESCRIPTION
## #139 — `task_results/` is unbounded and replayed by the SSE tick and the tasks list

`data/task_results/<id>.json` and `task_results/artifacts/<id>/` grow with no prune, and `list_task_results` glob-parses every file on each `/api/tasks` request and SSE child-discovery tick.

* **`headless.prune_task_results(parent_drive_root, *, retention_days, now)`** deletes the result JSON + its artifact subtree for tasks that are terminal **and** older than the GC retention window, skipping any task with an open review continuation (its result is load-bearing until the review resumes). Fail **closed**: if the continuation set is unreadable, prune nothing. Age is `max(result-embedded ts, file mtime)` so a freshly rewritten result carrying a stale `artifact_finalized_at` (canonical-newer copyback) is kept.
* Wired into `server_maintenance._startup_prune_sweeps()` and a new ~6h-throttled `_periodic_store_gc()` in `_periodic_supervisor_maintenance()`, so a long-lived supervisor stays bounded without a restart.
* **Pre-degradation tripwire:** `hot_store_growth_notes` gains a `task_results/*.json` directory aggregate (file count + total bytes) WARNING, mirroring the existing `archive/chat_*.jsonl` block. Threshold `context_budget.TASK_RESULTS_DIR_WARN_BYTES` (200 MB) sits next to `CHAT_ARCHIVE_SCAN_WARN_BYTES`. Remediation points at prune / bounded discovery, **never** at shortening retention.

The remaining leg of #139 — replacing the `sorted(glob("*.json"))` walk in `list_task_results` itself with a bounded recency window / maintained index — is left for a follow-up; this PR bounds the directory and flags the discovery window before the per-tick walk becomes latency-visible.

## #131 — `build_recent_sections` full-reads the unbounded activity logs each prompt

It streamed the whole `progress.jsonl` / `tools.jsonl` / `events.jsonl` / `supervisor.jsonl` every prompt just to keep the last 200 rows. `Memory.read_jsonl_tail` / `_read_jsonl_entries` gain an optional `tail_bytes` that threads into `iter_jsonl_objects`'s existing seek-from-end path; the recent-activity loop passes a 1 MiB window. `chat.jsonl` (full-project dialogue semantics) and the tiny `task_reflections.jsonl` read are unchanged.

## Tests

`prune_task_results` removes only old-terminal results (keeps young / non-terminal / open-review-continuation), drops their artifact dirs, and fails closed when the continuation store raises; `hot_store_growth_notes` warns above and stays silent below the task_results threshold. `test_phase3c_observability_gc`, `test_startup_hygiene`, `test_context_budget_ssot`, `test_headless_extraction`, `test_memory*` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZGh7G7f2g7w8KkQW74Z4V