### PR TITLE
Route runtime mode changes through the owner endpoint

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -852,8 +852,15 @@ def _load_settings() -> dict:
 
 
 def _save_settings(settings: dict) -> None:
-    # Owner-process boundary: first-run/env/provider saves may elevate runtime mode.
-    save_settings(settings, allow_elevation=True)
+    # The desktop launcher is the owner-controlled writer.  The generic
+    # config.save_settings ratchet deliberately makes allow_elevation inert
+    # after boot, which is correct for agent-reachable callers but also made a
+    # confirmed Cyber Pro selection fall back to Advanced.  Reuse the existing
+    # owner writer so the confirmation is honored while its document lock,
+    # persistence normalization and other owner-only checks remain in force.
+    from ouroboros.gateway.owner_settings import _owner_write_settings
+
+    _owner_write_settings(settings)
 
 
 def _request_runtime_mode_change(mode: str, confirm_fn) -> dict:

--- a/launcher.py
+++ b/launcher.py
@@ -1388,6 +1388,29 @@ def main():
                 log.warning("Runtime mode native confirmation failed: %s", exc, exc_info=True)
                 return {"ok": False, "error": f"Native confirmation failed: {exc}"}
 
+        def confirm_runtime_mode_change(self, mode: str) -> dict:
+            """Confirm a mode change without writing it.
+
+            The SPA persists the selected mode through the owner HTTP endpoint.
+            Keeping this bridge side-effect free lets older shells fall back to
+            the same in-app confirmation instead of normalizing newer modes
+            such as Cyber Pro through their stale local enum.
+            """
+            try:
+                mode_text = str(mode or "").strip().lower()
+                if mode_text not in {"light", "advanced", "pro", "cyber_pro"}:
+                    return {"confirmed": False, "error": "Unknown runtime mode."}
+                settings = _load_settings()
+                current = normalize_runtime_mode(settings.get("OUROBOROS_RUNTIME_MODE"))
+                message = (
+                    f"Change Ouroboros runtime mode from {current} to {mode_text}?\n\n"
+                    "The new mode is saved through the owner endpoint and takes effect after restart."
+                )
+                return {"confirmed": bool(self._native_confirm("Confirm Runtime Mode Change", message))}
+            except Exception as exc:
+                log.warning("Runtime mode native confirmation failed: %s", exc, exc_info=True)
+                return {"confirmed": False, "error": f"Native confirmation failed: {exc}"}
+
         def request_auto_grant_reviewed_skills_change(self, enabled: bool) -> dict:
             try:
                 return _request_auto_grant_reviewed_skills_change(bool(enabled), self._native_confirm)

--- a/tests/test_runtime_mode_elevation.py
+++ b/tests/test_runtime_mode_elevation.py
@@ -1285,6 +1285,28 @@ def test_launcher_runtime_mode_bridge_saves_after_confirmation(monkeypatch):
     assert saved["OUROBOROS_RUNTIME_MODE"] == "pro"
 
 
+def test_launcher_owner_writer_persists_cyber_pro_after_boot_pin(isolated_settings, monkeypatch):
+    """The confirmed desktop-owner path must bypass the agent boot ratchet.
+
+    ``config.save_settings(..., allow_elevation=True)`` is intentionally inert
+    after boot.  The launcher must therefore use the existing owner settings
+    writer, otherwise a confirmed Cyber Pro choice is silently persisted as the
+    active Advanced mode again.
+    """
+    import launcher
+    from ouroboros import config as cfg
+
+    _seed_disk(isolated_settings, {"OUROBOROS_RUNTIME_MODE": "advanced"})
+    monkeypatch.setenv("OUROBOROS_RUNTIME_MODE", "advanced")
+    cfg.initialize_runtime_mode_baseline("advanced")
+
+    launcher._save_settings({"OUROBOROS_RUNTIME_MODE": "cyber_pro"})
+
+    on_disk = json.loads(isolated_settings.read_text(encoding="utf-8"))
+    assert on_disk["OUROBOROS_RUNTIME_MODE"] == "cyber_pro"
+    assert os.environ["OUROBOROS_RUNTIME_MODE"] == "advanced"
+
+
 def test_launcher_runtime_mode_bridge_reports_pending_restart_against_active(monkeypatch):
     import launcher
 

