### PR TITLE
fix(review-evidence): task-scope the current_repo stale marker

### DIFF
--- a/ouroboros/review_evidence.py
+++ b/ouroboros/review_evidence.py
@@ -484,6 +484,12 @@ def collect_review_evidence(
         scoped_continuations = continuations
     scoped_continuations.sort(key=lambda item: str(item.updated_ts or item.created_ts or ""), reverse=True)
     stale_matches_repo = not repo_key or state.last_stale_repo_key in ("", repo_key)
+    # ibl-00615dbd1a16: a different task on the shared repo tree that recorded
+    # its own stale marker must NOT show up in this task's `current_repo` panel.
+    # An empty stored task_id (legacy/unattributed) still matches any caller so
+    # every pre-existing record stays effective; a non-empty stored task_id
+    # only matches itself or an unset task_id query.
+    stale_matches_task = (not task_id) or str(getattr(state, "last_stale_task_id", "") or "") in ("", task_id)
 
     evidence = {
         "task_id": task_id,
@@ -497,8 +503,8 @@ def collect_review_evidence(
                 matching_run=current_run if getattr(current_run, "repo_key", None) == repo_key and repo_key else None,
             ),
             "bypass_reason": str(getattr(current_run, "bypass_reason", "") or ""),
-            "stale_reason": str(getattr(state, "last_stale_reason", "") or "") if stale_matches_repo else "",
-            "stale_ts": str(getattr(state, "last_stale_from_edit_ts", "") or "") if stale_matches_repo else "",
+            "stale_reason": str(getattr(state, "last_stale_reason", "") or "") if (stale_matches_repo and stale_matches_task) else "",
+            "stale_ts": str(getattr(state, "last_stale_from_edit_ts", "") or "") if (stale_matches_repo and stale_matches_task) else "",
         },
         "recent_attempts": [_attempt_to_dict(item) for item in (scoped_attempts[-max_attempts:] if max_attempts > 0 else [])],
         "omitted_attempts": max(0, len(scoped_attempts) - max_attempts) if max_attempts > 0 else len(scoped_attempts),

--- a/ouroboros/review_state.py
+++ b/ouroboros/review_state.py
@@ -234,6 +234,7 @@ def _load_state_unlocked(
         last_stale_from_edit_ts=str(data.get("last_stale_from_edit_ts", "")),
         last_stale_reason=str(data.get("last_stale_reason", "")),
         last_stale_repo_key=str(data.get("last_stale_repo_key", "")),
+        last_stale_task_id=str(data.get("last_stale_task_id", "")),
     )
 
     state.attempts.sort(key=_attempt_order_key)
@@ -341,6 +342,7 @@ def _save_state_unlocked(drive_root: pathlib.Path, state: AdvisoryReviewState) -
         "last_stale_from_edit_ts": state.last_stale_from_edit_ts,
         "last_stale_reason": state.last_stale_reason,
         "last_stale_repo_key": state.last_stale_repo_key,
+        "last_stale_task_id": state.last_stale_task_id,
         "saved_at": _utc_now(),
     }
     atomic_write_json(path, data)
@@ -526,6 +528,7 @@ def invalidate_advisory_after_mutation(
     mutation_root: pathlib.Path | None = None,
     changed_paths: Optional[List[str]] = None,
     source_tool: str = "",
+    mutating_task_id: str = "",
 ) -> None:
     """Invalidate advisory freshness after mutation; ambiguous repo scope stales all."""
     try:
