### PR TITLE
fix(consolidator): defer cleanly on an empty/non-JSON model reply

### DIFF
--- a/ouroboros/consolidator.py
+++ b/ouroboros/consolidator.py
@@ -701,6 +701,57 @@ def consolidate_scratchpad(
     return _consolidate_scratchpad_blocks(memory, blocks, knowledge_dir, llm_client, identity_text)
 
 
+def _try_extract_embedded_json(raw: str) -> Optional[Dict[str, Any]]:
+    """One bounded recovery: a model reply that wraps JSON inside prose or fences.
+
+    Finds the FIRST ``{`` and the matching LAST ``}`` (counting nested braces so
+    prose after the JSON does not truncate it), then parses the slice. Returns
+    ``None`` when no balanced ``{...}`` slice parses as a dict — caller defers.
+    """
+    if not raw:
+        return None
+    first = raw.find("{")
+    if first < 0:
+        return None
+    last = raw.rfind("}")
+    if last <= first:
+        return None
+    depth = 0
+    end = -1
+    in_string = False
+    escape = False
+    for idx in range(first, len(raw)):
+        ch = raw[idx]
+        if in_string:
+            if escape:
+                escape = False
+                continue
+            if ch == "\\":
+                escape = True
+                continue
+            if ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                end = idx
+                break
+    if end < 0:
+        return None
+    candidate = raw[first : end + 1]
+    try:
+        parsed = json.loads(candidate)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
 def _consolidate_scratchpad_blocks(
     memory: Any,
     blocks: List[Dict[str, Any]],
@@ -761,7 +812,27 @@ Respond with JSON only (no fences):
         if raw.startswith("```"):
             raw = raw.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
 
-        result = json.loads(raw)
+        # BIBLE P1 — gap-not-lost: an empty/non-JSON model reply is a recoverable
+        # transient (e.g. 429-rate-limited fallback returning ""), NOT a fatal
+        # consolidation error. Defer cleanly with usage so the next pass retries;
+        # the broad outer except stays for genuinely unexpected failures (lock /
+        # IO), but a transient bad model reply must NEVER reach it.
+        if not raw:
+            log.warning("Scratchpad block consolidation: model returned empty response, deferring")
+            return usage
+        try:
+            result = json.loads(raw)
+        except json.JSONDecodeError:
+            # One bounded recovery: fenced/embedded JSON inside prose (find first
+            # `{` and the matching last `}`). If even that fails, defer cleanly.
+            recovered = _try_extract_embedded_json(raw)
+            if recovered is None:
+                log.warning(
+                    "Scratchpad block consolidation: non-JSON model response, deferring: %s",
+                    raw[:120],
+                )
+                return usage
+            result = recovered
 
         compressed_text = result.get("compressed_block", "")
         if not compressed_text or not compressed_text.strip():

--- a/tests/test_consolidator.py
+++ b/tests/test_consolidator.py
@@ -187,3 +187,212 @@ def test_existing_dialogue_blocks_remain_authoritative(tmp_path):
     blocks_path.write_text("[]", encoding="utf-8")
 
     assert json.loads(blocks_path.read_text()) == []
+
+
+# ---------------------------------------------------------------------------
+# ibl-28109914789e — defer on transient empty / non-JSON model reply
+# ---------------------------------------------------------------------------
+
+def _seed_scratchpad_blocks(tmp_path, count: int = 3) -> tuple[list[dict[str, object]], object]:
+    """Drop three pre-existing scratchpad blocks onto disk for consolidation.
+
+    Returns ``(blocks, memory)`` — the blocks already live on disk via
+    ``Memory.mutate_scratchpad_blocks`` so the consolidator's re-read-under-lock
+    sees them too.
+
+    Each block's content is padded past ``SCRATCHPAD_CONSOLIDATION_THRESHOLD_CHARS``
+    (30,000) so the consolidator actually enters its LLM call path; a 3-block
+    "block N" seed would otherwise early-return None before our deferral code
+    runs.
+    """
+    from ouroboros.memory import Memory
+
+    memory = Memory(drive_root=tmp_path)
+    pad = "x" * 12_000  # 3 * 12,000 = 36,000 > 30,000 threshold
+    blocks = [
+        {
+            "ts": f"2026-09-01T0{i}:00:00Z",
+            "source": "test",
+            "content": f"block {i} " + pad,
+        }
+        for i in range(count)
+    ]
+    memory.mutate_scratchpad_blocks(lambda _live: list(blocks))
+    return blocks, memory
+
+
+def _memory_with_blocks(tmp_path):
+    from ouroboros.memory import Memory
+
+    return Memory(drive_root=tmp_path)
+
+
+def test_consolidate_scratchpad_blocks_defers_on_empty_response(tmp_path, caplog):
+    """ibl-28109914789e — model returning ``""`` (e.g. 429-fallback empty body)
+    used to error the whole pass and return None, wedging the consolidator.
+
+    After the fix: empty response is a recoverable transient — the pass returns
+    the usage dict, logs a warning containing "empty", and DOES NOT write
+    knowledge or mutate scratchpad blocks."""
+    import logging
+
+    seeded, memory = _seed_scratchpad_blocks(tmp_path)
+    knowledge_dir = tmp_path / "knowledge"
+    knowledge_dir.mkdir(parents=True, exist_ok=True)
+    blocks_path = tmp_path / "memory" / "scratchpad_blocks.json"
+    before = json.loads(blocks_path.read_text())
+
+    mock_llm = MagicMock()
+    mock_llm.chat.return_value = (
+        {"content": ""},
+        {"prompt_tokens": 10, "completion_tokens": 0, "total_tokens": 10, "cost": 0.0},
+    )
+
+    from ouroboros.consolidator import _consolidate_scratchpad_blocks
+
+    caplog.set_level(logging.WARNING, logger="ouroboros.consolidator")
+    result = _consolidate_scratchpad_blocks(
+        memory=memory,
+        blocks=seeded,
+        knowledge_dir=knowledge_dir,
+        llm_client=mock_llm,
+        identity_text="",
+    )
+
+    # Clean deferral: usage returned, NOT None.
+    assert result is not None
+    assert result["prompt_tokens"] == 10
+    # No knowledge files were created.
+    assert not any(knowledge_dir.glob("*.md"))
+    # Scratchpad blocks on disk are unchanged (no merge ran).
+    after = json.loads(blocks_path.read_text())
+    assert after == before
+    # And the warning was loud enough to name "empty".
+    assert any("empty" in rec.message for rec in caplog.records)
+    # And NOT the loud ERROR path the old code took.
+    assert not any(rec.levelno >= logging.ERROR for rec in caplog.records)
+
+
+def test_consolidate_scratchpad_blocks_defers_on_non_json_prose(tmp_path, caplog):
+    """ibl-28109914789e — non-JSON prose reply must defer cleanly too."""
+    import logging
+
+    seeded, memory = _seed_scratchpad_blocks(tmp_path)
+    knowledge_dir = tmp_path / "knowledge"
+    knowledge_dir.mkdir(parents=True, exist_ok=True)
+    blocks_path = tmp_path / "memory" / "scratchpad_blocks.json"
+    before = json.loads(blocks_path.read_text())
+
+    mock_llm = MagicMock()
+    mock_llm.chat.return_value = (
+        {"content": "sorry I can't help with that right now"},
+        {"prompt_tokens": 12, "completion_tokens": 5, "total_tokens": 17, "cost": 0.0001},
+    )
+
+    from ouroboros.consolidator import _consolidate_scratchpad_blocks
+
+    caplog.set_level(logging.WARNING, logger="ouroboros.consolidator")
+    result = _consolidate_scratchpad_blocks(
+        memory=memory,
+        blocks=seeded,
+        knowledge_dir=knowledge_dir,
+        llm_client=mock_llm,
+        identity_text="",
+    )
+
+    assert result is not None
+    assert result["prompt_tokens"] == 12
+    # No knowledge writes, no scratchpad mutation.
+    assert not any(knowledge_dir.glob("*.md"))
+    after = json.loads(blocks_path.read_text())
+    assert after == before
+    # Warning names the deferred reason (the first 120 chars of raw).
+    assert any("non-JSON" in rec.message and "sorry I can" in rec.message
+               for rec in caplog.records)
+    # Never an ERROR.
+    assert not any(rec.levelno >= logging.ERROR for rec in caplog.records)
+
+
+def test_consolidate_scratchpad_blocks_recovers_embedded_json(tmp_path, caplog):
+    """A fenced ```` ```json\\n{...}\\n``` ```` payload is the existing happy path.
+    Also: a prose reply that wraps JSON inside braces still parses via the
+    bounded embedded-recovery path."""
+    seeded, memory = _seed_scratchpad_blocks(tmp_path)
+    knowledge_dir = tmp_path / "knowledge"
+    knowledge_dir.mkdir(parents=True, exist_ok=True)
+    blocks_path = tmp_path / "memory" / "scratchpad_blocks.json"
+
+    mock_llm = MagicMock()
+    mock_llm.chat.return_value = (
+        {"content": (
+            "Here you go:\n\n"
+            "```json\n"
+            "{\"compressed_block\": \"c\", \"knowledge_entries\": []}\n"
+            "```\n"
+        )},
+        {"prompt_tokens": 8, "completion_tokens": 4, "total_tokens": 12, "cost": 0.0001},
+    )
+
+    from ouroboros.consolidator import _consolidate_scratchpad_blocks
+
+    result = _consolidate_scratchpad_blocks(
+        memory=memory,
+        blocks=seeded,
+        knowledge_dir=knowledge_dir,
+        llm_client=mock_llm,
+        identity_text="",
+    )
+
+    assert result is not None
+    # Compression ran: scratchpad now holds the new compressed block.
+    blocks = json.loads(blocks_path.read_text())
+    assert any(b.get("source") == "consolidation" for b in blocks)
+
+
+def test_consolidate_scratchpad_blocks_valid_bare_json(tmp_path, caplog):
+    """A genuinely valid bare-JSON payload is the existing happy path —
+    parses and consolidates normally."""
+    seeded, memory = _seed_scratchpad_blocks(tmp_path)
+    knowledge_dir = tmp_path / "knowledge"
+    knowledge_dir.mkdir(parents=True, exist_ok=True)
+    blocks_path = tmp_path / "memory" / "scratchpad_blocks.json"
+
+    mock_llm = MagicMock()
+    mock_llm.chat.return_value = (
+        {"content": json.dumps({"compressed_block": "x", "knowledge_entries": []})},
+        {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10, "cost": 0.0},
+    )
+
+    from ouroboros.consolidator import _consolidate_scratchpad_blocks
+
+    result = _consolidate_scratchpad_blocks(
+        memory=memory,
+        blocks=seeded,
+        knowledge_dir=knowledge_dir,
+        llm_client=mock_llm,
+        identity_text="",
+    )
+
+    assert result is not None
+    blocks = json.loads(blocks_path.read_text())
+    assert any(b.get("source") == "consolidation" for b in blocks)
+
+
+def test_try_extract_embedded_json_balanced_and_skips_strings(tmp_path):
+    """Helper sanity: braces inside JSON strings do NOT count toward depth; the
+    outermost matching brace is picked; a top-level non-dict returns None."""
+    from ouroboros.consolidator import _try_extract_embedded_json
+
+    payload = (
+        'Sure! Here: {"a": "}", "b": 1, "c": {"d": 2}}\n\nThanks.'
+    )
+    parsed = _try_extract_embedded_json(payload)
+    assert parsed == {"a": "}", "b": 1, "c": {"d": 2}}
+
+    # Top-level list, not dict — defer.
+    assert _try_extract_embedded_json("[1, 2, 3]") is None
+    # Empty / no braces — defer.
+    assert _try_extract_embedded_json("") is None
+    assert _try_extract_embedded_json("no json here at all") is None
+    # Unbalanced — defer.
+    assert _try_extract_embedded_json("{ \"a\": 1 ") is None


### PR DESCRIPTION
## Problem

`ouroboros/consolidator.py::_consolidate_scratchpad_blocks` does:

```python
raw = (msg.get("content") or "").strip()
if raw.startswith("```"):
    raw = raw.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
result = json.loads(raw)
```

with no guard. An **empty** model reply (e.g. a 429-rate-limit fallback returning `""`) or any **non-JSON** reply raises `json.JSONDecodeError`, which the function's outer handler catches:

```python
except Exception as e:
    from ouroboros.llm_claudexor import propagate_model_error
    propagate_model_error(e)
    log.error("Scratchpad block consolidation failed: %s", e, exc_info=True)
    return None
```

Two real costs:

* **`return None` instead of `usage`** — `consolidate_scratchpad` threads this value up as the LLM call's usage/cost accounting. A real, billed LLM call happened; returning `None` loses track of it.
* **`propagate_model_error(e)` + ERROR log** escalates a benign "the model returned prose (or nothing) instead of JSON, once" the same way as a genuine provider failure.

## Fix — both additive, no change to a valid-JSON reply

* `_try_extract_embedded_json(raw)`: one bounded recovery for a reply that wraps its JSON inside prose or additional fences beyond the existing ` ``` ` strip — finds the first `{` and the matching last `}` (brace-depth aware, string-literal aware so a `}` inside a quoted string doesn't close early), parses the slice, returns `None` when nothing balanced parses as a dict.
* In `_consolidate_scratchpad_blocks`: an empty `raw` logs a **WARNING** and returns `usage` (deferred, not failed — the call still happened and cost real tokens). A `json.JSONDecodeError` first tries the embedded-JSON recovery; if that also fails, logs a WARNING with the first 120 chars of the reply and returns `usage`. The broad outer `except Exception` / `propagate_model_error` escalation is now reserved for genuinely unexpected failures (lock / IO), never a transient bad model reply.

## Tests

5 new cases in `tests/test_consolidator.py`: empty reply defers with `usage`; non-JSON prose reply defers with `usage`; JSON embedded in prose/fences is recovered and consolidation proceeds normally; the embedded-JSON extractor's brace-depth and string-literal edge cases. Full `test_consolidator.py` sweep (19 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qrMmbNvYXckXHFrQzfWNm