--- a/tests/test_runtime_mode_elevation.py
+++ b/tests/test_runtime_mode_elevation.py
@@ -1307,6 +1307,21 @@ def test_launcher_owner_writer_persists_cyber_pro_after_boot_pin(isolated_settin
     assert os.environ["OUROBOROS_RUNTIME_MODE"] == "advanced"
 
 
+def test_settings_ui_uses_confirm_only_bridge_and_owner_endpoint():
+    """A stale desktop bridge must never receive the new mode value to write."""
+    from pathlib import Path
+
+    source = (Path(__file__).resolve().parents[1] / "web/modules/settings.js").read_text(
+        encoding="utf-8"
+    )
+    start = source.index("async function saveRuntimeModeViaNativeBridgeIfNeeded")
+    end = source.index("async function saveAutoGrantViaNativeBridgeIfNeeded", start)
+    runtime_save = source[start:end]
+    assert "confirm_runtime_mode_change" in runtime_save
+    assert "ownerRuntimeMode(nextMode)" in runtime_save
+    assert "window.pywebview?.api?.request_runtime_mode_change" not in runtime_save
+
+
 def test_launcher_runtime_mode_bridge_reports_pending_restart_against_active(monkeypatch):
     import launcher
 

--- a/web/modules/settings.js
+++ b/web/modules/settings.js
@@ -464,7 +464,7 @@ export function initSettings({ state, setBeforePageLeave, ws } = {}) {
     }
 
     function syncRuntimeModeBridgeState() {
-        const hasBridge = Boolean(window.pywebview?.api?.request_runtime_mode_change);
+        const hasBridge = Boolean(window.pywebview?.api?.confirm_runtime_mode_change);
         const group = document.querySelector('[data-runtime-mode-group]');
         if (group) {
             group.title = hasBridge
@@ -898,20 +898,25 @@ export function initSettings({ state, setBeforePageLeave, ws } = {}) {
     async function saveRuntimeModeViaNativeBridgeIfNeeded(nextMode) {
         const currentMode = currentSettings?.OUROBOROS_RUNTIME_MODE || 'advanced';
         if (nextMode === currentMode) return null;
-        const bridge = window.pywebview?.api?.request_runtime_mode_change;
-        // Only the browser-side confirm is migrated to the in-house dialog; the
-        // desktop pywebview bridge path above stays exactly as it was.
-        const result = bridge
-            ? await bridge(nextMode)
-            : ((await openConfirmDialog({
+        // The native bridge is confirmation-only.  Older shells do not expose
+        // that method; fall back to the same in-app dialog so they never receive
+        // the legacy mutating request_runtime_mode_change call (which cannot
+        // represent Cyber Pro). Every surface writes through one owner endpoint.
+        const nativeConfirm = window.pywebview?.api?.confirm_runtime_mode_change;
+        const confirmed = nativeConfirm
+            ? (await nativeConfirm(nextMode))?.confirmed === true
+            : await openConfirmDialog({
                 title: 'Change runtime mode',
                 body: `Change Ouroboros runtime mode from ${currentMode} to ${nextMode}? The change takes effect after restart.`,
                 confirmLabel: 'Change mode',
-            }))
-                ? await apiClient.ownerRuntimeMode(nextMode)
-                : { ok: false, saved: false, error: 'Runtime mode change cancelled.' });
+            });
+        if (!confirmed) {
+            const result = { ok: false, saved: false, error: 'Runtime mode change cancelled.' };
+            throw Object.assign(new Error(result.error), { body: result });
+        }
+        const result = await apiClient.ownerRuntimeMode(nextMode);
         if (!result || result.ok !== true) {
-            throw Object.assign(new Error(result?.error || 'Runtime mode change was cancelled.'), { body: result });
+            throw Object.assign(new Error(result?.error || 'Runtime mode change failed.'), { body: result });
         }
         return result;
     }


### PR DESCRIPTION
## Summary

Runtime mode changes from the settings UI now use one owner-controlled HTTP write path on every surface. Desktop shells provide confirmation only; the browser UI is the fallback for older shells that do not expose the new confirm-only bridge.

This fixes Cyber Pro silently returning to Advanced when an older packaged launcher normalizes the new mode through its stale local enum before saving. The selected mode remains restart-bound.

## Changes

- Add a confirm-only `pywebview` bridge method for current desktop launchers.
- Route the SPA's runtime-mode save through `/api/owner/runtime-mode` regardless of bridge age or platform.
- Keep the existing owner writer, document lock, preconditions, audit, and restart-required behavior.
- Preserve the legacy mutating bridge only for old clients; current UI code no longer calls it.

## Verification

- `test_launcher_owner_writer_persists_cyber_pro_after_boot_pin`
- `test_launcher_runtime_mode_bridge_saves_after_confirmation`
- `test_settings_ui_uses_confirm_only_bridge_and_owner_endpoint`

All three focused tests pass with producer exit 0. No live runtime, account, or authentication state was changed by the tests.
