### PR TITLE
docs: reword stale fork-era comments to start-method-neutral truth

### DIFF
--- a/ouroboros/__init__.py
+++ b/ouroboros/__init__.py
@@ -8,7 +8,7 @@ Architecture: agent.py (orchestrator), tools/ (plugin tools),
 """
 
 # IMPORTANT: Do NOT import agent/loop/llm/etc here!
-# Eager imports here persist in forked worker processes as stale code,
+# Eager imports here persist in worker processes as stale code,
 # preventing hot-reload. Workers import make_agent directly.
 
 __all__ = ['agent', 'tools', 'llm', 'memory', 'review', 'utils']

--- a/ouroboros/llm_openai_compatible.py
+++ b/ouroboros/llm_openai_compatible.py
@@ -326,7 +326,7 @@ class _OpenAICompatibleLaneMixin:
         # Unknown capabilities mean no stripping.
         if skip_capability_fetch:
             # "Skip" means skip the NETWORK fetch (no_proxy fork-safety), not
-            # ignore an already-warm capability cache: a worker forked after the
+            # ignore an already-warm capability cache: a worker started after the
             # one-shot /models fetch still proactively strips unsupported params
             # instead of paying a reactive 404 + retry on every reviewer call.
             supported = (

--- a/supervisor/worker_process.py
+++ b/supervisor/worker_process.py
@@ -163,8 +163,9 @@ def worker_main(wid: int, in_q: Any, out_q: Any, repo_dir: str, drive_root: str,
     if not getattr(_sys, 'frozen', False):
         _sys.path.insert(0, repo_dir)
     _drive = _pathlib.Path(drive_root)
-    # Spawned workers must pin the runtime-mode baseline from the parent env;
-    # forked workers inherit it. This keeps the elevation ratchet consistent.
+    # Every worker must pin the runtime-mode baseline; workers receive that
+    # state through argv and per-task settings projection (forkserver/spawn do
+    # not inherit live parent memory). This keeps the elevation ratchet consistent.
     try:
         from ouroboros.config import initialize_runtime_mode_baseline
         initialize_runtime_mode_baseline()


### PR DESCRIPTION
### Problem
Three comments still describe Linux fork topology. Under forkserver/spawn, workers do not inherit live parent memory; state arrives via argv and per-task settings projection. Code is correct; prose is stale (see #679).

### Solution
Reword comments only in:
- `ouroboros/__init__.py`
- `ouroboros/llm_openai_compatible.py`
- `supervisor/worker_process.py`

No logic changes.

Fixes #679
