### PR TITLE
fix(loop): a recovered mid-run tool error must not degrade delivery when the model produced a real final answer

### DIFF
--- a/ouroboros/loop_delivery.py
+++ b/ouroboros/loop_delivery.py
@@ -736,6 +736,40 @@ def _parse_delivery_control_body(
     return None, False, False
 
 
+# Floor that rejects a trivial ack ("Review completed.", "service notice ...") as
+# a "final answer" in the repair-failed branch (ibl-local-05b94950560c). The real
+# guard is the no-shorter-than-retained check below; this only screens out
+# one-liners.
+_DELIVERY_PROSE_MIN_CHARS = 40
+
+
+def _is_substantive_final_prose(raw_text: str, retained_text: str) -> bool:
+    """True when a repair-failed reply is a genuine complete final answer.
+
+    The delivery-control repair-failed branch preserves the retained candidate and
+    degrades. But a code-change task that hit ONE recovered mid-run tool error can
+    reach this branch with the latch still armed while the model has actually
+    produced its real final answer in prose — degrading that is wrong
+    (ibl-local-05b94950560c).
+
+    The discriminator must NOT let a short service notice / mutating-tool
+    acknowledgement erase a full retained answer (the
+    ``*_cannot_erase_full_candidate`` contract). A real final answer here is:
+
+    * not JSON-shaped (a leading ``{`` / ``[`` is a mangled protocol attempt —
+      still degrade), and
+    * past the one-liner floor, and
+    * no shorter than the answer it would replace — a genuine "here is my complete
+      result" is never a terse fragment relative to what was already retained.
+    """
+    text = str(raw_text or "").strip()
+    if not text or text[0] in "{[":
+        return False
+    if len(text) < _DELIVERY_PROSE_MIN_CHARS:
+        return False
+    return len(text) >= len(str(retained_text or "").strip())
+
+
 def _resolve_delivery_control(
     content: Any,
     tools: ToolRegistry,
@@ -840,6 +874,25 @@ def _resolve_delivery_control(
         candidate.control_episode_seen = True
         _loop()._publish_delivery_candidate(tools, candidate, llm_trace)
         return "retry", ""
+
+    # (b) Raw was substantive prose — the model produced a real final answer
+    #     while the control latch was still armed (typical after a recovered
+    #     tool error). Accept it as a fresh candidate rather than degrading
+    #     (ibl-local-05b94950560c). A prose reply that still ENDS with a
+    #     balanced protocol object has ``is_control_intent`` set and falls
+    #     through to degraded-preserve.
+    if _is_substantive_final_prose(raw, candidate.full_text) and not is_control_intent:
+        ctx.messages.append({"role": "assistant", "content": raw})
+        tools._ctx._delivery_control_required = False
+        updated = _loop()._replace_delivery_candidate(
+            tools, ctx, llm_trace, raw, control="candidate",
+        )
+        llm_trace["reasoning_notes"].append(
+            "Delivery-control latch was still armed when the model produced a substantive "
+            "prose final answer (>= the retained candidate); accepted the prose rather than "
+            "degrading (one recovered tool error must not by itself degrade delivery)."
+        )
+        return "resolved", updated.full_text
 
     tools._ctx._delivery_control_required = False
     candidate.degraded = True

--- a/tests/test_delivery_candidate.py
+++ b/tests/test_delivery_candidate.py
@@ -914,3 +914,72 @@ def test_forced_fallback_rejects_stale_delivery_candidate(tmp_path, monkeypatch)
         hashlib.sha256(text.encode("utf-8")).hexdigest()
     )
     assert returned_trace["forced_finalization"]["source"] == "host_fallback"
+
+
+def test_recovered_tool_error_then_prose_does_not_degrade_to_delivery_control(
+    tmp_path, monkeypatch,
+):
+    """ibl-local-05b94950560c e2e: a code-change task whose run produced one
+    tool error (recovered) and then a normal final prose message must finalize
+    as EXECUTION_OK / REASON_FINAL_MESSAGE — NOT delivery_control_degraded.
+
+    The latch is armed via a child-handoff service notice (same lane the real
+    code-change tasks trigger). First response after arming is invalid
+    delivery-control JSON (repair round, status=retry). Second response is
+    substantive prose — the fix must accept it as a fresh resolved candidate
+    rather than degrading to the prior retained answer.
+    """
+    from ouroboros.outcomes import derive_loop_outcome
+
+    original = "Original complete answer covering the child conclusions."
+    # >= _DELIVERY_PROSE_MIN_CHARS (200) and >= len(original): a genuine
+    # "here is my complete result" reply, not a terse notice.
+    final_prose = (
+        "Implementation complete. The fix adds `_is_substantive_final_prose` to "
+        "ouroboros/loop.py and rewires the `_resolve_delivery_control` "
+        "repair-failed branch so a real prose final answer is accepted rather "
+        "than degraded. All touched regression tests pass; no further action is "
+        "required and nothing else in the delivery-control contract changes."
+    )
+    invalid_json = json.dumps({"delivery_control": "finalize"})
+    result, usage, trace, calls = _run_loop(
+        tmp_path,
+        monkeypatch,
+        [original, invalid_json, final_prose],
+        child=True,
+        bind_child_before_second=True,
+    )
+
+    assert len(calls) == 3
+    # The substantive prose is delivered, NOT the prior retained answer.
+    assert result == final_prose
+    assert trace["delivery_candidate"]["degraded"] is False
+    assert trace["delivery_candidate"]["finalization_control"] == "candidate"
+    # Clean execution axis — not delivery_control_degraded.
+    outcome = derive_loop_outcome(result, usage, trace)
+    execution = outcome["outcome_axes"]["execution"]
+    assert execution["status"] == "ok", (
+        f"recovered tool error + substantive prose final must finalize OK, got {execution}"
+    )
+    assert execution["reason_code"] != "delivery_control_degraded"
+
+
+def test_short_prose_after_repair_still_degrades_and_preserves_candidate(
+    tmp_path, monkeypatch,
+):
+    """Complement: a SHORT prose reply in the repair-failed branch (service
+    notice, ack) must NOT erase the retained answer — it still degrade-preserves.
+    Pins the ``_is_substantive_final_prose`` discriminator.
+    """
+    original = "Original complete answer with every implementation and verification detail."
+    result, _usage, trace, calls = _run_loop(
+        tmp_path,
+        monkeypatch,
+        [original, "service notice: child refreshed", "still just a short notice"],
+        child=True,
+        bind_child_before_second=True,
+    )
+    assert len(calls) == 3
+    assert result == original
+    assert trace["delivery_candidate"]["degraded"] is True
+    assert trace["delivery_candidate"]["finalization_control"] == "degraded_preserve"

--- a/tests/test_delivery_forced_finalization.py
+++ b/tests/test_delivery_forced_finalization.py
@@ -1688,6 +1688,89 @@ def test_nonforced_resolver_treats_unknown_verb_object_as_protocol_not_prose(tmp
     assert "delivery_control" not in text2
 
 
+def test_nonforced_resolver_recovers_with_prose_after_repair_attempt(tmp_path):
+    """ibl-local-05b94950560c: a recovered tool error must NOT by itself degrade
+    the delivery outcome.
+
+    Sequence that triggers the bug: an owner-revision latch was armed (typically
+    by a tool error/recovery round that left the latch set), the model answered
+    the first repair with an unknown-verb JSON, then on the second round the
+    model produced SUBSTANTIVE PROSE (not JSON). The previous code degraded the
+    candidate and returned the stale prior text — the model's real answer was
+    discarded. After the fix: the prose is accepted as a fresh candidate, the
+    candidate is NOT degraded, and the resolver returns ("resolved", prose_text).
+    """
+    loop, registry, limit_ctx, trace = _forced_test_context(tmp_path)
+    candidate = loop._replace_delivery_candidate(
+        registry, limit_ctx, trace, "Retained complete answer.", control="candidate",
+    )
+    candidate.finalization_control = "owner_revision_required"
+    registry._ctx._delivery_control_required = False
+    unknown_verb = json.dumps({"delivery_control": "finalize"})
+
+    # Round 1: bad JSON. Repair kicks in; returns ("retry", "").
+    status1, text1 = loop._resolve_delivery_control(
+        unknown_verb, registry, limit_ctx, trace,
+    )
+    assert status1 == "retry"
+    assert text1 == ""
+    assert candidate.repair_attempted is True
+
+    # Round 2: the model abandoned the protocol and produced a real final
+    # answer in plain prose. BEFORE the fix, this returned ("degraded",
+    # prior_text) and degraded=True. AFTER the fix, this returns
+    # ("resolved", prose_text) and the new candidate has degraded=False.
+    prose = "Here is the actual final answer in plain English, no JSON."
+    status2, text2 = loop._resolve_delivery_control(
+        prose, registry, limit_ctx, trace,
+    )
+    assert status2 == "resolved"
+    assert text2 == prose
+    new_candidate = registry._ctx._delivery_candidate
+    assert new_candidate.full_text == prose
+    assert new_candidate.degraded is False
+    assert new_candidate.degraded_reason == ""
+    assert new_candidate.finalization_control == "candidate"
+    # delivery_candidate projection in the trace mirrors candidate fields.
+    assert trace["delivery_candidate"]["degraded"] is False
+    assert trace["delivery_candidate"]["degraded_reason"] == ""
+
+
+def test_nonforced_resolver_still_degrades_on_genuine_protocol_violation(tmp_path):
+    """Anti-regression: when the repair-failed branch sees a real JSON-shaped
+    protocol attempt (unknown verb, duplicate key), the genuine-failure path
+    must STILL degrade. The fix only relaxes the prose-not-JSON case; it does
+    NOT relax the protocol-violation case.
+    """
+    loop, registry, limit_ctx, trace = _forced_test_context(tmp_path)
+    candidate = loop._replace_delivery_candidate(
+        registry, limit_ctx, trace, "Retained complete answer.", control="candidate",
+    )
+    candidate.finalization_control = "owner_revision_required"
+    registry._ctx._delivery_control_required = False
+    unknown_verb = json.dumps({"delivery_control": "finalize"})
+
+    # Two rounds of the same mangled JSON: round 1 = retry, round 2 = degraded.
+    status1, _text1 = loop._resolve_delivery_control(
+        unknown_verb, registry, limit_ctx, trace,
+    )
+    assert status1 == "retry"
+
+    status2, text2 = loop._resolve_delivery_control(
+        unknown_verb, registry, limit_ctx, trace,
+    )
+    assert status2 == "degraded"
+    assert text2 == candidate.full_text
+    # The genuine-failure path is preserved: degraded=True, degraded_reason set.
+    final_candidate = registry._ctx._delivery_candidate
+    assert final_candidate.degraded is True
+    assert final_candidate.degraded_reason == "invalid_delivery_control_after_repair"
+    assert final_candidate.finalization_control == "degraded_preserve"
+    assert trace["delivery_candidate"]["degraded"] is True
+    assert trace["delivery_candidate"]["degraded_reason"] == (
+        "invalid_delivery_control_after_repair"
+    )
+
 # ---------------------------------------------------------------------------
 # D2c (custody-absorption sprint, owner Q4=A): protocol-intent containment.
 # Both latch-gated resolvers share one fence-strip normalization with


### PR DESCRIPTION
## Problem

A code-change task that hits ONE recovered mid-run tool error can reach `_resolve_delivery_control`'s repair-failed branch (`ouroboros/loop_delivery.py`) with the delivery-control latch still armed **while the model has already produced its real final answer in prose**. The branch:

```python
tools._ctx._delivery_control_required = False
candidate.degraded = True
candidate.degraded_reason = "invalid_delivery_control_after_repair"
...
return "degraded", candidate.full_text
```

discards the prose unconditionally, preserves the retained (possibly stale) candidate, and the outcome reducer stamps `delivery_control_degraded` — the real deliverable is lost and the round budget is spent, even though the model actually finished. Investigation/analysis tasks are unaffected because they never arm the latch.

## Fix

`_is_substantive_final_prose(raw, retained)` (new, in `loop_delivery.py`) is true only when the repair-failed reply:

* is **not JSON-shaped** — a leading `{`/`[` is a mangled protocol attempt, not prose, and still degrades;
* is **past a one-liner floor** (40 chars);
* is **no shorter than the candidate it would replace** — a genuine "here is my complete result" is never a terse fragment relative to what was already retained.

This keeps the existing `*_cannot_erase_full_candidate` contract intact: a short service notice or mutating-tool acknowledgement still degrade-preserves.

In the repair-failed branch: when the reply is substantive final prose **and** is not itself control-shaped (`is_control_intent` — a prose reply that still *ends* with a balanced protocol object falls through to degraded-preserve, unchanged), accept it via `_replace_delivery_candidate(control="candidate")`, clear the latch, and return `("resolved", prose)` → `degraded=False` → `EXECUTION_OK`, not `delivery_control_degraded`.

## Tests

A real 3-round child-handoff scenario (original answer → invalid control JSON → substantive prose accepted) in `tests/test_delivery_forced_finalization.py`; the complement in `tests/test_delivery_candidate.py` (a short prose reply after repair still degrades). The pre-existing `*_cannot_erase_full_candidate` tests are unchanged and still pass. Full `-k "delivery or loop_delivery or forced_finalization"` sweep green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qrMmbNvYXckXHFrQzfWNm