### PR TITLE
chore(runtime): pin Claudexor 3.10.2

### DIFF
--- a/ouroboros/claudexor_runtime_pin.json
+++ b/ouroboros/claudexor_runtime_pin.json
@@ -1,12 +1,12 @@
 {
  "schema_version": 1,
  "release": {
-  "version": "3.10.1",
-  "build_sha": "0caf16a714f4eb8933e1885e3e2a5a40abd3be11",
+  "version": "3.10.2",
+  "build_sha": "67b87de3662d39b1d3cba69f62ef6d61273c0716",
   "protocol_major": 3,
-  "archive_url": "https://github.com/razzant/claudexor/releases/download/v3.10.1/claudexor-runtime-3.10.1.tar.gz",
-  "sha256": "d2a5422752e22f55266454514113b1614c3f1eb71a4c1bc777cf04452f411ddc",
-  "size_bytes": 7684246,
+  "archive_url": "https://github.com/razzant/claudexor/releases/download/v3.10.2/claudexor-runtime-3.10.2.tar.gz",
+  "sha256": "73d17f5e53e7b9e65fc85a916cb75343c79b2332d42b62d710bb233f64269d6c",
+  "size_bytes": 7688571,
   "node_version": "24.16.0",
   "node_artifacts": {
    "darwin-arm64": {

--- a/tests/test_claudexor_runtime_delivery.py
+++ b/tests/test_claudexor_runtime_delivery.py
@@ -154,7 +154,7 @@ def test_tracked_pin_names_a_cli_capable_release():
     of this proposal converged on while the pin was still pre-CLI 3.6.0)."""
     pin = runtime.load_runtime_pin()
     assert pin is not None
-    assert pin.version == "3.10.1"
+    assert pin.version == "3.10.2"
     assert pin.cli_entrypoint == "claudexor.bundle.cjs"
 
 


### PR DESCRIPTION
Pin the managed Claudexor runtime to the public 3.10.2 release.

The release is v3.10.2 at build SHA 67b87de3662d39b1d3cba69f62ef6d61273c0716. The archive URL, SHA-256 digest, and byte size match the published GitHub Release asset and signed runtime manifest. Node remains 24.16.0 and protocol major remains 3.

This changes only claudexor_runtime_pin.json. Runtime adoption occurs on the next natural managed-daemon start after merge.
