### PR TITLE
fix(skill-review): reconcile pending-forever review_job.json zombies

### DIFF
--- a/ouroboros/skill_review_runner.py
+++ b/ouroboros/skill_review_runner.py
@@ -537,6 +537,92 @@ def mark_stale_review_job_interrupted(
     )
 
 
+def _mark_pending_review_zombie_interrupted(
+    drive_root: pathlib.Path,
+    skill_name: str,
+    *,
+    current_content_hash: str = "",
+    stale_after_sec: int = _STALE_REVIEW_JOB_SEC,
+) -> bool:
+    """Heal a pending-forever review_job.json (ibl-f334f2324443).
+
+    A ``review_job.json`` may stay at ``status=pending`` forever when its
+    lifecycle dispatch never reached ``_on_started`` (e.g. a duplicate
+    ``dedupe_key`` collision against an earlier stuck job, a worker that
+    died before acquiring the lifecycle file lock, or an infra failure
+    that aborted before the heartbeat). The existing
+    ``mark_stale_review_job_interrupted`` only catches the
+    ``status=running`` case (pid-dead or heartbeat-stale), so these pending
+    zombies silently block every retry: a fresh dispatch hits the duplicate
+    payload and stays pending too, accumulating across runs until the user
+    manually rewrites the file.
+
+    Detection: ``status=pending`` AND age (from ``started_at`` /
+    ``created_at`` / file mtime, in that order) greater than the stale
+    threshold AND no live pid. The fix transitions the file to
+    ``status=interrupted`` with reason ``pending_zombie_never_started`` so
+    a retry can acquire a fresh lifecycle lease. Returns True iff a
+    transition happened.
+    """
+    path = review_job_state_path(drive_root, skill_name)
+    data = _read_review_job(path)
+    if str(data.get("status") or "") != "pending":
+        return False
+    pid = int(data.get("pid") or 0)
+    if pid and _pid_alive(pid):
+        return False
+    ts_candidate = (
+        str(data.get("started_at") or "")
+        or str(data.get("created_at") or "")
+        or str(data.get("last_heartbeat_at") or "")
+    )
+    age = _iso_age_sec(ts_candidate) if ts_candidate else 0.0
+    if not age:
+        try:
+            age = max(0.0, time.time() - path.stat().st_mtime)
+        except OSError:
+            age = 0.0
+    if age < stale_after_sec:
+        return False
+    now = utc_now_iso()
+    payload = {
+        **data,
+        "status": "interrupted",
+        "lifecycle_status": "interrupted",
+        "finished_at": now,
+        "interrupted_at": now,
+        "interrupt_reason": "pending_zombie_never_started",
+        "content_hash": data.get("content_hash") or current_content_hash,
+    }
+    payload["terminal_reason"] = payload["interrupt_reason"]
+    atomic_write_json(path, payload, trailing_newline=True)
+    _append_terminal_history(
+        drive_root,
+        skill_name,
+        payload,
+        status="interrupted",
+        terminal_reason=str(payload["interrupt_reason"]),
+        ts=now,
+    )
+    _append_review_chat_summary(
+        drive_root, skill_name, payload, status="interrupted", ts=now,
+    )
+    _append_interrupted_review_progress(drive_root, skill_name, payload, ts=now)
+    append_jsonl(
+        _events_path(drive_root),
+        {
+            "ts": now,
+            "type": "skill_review_pending_zombie_healed",
+            "skill": skill_name,
+            "content_hash": payload.get("content_hash", ""),
+            "job_id": payload.get("job_id", ""),
+            "age_sec": round(age, 3),
+            "reason": payload["interrupt_reason"],
+        },
+    )
+    return True
+
+
 def reconcile_stale_review_jobs(
     drive_root: pathlib.Path,
     *,
@@ -556,14 +642,23 @@ def reconcile_stale_review_jobs(
         if skill_name in collision_names:
             continue
         before = _read_review_job(path)
-        if str(before.get("status") or "") != "running":
+        status_before = str(before.get("status") or "")
+        if status_before == "running":
+            mark_stale_review_job_interrupted(
+                pathlib.Path(drive_root),
+                skill_name,
+                current_content_hash=str(before.get("content_hash") or ""),
+                stale_after_sec=stale_after_sec,
+            )
+        elif status_before == "pending":
+            _mark_pending_review_zombie_interrupted(
+                pathlib.Path(drive_root),
+                skill_name,
+                current_content_hash=str(before.get("content_hash") or ""),
+                stale_after_sec=stale_after_sec,
+            )
+        else:
             continue
-        mark_stale_review_job_interrupted(
-            pathlib.Path(drive_root),
-            skill_name,
-            current_content_hash=str(before.get("content_hash") or ""),
-            stale_after_sec=stale_after_sec,
-        )
         after = _read_review_job(path)
         if str(after.get("status") or "") == "interrupted":
             count += 1

--- a/tests/test_skill_exec.py
+++ b/tests/test_skill_exec.py
@@ -26,6 +26,7 @@ from ouroboros.skill_loader import (
 from ouroboros.tools import skill_exec as skill_exec_mod
 from ouroboros.tools.registry import ToolContext, ToolRegistry
 from ouroboros.contracts.task_constraint import TaskConstraint
+from ouroboros.utils import utc_now_iso
 
 
 from tests._shared import clean_extension_runtime_state
@@ -1481,6 +1482,80 @@ def test_reconcile_stale_review_jobs_heals_dead_running_job(tmp_path, monkeypatc
     data = json.loads(job_path.read_text(encoding="utf-8"))
     assert data["status"] == "interrupted"
     assert data["interrupt_reason"] == "owner_process_exited"
+
+
+def test_reconcile_stale_review_jobs_heals_pending_zombie(tmp_path, monkeypatch):
+    # ibl-f334f2324443: review_job.json stuck at status=pending forever (the
+    # lifecycle dispatch never reached _on_started — duplicate dedupe collision
+    # or worker died before file-lock). mark_stale_review_job_interrupted only
+    # catches status=running; pending zombies silently block every retry. The
+    # fix detects pending + old + no live pid and transitions to interrupted.
+    from ouroboros.skill_review_runner import (
+        reconcile_stale_review_jobs,
+        review_job_state_path,
+    )
+
+    ctx = _make_ctx(tmp_path)
+    job_path = review_job_state_path(ctx.drive_root, "gamma")
+    job_path.parent.mkdir(parents=True, exist_ok=True)
+    job_path.write_text(
+        json.dumps(
+            {
+                "status": "pending",
+                "skill": "gamma",
+                "content_hash": "h2",
+                "job_id": "skill-job-pending",
+                "started_at": "2026-01-01T00:00:00+00:00",
+                "pid": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("ouroboros.skill_review_runner._pid_alive", lambda _pid: False)
+
+    healed = reconcile_stale_review_jobs(ctx.drive_root)
+
+    assert healed == 1
+    data = json.loads(job_path.read_text(encoding="utf-8"))
+    assert data["status"] == "interrupted"
+    assert data["interrupt_reason"] == "pending_zombie_never_started"
+    events_text = (ctx.drive_root / "logs" / "events.jsonl").read_text(encoding="utf-8")
+    assert "skill_review_pending_zombie_healed" in events_text
+
+
+def test_reconcile_stale_review_jobs_skips_fresh_pending(tmp_path, monkeypatch):
+    # ibl-f334f2324443: a pending job that's YOUNGER than the stale threshold
+    # must NOT be healed — that would race a legitimate dispatch that's still
+    # acquiring its lifecycle file lock. The fix only heals old pending jobs.
+    from ouroboros.skill_review_runner import (
+        reconcile_stale_review_jobs,
+        review_job_state_path,
+    )
+
+    ctx = _make_ctx(tmp_path)
+    job_path = review_job_state_path(ctx.drive_root, "delta")
+    job_path.parent.mkdir(parents=True, exist_ok=True)
+    now_iso = utc_now_iso()
+    job_path.write_text(
+        json.dumps(
+            {
+                "status": "pending",
+                "skill": "delta",
+                "content_hash": "h3",
+                "job_id": "skill-job-fresh",
+                "started_at": now_iso,
+                "pid": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("ouroboros.skill_review_runner._pid_alive", lambda _pid: False)
+
+    healed = reconcile_stale_review_jobs(ctx.drive_root)
+
+    assert healed == 0
+    data = json.loads(job_path.read_text(encoding="utf-8"))
+    assert data["status"] == "pending"
 
 
 def test_async_review_cancellation_waits_for_review_thread(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

A `review_job.json` can stay at `status=pending` forever when its lifecycle dispatch never reaches `_on_started`:

* a duplicate `dedupe_key` collision against an earlier stuck job,
* a worker that died before acquiring the lifecycle file lock,
* an infra failure that aborted before the heartbeat.

`mark_stale_review_job_interrupted` only handles the `running` case (pid-dead or heartbeat-stale) — it returns immediately for anything else:

```python
if str(data.get("status") or "") != "running":
    return
```

and `reconcile_stale_review_jobs` also filters to `running` before calling it:

```python
if str(before.get("status") or "") != "running":
    continue
```

A pending zombie is **never** reconciled: a fresh dispatch hits the same duplicate payload and stays pending too, accumulating across runs until someone manually rewrites the file.

## Fix

* `_mark_pending_review_zombie_interrupted` (new): `status == "pending"` AND `age > _STALE_REVIEW_JOB_SEC` AND no live pid → transition to `status="interrupted"` with reason `pending_zombie_never_started`, write terminal history + chat summary + progress (mirroring the existing running-branch's disclosure shape), and emit a typed `skill_review_pending_zombie_healed` event row so a fresh dispatch can acquire a clean lease.
* `reconcile_stale_review_jobs` now branches on status: `running` → the existing path (unchanged); `pending` → the new path; anything else → skip. Wire points unchanged (`/api/extensions`, `/api/skills/daemons`).

## Tests

`test_reconcile_stale_review_jobs_heals_pending_zombie` verifies the transition + the `skill_review_pending_zombie_healed` event; `test_reconcile_stale_review_jobs_skips_fresh_pending` verifies a young pending job is **not** raced into `interrupted` (would collide with a legitimate in-flight dispatch still acquiring its lifecycle file lock). Full `-k "skill_review or skill_exec"` sweep (206 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qrMmbNvYXckXHFrQzfWNm