@@ -536,13 +539,17 @@ def invalidate_advisory_after_mutation(
 
         def _mutate(state: AdvisoryReviewState) -> None:
             if not resolved_repo_keys or len(resolved_repo_keys) != 1:
-                state.mark_repo_stale(repo_key="", reason_ts=reason_ts, reason=reason, stale_repo_key="")
+                state.mark_repo_stale(
+                    repo_key="", reason_ts=reason_ts, reason=reason, stale_repo_key="",
+                    stale_task_id=mutating_task_id,
+                )
                 return
             state.mark_repo_stale(
                 repo_key=resolved_repo_keys[0],
                 reason_ts=reason_ts,
                 reason=reason,
                 stale_repo_key=resolved_repo_keys[0],
+                stale_task_id=mutating_task_id,
             )
 
         update_state(drive_root, _mutate)

--- a/ouroboros/review_state_model.py
+++ b/ouroboros/review_state_model.py
@@ -60,6 +60,7 @@ class AdvisoryReviewState:
     last_stale_from_edit_ts: str = ""
     last_stale_reason: str = ""
     last_stale_repo_key: str = ""
+    last_stale_task_id: str = ""
 
     def latest(self) -> Optional[AdvisoryRunRecord]:
         return self.advisory_runs[-1] if self.advisory_runs else None
@@ -202,6 +203,7 @@ class AdvisoryReviewState:
             self.last_stale_from_edit_ts = ""
             self.last_stale_reason = ""
             self.last_stale_repo_key = ""
+            self.last_stale_task_id = ""
         self._sync_commit_readiness_debts(repo_key=run.repo_key or None)
 
     def mark_stale(self, snapshot_hash: str) -> None:
@@ -224,6 +226,7 @@ class AdvisoryReviewState:
         reason_ts: str = "",
         reason: str = "",
         stale_repo_key: str = "",
+        stale_task_id: str = "",
     ) -> int:
         """Invalidate advisory runs for a repo, falling back conservatively."""
         invalidatable = [
@@ -247,6 +250,7 @@ class AdvisoryReviewState:
             self.last_stale_from_edit_ts = reason_ts or _rs()._utc_now()
             self.last_stale_reason = reason
             self.last_stale_repo_key = stale_repo_key or repo_key
+            self.last_stale_task_id = stale_task_id
             self._sync_commit_readiness_debts(repo_key=stale_repo_key or repo_key or None)
         return len(target_runs)
 
@@ -792,6 +796,7 @@ class AdvisoryReviewState:
             self.last_stale_from_edit_ts = ""
             self.last_stale_reason = ""
             self.last_stale_repo_key = ""
+            self.last_stale_task_id = ""
             for debt in _rs()._commit_readiness_debts_view(self):
                 self._hydrate_commit_readiness_debt(debt)
                 if debt.status in _rs()._OPEN_COMMIT_READINESS_DEBT_STATUSES:
@@ -809,6 +814,7 @@ class AdvisoryReviewState:
             self.last_stale_from_edit_ts = ""
             self.last_stale_reason = ""
             self.last_stale_repo_key = ""
+            self.last_stale_task_id = ""
         self._sync_commit_readiness_debts(repo_key=repo_key)
 
     def expire_stale_attempts(

--- a/ouroboros/tools/commit_gate.py
+++ b/ouroboros/tools/commit_gate.py
@@ -751,6 +751,7 @@ def _invalidate_advisory(
             mutation_root=mutation_root or pathlib.Path(ctx.repo_dir),
             changed_paths=changed_paths,
             source_tool=source_tool or _current_review_tool_name(ctx),
+            mutating_task_id=str(getattr(ctx, "task_id", "") or ""),
         )
     except Exception:
         pass

--- a/tests/test_review_evidence_stale_task_scope.py
+++ b/tests/test_review_evidence_stale_task_scope.py
@@ -1,0 +1,130 @@
+"""ibl-00615dbd1a16: `review_evidence.current_repo.stale_reason` / `.stale_ts`
+must be scoped to the querying task. On the shared /opt/ouroboros tree a task
+that recorded its own stale marker used to leak into every other task's
+`current_repo` panel (only `last_stale_repo_key` gated it). A `last_stale_task_id`
+now gates the displayed marker; an empty stored id (legacy / unattributed)
+still matches every caller so pre-existing records stay effective."""
+from __future__ import annotations
+
+import pathlib
+
+from ouroboros.review_evidence import collect_review_evidence
+from ouroboros.review_state import (
+    AdvisoryRunRecord,
+    AdvisoryReviewState,
+    invalidate_advisory_after_mutation,
+    load_state,
+    make_repo_key,
+    save_state,
+)
+
+
+def _repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    return repo
+
+
+def _seed_state_with_stale(drive_root, repo_key, *, stale_task_id):
+    st = AdvisoryReviewState()
+    st.add_run(AdvisoryRunRecord(
+        snapshot_hash="deadbeef", commit_message="m", status="fresh",
+        ts="2026-08-31T00:00:00", repo_key=repo_key,
+    ))
+    st.mark_repo_stale(
+        repo_key=repo_key, reason_ts="2026-08-31T12:00:00",
+        reason="edit_text mutated the worktree", stale_repo_key=repo_key,
+        stale_task_id=stale_task_id,
+    )
+    save_state(drive_root, st)
+
+
+def test_stale_marker_hidden_from_a_different_task(tmp_path):
+    drive = tmp_path / "drive"
+    (drive / "state").mkdir(parents=True)
+    repo = _repo(tmp_path)
+    rk = make_repo_key(repo)
+    _seed_state_with_stale(drive, rk, stale_task_id="taskA")
+
+    ev = collect_review_evidence(drive, task_id="taskB", repo_dir=repo)
+    assert ev["current_repo"]["stale_reason"] == ""
+    assert ev["current_repo"]["stale_ts"] == ""
+
+
+def test_stale_marker_visible_to_the_task_that_set_it(tmp_path):
+    drive = tmp_path / "drive"
+    (drive / "state").mkdir(parents=True)
+    repo = _repo(tmp_path)
+    rk = make_repo_key(repo)
+    _seed_state_with_stale(drive, rk, stale_task_id="taskA")
+
+    ev = collect_review_evidence(drive, task_id="taskA", repo_dir=repo)
+    assert ev["current_repo"]["stale_reason"] == "edit_text mutated the worktree"
+    assert ev["current_repo"]["stale_ts"] == "2026-08-31T12:00:00"
+
+
+def test_legacy_unattributed_stale_marker_still_shows_for_everyone(tmp_path):
+    drive = tmp_path / "drive"
+    (drive / "state").mkdir(parents=True)
+    repo = _repo(tmp_path)
+    rk = make_repo_key(repo)
+    _seed_state_with_stale(drive, rk, stale_task_id="")
+
+    for tid in ("taskA", "taskB", ""):
+        ev = collect_review_evidence(drive, task_id=tid, repo_dir=repo)
+        assert ev["current_repo"]["stale_reason"] == "edit_text mutated the worktree", tid
+
+
+def test_stale_task_id_round_trips_through_save_load(tmp_path):
+    drive = tmp_path / "drive"
+    (drive / "state").mkdir(parents=True)
+    st = AdvisoryReviewState()
+    # mark_repo_stale only records the marker when there is an invalidatable run.
+    st.add_run(AdvisoryRunRecord(
+        snapshot_hash="0ff1ce", commit_message="m", status="fresh",
+        ts="2026-08-31T08:00:00", repo_key="k",
+    ))
+    st.mark_repo_stale(
+        repo_key="k", reason_ts="2026-08-31T09:00:00", reason="r",
+        stale_repo_key="k", stale_task_id="t-123",
+    )
+    save_state(drive, st)
+    reloaded = load_state(drive)
+    assert reloaded.last_stale_task_id == "t-123"
+
+
+def test_invalidate_advisory_after_mutation_records_the_task_id(tmp_path):
+    drive = tmp_path / "drive"
+    (drive / "state").mkdir(parents=True)
+    repo = _repo(tmp_path)
+    st = AdvisoryReviewState()
+    st.add_run(AdvisoryRunRecord(
+        snapshot_hash="cafef00d", commit_message="m", status="fresh",
+        ts="2026-08-31T00:00:00", repo_key=make_repo_key(repo),
+    ))
+    save_state(drive, st)
+
+    invalidate_advisory_after_mutation(
+        pathlib.Path(drive),
+        mutation_root=pathlib.Path(repo),
+        changed_paths=["x.py"],
+        mutating_task_id="t-abc",
+    )
+    assert load_state(drive).last_stale_task_id == "t-abc"
+
+
+def test_add_run_clears_the_stale_task_id(tmp_path):
+    drive = tmp_path / "drive"
+    (drive / "state").mkdir(parents=True)
+    repo = _repo(tmp_path)
+    rk = make_repo_key(repo)
+    st = AdvisoryReviewState()
+    st.mark_repo_stale(
+        repo_key=rk, reason_ts="2026-08-31T12:00:00", reason="r",
+        stale_repo_key=rk, stale_task_id="taskA",
+    )
+    st.add_run(AdvisoryRunRecord(
+        snapshot_hash="feedface", commit_message="m", status="fresh",
+        ts="2026-08-31T13:00:00", repo_key=rk,
+    ))
+    assert st.last_stale_task_id == ""


### PR DESCRIPTION
## Problem

`review_evidence.collect_review_evidence`'s `current_repo.stale_reason` / `.stale_ts` are read from the module-global `AdvisoryReviewState.last_stale_reason` / `last_stale_from_edit_ts`, gated only by `last_stale_repo_key`. On a shared repo tree with multiple concurrent tasks, a task can read **another task's** stale-advisory marker in its evidence panel.

The `commit_reviewed` gate itself is not fooled (it hashes files), but the displayed evidence panel misleads the agent — it can show a stale-marker reason/timestamp/path from a completely unrelated task's edit, or (less obviously) suppress a marker that really is about the querying task's own worktree mutation once a second task's run happens to reset the repo-level fields first.

Confirmed live on a shared multi-task tree: three unrelated tasks all displayed the same `stale_ts`/`stale_reason`/paths belonging to only one of them.

## Fix

- New `AdvisoryReviewState.last_stale_task_id` field (`ouroboros/review_state_model.py`), set by `mark_repo_stale(stale_task_id=)`.
- Threaded from `invalidate_advisory_after_mutation(mutating_task_id=)` (`ouroboros/review_state.py`), which `commit_gate._invalidate_advisory` now fills from `ctx.task_id`.
- Reset alongside `last_stale_repo_key` in all three existing reset paths (`add_run`, both branches of `on_successful_commit`).
- Round-tripped through `save_state`/`load_state`.
- `collect_review_evidence` now gates the displayed `stale_reason`/`stale_ts` on `stale_matches_repo AND stale_matches_task`, where an empty stored id (legacy/unattributed marker, or a caller passing no `task_id`) still matches every caller, so pre-existing records and single-task usage are unaffected.

No change to `_check_advisory_freshness`, the readiness-debt generator, or `format_status_section` — only the evidence-panel display path.

## Tests

6 new tests in `tests/test_review_evidence_stale_task_scope.py`: cross-task hiding, same-task visibility, legacy-marker backward compatibility, save/load round-trip of the new field, and both reset paths (`add_run`, `invalidate_advisory_after_mutation`).

Also ran the full existing `review_evidence`/`review_state`/`commit_gate` suites locally — all green, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qrMmbNvYXckXHFrQzfWNm